### PR TITLE
Load icons lazily and fix icon-related memory leaks

### DIFF
--- a/src/MacroDeck/ActionButton/ButtonLabel.cs
+++ b/src/MacroDeck/ActionButton/ButtonLabel.cs
@@ -53,7 +53,8 @@ public class ButtonLabel
             ButtonLabelPosition.BOTTOM => ContentAlignment.BottomCenter,
             _ => ContentAlignment.MiddleCenter
         };
-        _labelHex128_64Base64 = Base64.GetBase64ByteArray((Bitmap)Base64.GetImageFromBase64(_labelBase64),
+        using var labelImage = Base64.GetImageFromBase64(_labelBase64);
+        _labelHex128_64Base64 = Base64.GetBase64ByteArray((Bitmap)labelImage,
             new Size(128, 64),
             contentAlignment);
     }

--- a/src/MacroDeck/GUI/CustomControls/ExtensionsView/ExtensionItemView.cs
+++ b/src/MacroDeck/GUI/CustomControls/ExtensionsView/ExtensionItemView.cs
@@ -16,10 +16,14 @@ public partial class ExtensionItemView : RoundedUserControl
 
     public event EventHandler ExtensionRemoved;
 
+    // Icon pack preview generated on demand for this item; disposed when the control is disposed.
+    private Image _generatedPreview;
+
 
     public ExtensionItemView(IMacroDeckExtension macroDeckExtension, bool updateAvailable)
     {
         this.macroDeckExtension = macroDeckExtension;
+        Disposed += (_, _) => _generatedPreview?.Dispose();
         InitializeComponent();
 
         btnUpdate.Text = LanguageManager.Strings.Update;
@@ -88,9 +92,8 @@ public partial class ExtensionItemView : RoundedUserControl
                     lblStatus.BackColor = Color.Transparent;
                 }
 
-                extensionIcon.BackgroundImage = iconPack.IconPackIcon == null
-                    ? IconPackPreview.GeneratePreviewImage(iconPack)
-                    : iconPack.IconPackIcon;
+                _generatedPreview = iconPack.IconPackIcon ?? IconPackPreview.GeneratePreviewImage(iconPack);
+                extensionIcon.BackgroundImage = _generatedPreview;
                 lblExtensionName.Text = iconPack.Name;
                 lblVersion.Text = $"{LanguageManager.Strings.InstalledVersion}: {iconPack.Version}";
                 break;

--- a/src/MacroDeck/GUI/CustomControls/RoundedButton.cs
+++ b/src/MacroDeck/GUI/CustomControls/RoundedButton.cs
@@ -14,6 +14,13 @@ public class RoundedButton : PictureBox
         get => _foregroundImage;
         set
         {
+            // The foreground image only ever holds freshly generated label bitmaps, so the
+            // previous one can safely be disposed to avoid leaking GDI bitmaps.
+            if (_foregroundImage != null && !ReferenceEquals(_foregroundImage, value))
+            {
+                _foregroundImage.Dispose();
+            }
+
             _foregroundImage = value;
             Invalidate();
         }
@@ -54,6 +61,19 @@ public class RoundedButton : PictureBox
         MouseEnter += OnMouseEnter;
         MouseLeave += OnMouseLeave;
         Padding = Padding.Empty;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Dispose the foreground (label) image. The background image is NOT disposed here
+            // because some RoundedButtons display shared Properties.Resources.* bitmaps.
+            _foregroundImage?.Dispose();
+            _foregroundImage = null;
+        }
+
+        base.Dispose(disposing);
     }
 
     private void OnMouseEnter(object sender, EventArgs e)

--- a/src/MacroDeck/GUI/Dialogs/ButtonEditor.cs
+++ b/src/MacroDeck/GUI/Dialogs/ButtonEditor.cs
@@ -40,6 +40,15 @@ public partial class ButtonEditor : DialogForm
 
     public ActionButton.ActionButton ActionButton => actionButton;
 
+    protected override void OnFormClosed(FormClosedEventArgs e)
+    {
+        // btnPreview.BackgroundImage only ever holds a freshly loaded icon image, so dispose
+        // it on close to release the GDI bitmap.
+        btnPreview.BackgroundImage?.Dispose();
+        btnPreview.BackgroundImage = null;
+        base.OnFormClosed(e);
+    }
+
     public ButtonEditor(ActionButton.ActionButton actionButton, MacroDeckFolder folder)
     {
         InitializeComponent();
@@ -227,11 +236,13 @@ public partial class ButtonEditor : DialogForm
                 var icon = IconManager.GetIconByString(iconString);
                 if (icon != null)
                 {
+                    btnPreview.BackgroundImage?.Dispose();
                     btnPreview.BackgroundImage = icon.IconImage;
                 }
             }
             else
             {
+                btnPreview.BackgroundImage?.Dispose();
                 btnPreview.BackgroundImage = null;
             }
 

--- a/src/MacroDeck/GUI/Dialogs/IconSelector.cs
+++ b/src/MacroDeck/GUI/Dialogs/IconSelector.cs
@@ -39,9 +39,31 @@ public partial class IconSelector : DialogForm
         btnGenerateStatic.Text = LanguageManager.Strings.GenerateStatic;
     }
 
+    protected override void OnFormClosed(FormClosedEventArgs e)
+    {
+        // Release all icon bitmaps held by the grid buttons and the preview when the dialog closes.
+        ClearIconList();
+        btnPreview.BackgroundImage?.Dispose();
+        btnPreview.BackgroundImage = null;
+        base.OnFormClosed(e);
+    }
+
+    private void ClearIconList()
+    {
+        foreach (Control control in iconList.Controls)
+        {
+            // Each grid button's background image is a freshly loaded icon image; dispose it
+            // along with the control to release the GDI bitmaps.
+            control.BackgroundImage?.Dispose();
+            control.Dispose();
+        }
+
+        iconList.Controls.Clear();
+    }
+
     private void LoadIcons(IconPack iconPack, bool scrollDown = false)
     {
-        iconList.Controls.Clear();
+        ClearIconList();
         foreach (var icon in iconPack.Icons)
         {
             Task.Run(() =>
@@ -77,8 +99,9 @@ public partial class IconSelector : DialogForm
     {
         var previewImage = icon.IconImage;
 
-        btnGenerateStatic.Visible = icon.IconImage.RawFormat.ToString().ToLower() == "gif";
+        btnGenerateStatic.Visible = previewImage.RawFormat.ToString().ToLower() == "gif";
 
+        btnPreview.BackgroundImage?.Dispose();
         btnPreview.BackgroundImage = previewImage;
         lblSize.Text = $@"{Encoding.Unicode.GetByteCount(icon.IconBase64) / 1000:n0} kByte";
         lblType.Text = previewImage.RawFormat.ToString().ToUpper();
@@ -201,7 +224,7 @@ public partial class IconSelector : DialogForm
                 {
                     using var ms = new MemoryStream();
                     icon.Save(ms, ImageFormat.Png);
-                    var iconStatic = Image.FromStream(ms);
+                    using var iconStatic = Image.FromStream(ms);
                     IconManager.AddIconImage(iconPack, iconStatic);
                 }
 
@@ -302,6 +325,7 @@ public partial class IconSelector : DialogForm
             DialogResult.Yes)
         {
             IconManager.DeleteIconPack(iconPack);
+            btnPreview.BackgroundImage?.Dispose();
             btnPreview.BackgroundImage = null;
             SelectedIcon = null;
             lblSize.Text = "";
@@ -377,6 +401,7 @@ public partial class IconSelector : DialogForm
             DialogResult.Yes)
         {
             IconManager.DeleteIcon(SelectedIconPack, SelectedIcon);
+            btnPreview.BackgroundImage?.Dispose();
             btnPreview.BackgroundImage = null;
             btnPreview.Image = null;
             SelectedIcon = null;
@@ -446,14 +471,11 @@ public partial class IconSelector : DialogForm
     private void BtnGenerateStatic_Click(object sender, EventArgs e)
     {
         var iconPack = IconManager.GetIconPackByName(iconPacksBox.Text);
-        var icon = SelectedIcon.IconImage;
-        var ms = new MemoryStream();
+        using var icon = SelectedIcon.IconImage;
+        using var ms = new MemoryStream();
         icon.Save(ms, ImageFormat.Png);
-        var bmpBytes = ms.GetBuffer();
-        ms = new MemoryStream(bmpBytes);
-        var iconStatic = Image.FromStream(ms);
-        ms.Close();
-        ms.Dispose();
+        ms.Position = 0;
+        using var iconStatic = Image.FromStream(ms);
         var addedIcon = IconManager.AddIconImage(iconPack, iconStatic);
         SelectIcon(addedIcon);
         LoadIcons(iconPack, true);

--- a/src/MacroDeck/GUI/MainWindowViews/DeckView.cs
+++ b/src/MacroDeck/GUI/MainWindowViews/DeckView.cs
@@ -234,6 +234,7 @@ public partial class DeckView : UserControl
                 var icon = IconManager.GetIconByString(actionButton.IconOn);
                 if (icon != null)
                 {
+                    button.BackgroundImage?.Dispose();
                     button.BackgroundImage = icon.IconImage;
                 }
             }
@@ -255,6 +256,7 @@ public partial class DeckView : UserControl
                 var icon = IconManager.GetIconByString(actionButton.IconOff);
                 if (icon != null)
                 {
+                    button.BackgroundImage?.Dispose();
                     button.BackgroundImage = icon.IconImage;
                 }
             }

--- a/src/MacroDeck/Icons/Icon.cs
+++ b/src/MacroDeck/Icons/Icon.cs
@@ -7,8 +7,6 @@ public class Icon
 {
     private string _filePath;
 
-    private string _iconBase64 = "";
-
     public string FilePath
     {
         get => _filePath;
@@ -17,6 +15,10 @@ public class Icon
 
     public string IconId { get; set; } = Guid.NewGuid().ToString();
 
+    /// <summary>
+    /// Loads the icon from disk on every access. The returned <see cref="Image"/> is a fresh
+    /// instance and is NOT cached; the caller takes ownership and MUST dispose it.
+    /// </summary>
     public Image IconImage
     {
         get
@@ -29,18 +31,25 @@ public class Icon
         }
     }
 
+    /// <summary>
+    /// Computes the base64 representation on demand. Nothing is cached, so the icon data
+    /// is never kept in memory permanently.
+    /// </summary>
     public string IconBase64
     {
         get
         {
-            if (string.IsNullOrWhiteSpace(_iconBase64))
-            {
-                _iconBase64 = Base64.GetBase64FromImage(IconImage);
-            }
-
-            return _iconBase64;
+            using var image = IconImage;
+            return Base64.GetBase64FromImage(image);
         }
     }
 
-    public string IconHex128_64Base64 => Base64.GetBase64ByteArray((Bitmap)IconImage, new Size(128, 64));
+    public string IconHex128_64Base64
+    {
+        get
+        {
+            using var image = IconImage;
+            return Base64.GetBase64ByteArray((Bitmap)image, new Size(128, 64));
+        }
+    }
 }

--- a/src/MacroDeck/Icons/IconManager.cs
+++ b/src/MacroDeck/Icons/IconManager.cs
@@ -112,7 +112,8 @@ public class IconManager
             }
         }
 
-        iconPack.IconPackIcon = IconPackPreview.GeneratePreviewImage(iconPack);
+        // The preview image is intentionally not generated here to avoid keeping a bitmap
+        // per icon pack permanently in memory. Consumers generate it on demand and dispose it.
         return true;
     }
 
@@ -200,7 +201,10 @@ public class IconManager
         var iconPackDir = Path.Combine(ApplicationPaths.IconPackDirectoryPath, iconPack.PackageId);
         try
         {
-            iconPack.IconPackIcon?.Save(Path.Combine(iconPackDir, "ExtensionIcon.png"));
+            using (var preview = iconPack.IconPackIcon ?? IconPackPreview.GeneratePreviewImage(iconPack))
+            {
+                preview?.Save(Path.Combine(iconPackDir, "ExtensionIcon.png"));
+            }
             using var archive = ZipFile.Open(Path.Combine(ApplicationPaths.BackupsDirectoryPath,
                     destination,
                     $"{iconPack.Name}.macroDeckIconPack"),

--- a/src/MacroDeck/Icons/IconPack.cs
+++ b/src/MacroDeck/Icons/IconPack.cs
@@ -25,7 +25,9 @@ public class IconPack
     public List<Icon> Icons;
 
     /// <summary>
-    /// Icon displayed in the extension manager
+    /// Icon displayed in the extension manager. Not populated permanently to avoid keeping a
+    /// bitmap per icon pack in memory; consumers generate it on demand via
+    /// <see cref="SuchByte.MacroDeck.Utils.IconPackPreview.GeneratePreviewImage"/> and dispose it.
     /// </summary>
     public Image IconPackIcon { get; set; }
 

--- a/src/MacroDeck/Profiles/ProfileManager.cs
+++ b/src/MacroDeck/Profiles/ProfileManager.cs
@@ -135,22 +135,29 @@ public static class ProfileManager
                 labelOffText = TemplateManager.RenderTemplate(labelOffText);
                 labelOnText = TemplateManager.RenderTemplate(labelOnText);
 
-                actionButton.LabelOff.LabelBase64 = Base64.GetBase64FromImage(LabelGenerator.GetLabel(
+                using (var labelOffImage = LabelGenerator.GetLabel(
                     new Bitmap(250, 250),
                     labelOffText,
                     actionButton.LabelOff.LabelPosition,
                     new Font(actionButton.LabelOff.FontFamily, actionButton.LabelOff.Size),
                     actionButton.LabelOff.LabelColor,
                     Color.Black,
-                    new SizeF(2.0f, 2.0f)));
-                actionButton.LabelOn.LabelBase64 = Base64.GetBase64FromImage(LabelGenerator.GetLabel(
+                    new SizeF(2.0f, 2.0f)))
+                {
+                    actionButton.LabelOff.LabelBase64 = Base64.GetBase64FromImage(labelOffImage);
+                }
+
+                using (var labelOnImage = LabelGenerator.GetLabel(
                     new Bitmap(250, 250),
                     labelOnText,
                     actionButton.LabelOn.LabelPosition,
                     new Font(actionButton.LabelOn.FontFamily, actionButton.LabelOn.Size),
                     actionButton.LabelOn.LabelColor,
                     Color.Black,
-                    new SizeF(2.0f, 2.0f)));
+                    new SizeF(2.0f, 2.0f)))
+                {
+                    actionButton.LabelOn.LabelBase64 = Base64.GetBase64FromImage(labelOnImage);
+                }
                 foreach (var macroDeckClient in MacroDeckServer.Clients)
                 {
                     MacroDeckServer.SendButton(macroDeckClient, actionButton);

--- a/src/MacroDeck/Utils/Base64.cs
+++ b/src/MacroDeck/Utils/Base64.cs
@@ -133,29 +133,36 @@ public class Base64
             return "";
         }
 
+        // Does NOT dispose the passed image; the caller retains ownership.
+        Bitmap tempBitmap = null;
         try
         {
             using var ms = new MemoryStream();
             var format = image.RawFormat;
+            var imageToSave = image;
             switch (format.ToString().ToLower())
             {
                 case "gif":
                     break;
                 default:
-                    image = new Bitmap(
-                        image); // Generating a new bitmap if the file format is not a gif because otherwise it causes a GDI+ error in some cases
+                    // Generating a new bitmap if the file format is not a gif because otherwise it causes a GDI+ error in some cases
+                    tempBitmap = new Bitmap(image);
+                    imageToSave = tempBitmap;
                     format = ImageFormat.Png;
                     break;
             }
 
-            image.Save(ms, format);
-            image.Dispose();
+            imageToSave.Save(ms, format);
 
             return Convert.ToBase64String(ms.ToArray());
         }
         catch
         {
             return "";
+        }
+        finally
+        {
+            tempBitmap?.Dispose();
         }
     }
 }

--- a/src/MacroDeck/Utils/IconPackPreview.cs
+++ b/src/MacroDeck/Utils/IconPackPreview.cs
@@ -20,7 +20,7 @@ public static class IconPackPreview
             g.Clear(Color.FromArgb(32, 32, 32));
         }
 
-        var canvas = Graphics.FromImage(bitmap);
+        using var canvas = Graphics.FromImage(bitmap);
         canvas.InterpolationMode = InterpolationMode.Bicubic;
         foreach (var icon in iconPack.Icons.Take(4))
         {
@@ -33,7 +33,11 @@ public static class IconPackPreview
                     X = column * (iconSize + column * padding),
                     Y = row * (iconSize + row * padding)
                 };
-                canvas.DrawImage(new Bitmap(icon.IconImage), iconRectangle);
+                using (var iconImage = icon.IconImage)
+                {
+                    canvas.DrawImage(iconImage, iconRectangle);
+                }
+
                 column++;
                 if (column >= 2)
                 {


### PR DESCRIPTION
Icons are no longer kept in memory permanently and the GDI bitmaps created while displaying them are now disposed properly.