### PR TITLE
Downgrade cross-repo PAT to GITHUB_TOKEN for public read-only checkout

### DIFF
--- a/.github/workflows/pull-web-client.yml
+++ b/.github/workflows/pull-web-client.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout Web Client repository
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.PRIVATE_REPO_PAT}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{inputs.web-client-version}}
           path: 'MacroDeck.WebClient'
           repository: 'Macro-Deck-App/Macro-Deck-Client-App'


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

### 🔴 `pat-cross-repo` · `update-web-client`

**Why downgrade this token.**

`Checkout Web Client repository` uses `${{ secrets.PRIVATE_REPO_PAT }}` to read `Macro-Deck-App/Macro-Deck-Client-App` (a public repository). The PAT carries the union of its owner's repository permissions — almost always broader than this single read requires. `GITHUB_TOKEN` is workflow-scoped, ephemeral, and gives the same 5000/hr rate-limit ceiling for authenticated reads on public data — the strictly-safer credential.

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/pull-web-client.yml
+++ b/.github/workflows/pull-web-client.yml
@@ -29,7 +29,7 @@
       - name: Checkout Web Client repository
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.PRIVATE_REPO_PAT}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{inputs.web-client-version}}
           path: 'MacroDeck.WebClient'
           repository: 'Macro-Deck-App/Macro-Deck-Client-App'
```

</details>


---

_AI-generated. Review the diff before merging._

