### PR TITLE
fix adb client error: address is not valid

### DIFF
--- a/MacroDeck/Server/ADBServerHelper.cs
+++ b/MacroDeck/Server/ADBServerHelper.cs
@@ -19,9 +19,9 @@ public class AdbDeviceConnectionStateChangedEventArgs : EventArgs
 public class ADBServerHelper
 {
 
-    private static AdbServer? _adbServer;
+    private static IAdbServer? _adbServer;
 
-    private static AdbClient? _adbClient;
+    private static IAdbClient? _adbClient;
 
     private static string _adbFolderName = "Android Debug Bridge";
 
@@ -59,14 +59,14 @@ public class ADBServerHelper
         }
         
         MacroDeckLogger.Info(typeof(ADBServerHelper), $"Starting ADB server using {_adbPath}");
-        _adbServer = new AdbServer();
+
+        _adbClient = new AdbClient();
+        _adbServer = new AdbServer(_adbClient, Factories.AdbCommandLineClientFactory);
         var result = _adbServer.StartServer(_adbPath, true);
         if (result != StartServerResult.Started)
         {
             MacroDeckLogger.Info(typeof(ADBServerHelper), "Unable to start ADB server");
         }
-
-        _adbClient = new AdbClient();
 
         Task.Run(() =>
         {


### PR DESCRIPTION
AdbServer creates its own client in default constructor. 

PS. SharpAdbClient is now an archived repo. no more updates. maybe move to AdvancedSharpAdbClient?