### PR TITLE
Fix empty deck when restoring main window from tray

### DIFF
--- a/src/MacroDeck/GUI/MainWindowViews/DeckView.cs
+++ b/src/MacroDeck/GUI/MainWindowViews/DeckView.cs
@@ -147,6 +147,14 @@ public partial class DeckView : UserControl
             return;
         }
 
+        // While the window is minimized the button panel collapses to a zero size, which would make
+        // the computed button size negative and render the deck empty. Skip the layout in that case;
+        // it runs again once the window is restored to a usable size.
+        if (buttonPanel.Width <= 0 || buttonPanel.Height <= 0)
+        {
+            return;
+        }
+
         if (clear)
         {
             foreach (RoundedButton roundedButton in buttonPanel.Controls)


### PR DESCRIPTION
Showing an existing main window from the tray cycles its state through Minimized -> Normal. The custom Form raises FormWindowStateChanged on each transition, which triggers DeckView.UpdateButtons(). While minimized the button panel has a zero size, so the computed button size became negative and the deck rendered empty.

Skip the button layout when the panel has no usable size; it runs again once the window is restored.