### PR TITLE
Feature/labelgenerator unicode symbol rendering

### DIFF
--- a/MacroDeck/Utils/LabelGenerator.cs
+++ b/MacroDeck/Utils/LabelGenerator.cs
@@ -1,5 +1,8 @@
 ﻿using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Globalization;
+using System.Text;
+using System.Windows.Forms;
 using SuchByte.MacroDeck.ActionButton;
 
 namespace SuchByte.MacroDeck.Utils;
@@ -9,6 +12,14 @@ public class LabelGenerator
     public static Image GetLabel(Image img, string text, ButtonLabelPosition buttonLabelPosition, Font font, Color textColor, Color shadowColor, SizeF shadowOffset)
     {
         if (img == null) return img;
+
+        text = SanitizeLabelText(text);
+        if (string.IsNullOrEmpty(text)) return img;
+
+        if (NeedsUnicodeFallback(text))
+        {
+            return DrawLabelWithTextRenderer(img, text, buttonLabelPosition, font, textColor, shadowColor, shadowOffset);
+        }
 
         var g = Graphics.FromImage(img);
 
@@ -45,11 +56,88 @@ public class LabelGenerator
 
         gp.Dispose();
         b.Dispose();
-        b.Dispose();
+        p.Dispose();
         font.Dispose();
         sf.Dispose();
         g.Dispose();
 
         return img;
+    }
+
+    private static Image DrawLabelWithTextRenderer(Image img, string text, ButtonLabelPosition buttonLabelPosition, Font font, Color textColor, Color shadowColor, SizeF shadowOffset)
+    {
+        using var g = Graphics.FromImage(img);
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+
+        var bounds = new Rectangle(2, 2, img.Width - 4, img.Height - 4);
+        var flags = TextFormatFlags.HorizontalCenter | TextFormatFlags.WordBreak | TextFormatFlags.NoPadding;
+        flags |= buttonLabelPosition switch
+        {
+            ButtonLabelPosition.TOP => TextFormatFlags.Top,
+            ButtonLabelPosition.CENTER => TextFormatFlags.VerticalCenter,
+            _ => TextFormatFlags.Bottom,
+        };
+
+        using var renderFont = CreateUnicodeFriendlyFont(font);
+        var shadowRect = new Rectangle(
+            bounds.X + (int)Math.Round(shadowOffset.Width),
+            bounds.Y + (int)Math.Round(shadowOffset.Height),
+            bounds.Width,
+            bounds.Height);
+
+        TextRenderer.DrawText(g, text, renderFont, shadowRect, shadowColor, flags);
+        TextRenderer.DrawText(g, text, renderFont, bounds, textColor, flags);
+        font.Dispose();
+
+        return img;
+    }
+
+    private static Font CreateUnicodeFriendlyFont(Font originalFont)
+    {
+        var targetSize = Math.Max(8f, originalFont.Size * 5f);
+        try
+        {
+            return new Font("Segoe UI Emoji", targetSize, originalFont.Style, GraphicsUnit.Pixel);
+        }
+        catch
+        {
+            return new Font("Segoe UI", targetSize, originalFont.Style, GraphicsUnit.Pixel);
+        }
+    }
+
+    private static bool NeedsUnicodeFallback(string text)
+    {
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (rune.Value > 0x7F)
+            {
+                var category = Rune.GetUnicodeCategory(rune);
+                if (category == UnicodeCategory.OtherSymbol || category == UnicodeCategory.Surrogate || rune.Value >= 0x1F000)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string SanitizeLabelText(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+
+        var sb = new StringBuilder(text.Length);
+        foreach (var rune in text.EnumerateRunes())
+        {
+            if (rune.Value is 0xFE0E or 0xFE0F)
+            {
+                continue;
+            }
+
+            sb.Append(rune.ToString());
+        }
+
+        return sb.ToString();
     }
 }

--- a/MacroDeck/Utils/LabelGenerator.cs
+++ b/MacroDeck/Utils/LabelGenerator.cs
@@ -11,10 +11,18 @@ public class LabelGenerator
 {
     public static Image GetLabel(Image img, string text, ButtonLabelPosition buttonLabelPosition, Font font, Color textColor, Color shadowColor, SizeF shadowOffset)
     {
-        if (img == null) return img;
+        if (img == null)
+        {
+            font.Dispose();
+            return img;
+        }
 
         text = SanitizeLabelText(text);
-        if (string.IsNullOrEmpty(text)) return img;
+        if (string.IsNullOrEmpty(text))
+        {
+            font.Dispose();
+            return img;
+        }
 
         if (NeedsUnicodeFallback(text))
         {
@@ -100,7 +108,7 @@ public class LabelGenerator
         {
             return new Font("Segoe UI Emoji", targetSize, originalFont.Style, GraphicsUnit.Pixel);
         }
-        catch
+        catch (ArgumentException)
         {
             return new Font("Segoe UI", targetSize, originalFont.Style, GraphicsUnit.Pixel);
         }
@@ -113,7 +121,7 @@ public class LabelGenerator
             if (rune.Value > 0x7F)
             {
                 var category = Rune.GetUnicodeCategory(rune);
-                if (category == UnicodeCategory.OtherSymbol || category == UnicodeCategory.Surrogate || rune.Value >= 0x1F000)
+                if (category == UnicodeCategory.OtherSymbol || rune.Value >= 0x1F000)
                 {
                     return true;
                 }


### PR DESCRIPTION
> [!IMPORTANT]
> Transparency Note: The code changes in this PR were done with the help of Github Copilot using Claude Sonnet 4.6
> It was tested manually and is working, please confirm/mind.

## Summary
Fixes button label rendering issues where emojis/symbols render as tofu squares and where a stray box appears between symbol and text for strings like ⬇️ Download.

## Problem
- MacroDeck button labels are rasterized in LabelGenerator via GraphicsPath.AddString.
- This path does not handle Unicode symbol/emoji fallback robustly with user-selected fonts (e.g. Impact).
- Variation selectors (U+FE0E/U+FE0F) in emoji sequences could surface as visible square glyphs depending on font/render path.

## Root Cause
- GDI path text rendering (AddString) is optimized for vector outlines, but not reliable for modern emoji/symbol shaping/fallback.
- The label pipeline fed raw Unicode text (including variation selectors) directly into that renderer.

## Changes
- MacroDeck/Utils/LabelGenerator.cs
  - Sanitize label text by removing variation selector runes (U+FE0E, U+FE0F).
  - Detect Unicode-heavy symbol/emoji content and switch to a fallback renderer.
  - Add Unicode-friendly fallback rendering path using TextRenderer.DrawText.
  - Use Segoe UI Emoji (fallback Segoe UI) for Unicode path rendering.
  - Keep original GraphicsPath.AddString path for standard non-Unicode labels.
  - Fix disposal bug (Pen was not disposed; duplicate Brush.Dispose).

## Validation
- Built successfully: dotnet build MacroDeck/MacroDeck.csproj -c Release
- Result: 0 errors (pre-existing warnings only).

## User Impact
- Emoji/symbol labels are displayed more reliably.
- The extra square symbol between icon and text (from variation selector rendering) is removed.
- No behavior change for regular ASCII label rendering.
