### PR TITLE
Fix pat-cross-repo in pull-web-client.yml

### DIFF
--- a/.github/workflows/pull-web-client.yml
+++ b/.github/workflows/pull-web-client.yml
@@ -26,10 +26,20 @@ jobs:
         with:
           ref: ${{inputs.destination-branch}}
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            Macro-Deck-Client-App
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout Web Client repository
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.PRIVATE_REPO_PAT}}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{inputs.web-client-version}}
           path: 'MacroDeck.WebClient'
           repository: 'Macro-Deck-App/Macro-Deck-Client-App'


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

> ⚠️ **Advisory PR — maintainer setup required before merge.**
> 
> This PR inserts a GitHub App installation token step that references `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` — neither exists yet on this repo. Complete the checklist below first, then mark the PR ready-for-review.

## Setup checklist

- [ ] **Register a GitHub App** with the permissions listed in the inserted step's `permission-<name>` inputs, and install it on the target repository.
- [ ] **Store the App's Client ID** in repository or organization variables as `APP_ID`.
- [ ] **Store the App's private key** in repository or organization secrets as `APP_PRIVATE_KEY`.

Once these three are done, mark this PR ready-for-review and merge. The `actions/create-github-app-token` step will generate a short-lived, repo-scoped token at runtime — strictly safer than the long-lived PAT it replaces.

### 🔴 `pat-cross-repo` · `update-web-client`

Job `update-web-client`, step `Checkout Web Client repository` uses `secrets.PRIVATE_REPO_PAT` as a checkout token, and the comprehension marks this TokenSource with `cross_repo_confidence: high` due to the checkout of `Macro-Deck-App/Macro-Deck-Client-App`. This is a cross-repo…

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/pull-web-client.yml
+++ b/.github/workflows/pull-web-client.yml
@@ -26,10 +26,20 @@
         with:
           ref: ${{inputs.destination-branch}}
 
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            Macro-Deck-Client-App
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout Web Client repository
         uses: actions/checkout@v4
         with:
-          token: ${{secrets.PRIVATE_REPO_PAT}}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{inputs.web-client-version}}
           path: 'MacroDeck.WebClient'
           repository: 'Macro-Deck-App/Macro-Deck-Client-App'
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
