### PR TITLE
feat: add Admin REST API, MCP server, and CLI tool

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,5 +26,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/MacroDeck.Cli/ApiClient.cs
+++ b/MacroDeck.Cli/ApiClient.cs
@@ -1,0 +1,106 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace MacroDeck.Cli;
+
+/// <summary>
+/// Thin HTTP wrapper over the MacroDeck admin REST API.
+/// URL and API key are resolved in priority order:
+///   1. CLI options (--url / --key)
+///   2. Environment variables MACRODECK_URL / MACRODECK_API_KEY
+///   3. Defaults (http://localhost:8191)
+/// </summary>
+public class ApiClient
+{
+    private static readonly JsonSerializerOptions PrettyJson = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly HttpClient _http;
+
+    public ApiClient(string baseUrl, string apiKey)
+    {
+        _http = new HttpClient
+        {
+            BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/")
+        };
+        _http.DefaultRequestHeaders.Add("X-MacroDeck-Admin-Key", apiKey);
+        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+
+    public static ApiClient FromEnvironment(string? urlOverride = null, string? keyOverride = null)
+    {
+        var url = urlOverride
+            ?? Environment.GetEnvironmentVariable("MACRODECK_URL")
+            ?? "http://localhost:8191";
+        var key = keyOverride
+            ?? Environment.GetEnvironmentVariable("MACRODECK_API_KEY")
+            ?? string.Empty;
+        return new ApiClient(url, key);
+    }
+
+    public async Task<string> GetAsync(string path)
+    {
+        var response = await _http.GetAsync(path);
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"GET {path} → {(int)response.StatusCode}: {body}");
+        return PrettyFormat(body);
+    }
+
+    public async Task<string> PostAsync(string path, object body)
+    {
+        var response = await _http.PostAsync(path, JsonContent(body));
+        var raw = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"POST {path} → {(int)response.StatusCode}: {raw}");
+        return PrettyFormat(raw);
+    }
+
+    public async Task<string> PutAsync(string path, object body)
+    {
+        var response = await _http.PutAsync(path, JsonContent(body));
+        var raw = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"PUT {path} → {(int)response.StatusCode}: {raw}");
+        return PrettyFormat(raw);
+    }
+
+    public async Task<string> PatchAsync(string path, object body)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Patch, path) { Content = JsonContent(body) };
+        var response = await _http.SendAsync(request);
+        var raw = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"PATCH {path} → {(int)response.StatusCode}: {raw}");
+        return PrettyFormat(raw);
+    }
+
+    public async Task<bool> DeleteAsync(string path)
+    {
+        var response = await _http.DeleteAsync(path);
+        return response.IsSuccessStatusCode;
+    }
+
+    private static StringContent JsonContent(object body)
+    {
+        var json = JsonSerializer.Serialize(body, PrettyJson);
+        return new StringContent(json, Encoding.UTF8, "application/json");
+    }
+
+    private static string PrettyFormat(string raw)
+    {
+        try
+        {
+            var doc = JsonDocument.Parse(raw);
+            return JsonSerializer.Serialize(doc, PrettyJson);
+        }
+        catch
+        {
+            return raw;
+        }
+    }
+}

--- a/MacroDeck.Cli/Commands/ButtonCommands.cs
+++ b/MacroDeck.Cli/Commands/ButtonCommands.cs
@@ -1,0 +1,85 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace MacroDeck.Cli.Commands;
+
+public static class ButtonCommands
+{
+    public static Command ListButtons(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID.");
+        var folderIdArg = new Argument<string>("folderId", "Folder ID.");
+        var cmd = new Command("list", "List all buttons in a folder.");
+        cmd.AddArgument(profileIdArg);
+        cmd.AddArgument(folderIdArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var pid = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            var fid = ctx.ParseResult.GetValueForArgument(folderIdArg);
+            Console.WriteLine(await clientFactory(ctx).GetAsync($"api/profiles/{pid}/folders/{fid}/buttons"));
+        });
+        return cmd;
+    }
+
+    public static Command CreateButton(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID.");
+        var folderIdArg = new Argument<string>("folderId", "Folder ID.");
+        var xOpt = new Option<int>("--x", "Column (0-based).") { IsRequired = true };
+        var yOpt = new Option<int>("--y", "Row (0-based).") { IsRequired = true };
+        var labelOpt = new Option<string>("--label", () => "", "Off-state label text.");
+        var labelOnOpt = new Option<string>("--label-on", () => "", "On-state label text.");
+        var actionsOpt = new Option<string>("--actions-json", () => "[]",
+            "JSON array of action assignments: [{\"pluginName\":\"...\",\"actionClass\":\"...\",\"configuration\":{...}}]");
+        var cmd = new Command("create", "Create a button at a grid position.");
+        cmd.AddArgument(profileIdArg);
+        cmd.AddArgument(folderIdArg);
+        cmd.AddOption(xOpt);
+        cmd.AddOption(yOpt);
+        cmd.AddOption(labelOpt);
+        cmd.AddOption(labelOnOpt);
+        cmd.AddOption(actionsOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var pid = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            var fid = ctx.ParseResult.GetValueForArgument(folderIdArg);
+            var actionsJson = ctx.ParseResult.GetValueForOption(actionsOpt) ?? "[]";
+            object actions;
+            try { actions = System.Text.Json.JsonSerializer.Deserialize<object>(actionsJson)!; }
+            catch { Console.Error.WriteLine("--actions-json is not valid JSON."); ctx.ExitCode = 1; return; }
+
+            var result = await clientFactory(ctx).PostAsync(
+                $"api/profiles/{pid}/folders/{fid}/buttons",
+                new
+                {
+                    positionX = ctx.ParseResult.GetValueForOption(xOpt),
+                    positionY = ctx.ParseResult.GetValueForOption(yOpt),
+                    labelOffText = ctx.ParseResult.GetValueForOption(labelOpt),
+                    labelOnText = ctx.ParseResult.GetValueForOption(labelOnOpt),
+                    actions = actions,
+                });
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+
+    public static Command DeleteButton(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID.");
+        var folderIdArg = new Argument<string>("folderId", "Folder ID.");
+        var guidArg = new Argument<string>("buttonGuid", "Button GUID.");
+        var cmd = new Command("delete", "Delete a button.");
+        cmd.AddArgument(profileIdArg);
+        cmd.AddArgument(folderIdArg);
+        cmd.AddArgument(guidArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var pid = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            var fid = ctx.ParseResult.GetValueForArgument(folderIdArg);
+            var guid = ctx.ParseResult.GetValueForArgument(guidArg);
+            var ok = await clientFactory(ctx).DeleteAsync($"api/profiles/{pid}/folders/{fid}/buttons/{guid}");
+            Console.WriteLine(ok ? "Button deleted." : "Not found.");
+        });
+        return cmd;
+    }
+}

--- a/MacroDeck.Cli/Commands/ConfigCommands.cs
+++ b/MacroDeck.Cli/Commands/ConfigCommands.cs
@@ -1,0 +1,56 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace MacroDeck.Cli.Commands;
+
+public static class ConfigCommands
+{
+    public static Command GetConfig(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var cmd = new Command("get", "Get current MacroDeck configuration.");
+        cmd.SetHandler(async ctx =>
+        {
+            Console.WriteLine(await clientFactory(ctx).GetAsync("api/config"));
+        });
+        return cmd;
+    }
+
+    public static Command UpdateConfig(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var hostOpt = new Option<string?>("--host", "Host / bind address.");
+        var portOpt = new Option<int?>("--port", "Port number.");
+        var adbOpt = new Option<bool?>("--adb", "Enable/disable ADB support.");
+        var sslOpt = new Option<bool?>("--ssl", "Enable/disable SSL.");
+        var autoStartOpt = new Option<bool?>("--auto-start", "Enable/disable autostart.");
+        var cmd = new Command("update", "Patch MacroDeck configuration (only supplied fields are changed).");
+        cmd.AddOption(hostOpt);
+        cmd.AddOption(portOpt);
+        cmd.AddOption(adbOpt);
+        cmd.AddOption(sslOpt);
+        cmd.AddOption(autoStartOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var patch = new Dictionary<string, object?>();
+            var host = ctx.ParseResult.GetValueForOption(hostOpt);
+            if (host is not null) patch["host"] = host;
+            var port = ctx.ParseResult.GetValueForOption(portOpt);
+            if (port is not null) patch["port"] = port;
+            var adb = ctx.ParseResult.GetValueForOption(adbOpt);
+            if (adb is not null) patch["adbSupport"] = adb;
+            var ssl = ctx.ParseResult.GetValueForOption(sslOpt);
+            if (ssl is not null) patch["ssl"] = ssl;
+            var autoStart = ctx.ParseResult.GetValueForOption(autoStartOpt);
+            if (autoStart is not null) patch["autoStart"] = autoStart;
+
+            if (patch.Count == 0)
+            {
+                Console.Error.WriteLine("No fields provided. Use --host, --port, --adb, --ssl, or --auto-start.");
+                ctx.ExitCode = 1;
+                return;
+            }
+
+            Console.WriteLine(await clientFactory(ctx).PatchAsync("api/config", patch));
+        });
+        return cmd;
+    }
+}

--- a/MacroDeck.Cli/Commands/ConfigCommands.cs
+++ b/MacroDeck.Cli/Commands/ConfigCommands.cs
@@ -17,34 +17,46 @@ public static class ConfigCommands
 
     public static Command UpdateConfig(Func<InvocationContext, ApiClient> clientFactory)
     {
-        var hostOpt = new Option<string?>("--host", "Host / bind address.");
-        var portOpt = new Option<int?>("--port", "Port number.");
-        var adbOpt = new Option<bool?>("--adb", "Enable/disable ADB support.");
-        var sslOpt = new Option<bool?>("--ssl", "Enable/disable SSL.");
+        var autoUpdatesOpt = new Option<bool?>("--auto-updates", "Enable/disable automatic update checks.");
+        var updateBetaOpt = new Option<bool?>("--update-beta-versions", "Enable/disable beta updates.");
+        var adbOpt = new Option<bool?>("--enable-adb-server", "Enable/disable ADB server support.");
+        var adbAutoStartOpt = new Option<bool?>("--enable-adb-auto-start-app", "Enable/disable auto-start of Android app via ADB.");
+        var askConnectionsOpt = new Option<bool?>("--ask-on-new-connections", "Prompt when new devices attempt to connect.");
+        var blockConnectionsOpt = new Option<bool?>("--block-new-connections", "Block new device connections.");
+        var languageOpt = new Option<string?>("--language", "Set UI language (e.g. English, German).");
         var autoStartOpt = new Option<bool?>("--auto-start", "Enable/disable autostart.");
         var cmd = new Command("update", "Patch MacroDeck configuration (only supplied fields are changed).");
-        cmd.AddOption(hostOpt);
-        cmd.AddOption(portOpt);
+        cmd.AddOption(autoUpdatesOpt);
+        cmd.AddOption(updateBetaOpt);
         cmd.AddOption(adbOpt);
-        cmd.AddOption(sslOpt);
+        cmd.AddOption(adbAutoStartOpt);
+        cmd.AddOption(askConnectionsOpt);
+        cmd.AddOption(blockConnectionsOpt);
+        cmd.AddOption(languageOpt);
         cmd.AddOption(autoStartOpt);
         cmd.SetHandler(async (InvocationContext ctx) =>
         {
             var patch = new Dictionary<string, object?>();
-            var host = ctx.ParseResult.GetValueForOption(hostOpt);
-            if (host is not null) patch["host"] = host;
-            var port = ctx.ParseResult.GetValueForOption(portOpt);
-            if (port is not null) patch["port"] = port;
+            var autoUpdates = ctx.ParseResult.GetValueForOption(autoUpdatesOpt);
+            if (autoUpdates is not null) patch["autoUpdates"] = autoUpdates;
+            var updateBeta = ctx.ParseResult.GetValueForOption(updateBetaOpt);
+            if (updateBeta is not null) patch["updateBetaVersions"] = updateBeta;
             var adb = ctx.ParseResult.GetValueForOption(adbOpt);
-            if (adb is not null) patch["adbSupport"] = adb;
-            var ssl = ctx.ParseResult.GetValueForOption(sslOpt);
-            if (ssl is not null) patch["ssl"] = ssl;
+            if (adb is not null) patch["enableAdbServer"] = adb;
+            var adbAutoStart = ctx.ParseResult.GetValueForOption(adbAutoStartOpt);
+            if (adbAutoStart is not null) patch["enableAdbAutoStartApp"] = adbAutoStart;
+            var askConnections = ctx.ParseResult.GetValueForOption(askConnectionsOpt);
+            if (askConnections is not null) patch["askOnNewConnections"] = askConnections;
+            var blockConnections = ctx.ParseResult.GetValueForOption(blockConnectionsOpt);
+            if (blockConnections is not null) patch["blockNewConnections"] = blockConnections;
+            var language = ctx.ParseResult.GetValueForOption(languageOpt);
+            if (language is not null) patch["language"] = language;
             var autoStart = ctx.ParseResult.GetValueForOption(autoStartOpt);
             if (autoStart is not null) patch["autoStart"] = autoStart;
 
             if (patch.Count == 0)
             {
-                Console.Error.WriteLine("No fields provided. Use --host, --port, --adb, --ssl, or --auto-start.");
+                Console.Error.WriteLine("No fields provided. Use one or more supported options like --auto-start, --auto-updates, --enable-adb-server, --language, etc.");
                 ctx.ExitCode = 1;
                 return;
             }

--- a/MacroDeck.Cli/Commands/DeviceCommands.cs
+++ b/MacroDeck.Cli/Commands/DeviceCommands.cs
@@ -1,0 +1,55 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace MacroDeck.Cli.Commands;
+
+public static class DeviceCommands
+{
+    public static Command ListDevices(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var cmd = new Command("list", "List known devices.");
+        cmd.SetHandler(async ctx =>
+        {
+            Console.WriteLine(await clientFactory(ctx).GetAsync("api/devices"));
+        });
+        return cmd;
+    }
+
+    public static Command AssignProfile(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var clientIdArg = new Argument<string>("clientId", "Device client ID.");
+        var profileIdOpt = new Option<string>("--profile", "Profile ID to assign.") { IsRequired = true };
+        var cmd = new Command("assign-profile", "Assign a profile to a device.");
+        cmd.AddArgument(clientIdArg);
+        cmd.AddOption(profileIdOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var cid = ctx.ParseResult.GetValueForArgument(clientIdArg);
+            var result = await clientFactory(ctx).PutAsync($"api/devices/{Uri.EscapeDataString(cid)}/profile", new
+            {
+                profileId = ctx.ParseResult.GetValueForOption(profileIdOpt),
+            });
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+
+    public static Command SetBlocked(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var clientIdArg = new Argument<string>("clientId", "Device client ID.");
+        var blockedOpt = new Option<bool>("--blocked", "true to block, false to unblock.") { IsRequired = true };
+        var cmd = new Command("set-blocked", "Block or unblock a device.");
+        cmd.AddArgument(clientIdArg);
+        cmd.AddOption(blockedOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var cid = ctx.ParseResult.GetValueForArgument(clientIdArg);
+            var result = await clientFactory(ctx).PutAsync($"api/devices/{Uri.EscapeDataString(cid)}/blocked", new
+            {
+                blocked = ctx.ParseResult.GetValueForOption(blockedOpt),
+            });
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+}

--- a/MacroDeck.Cli/Commands/PluginCommands.cs
+++ b/MacroDeck.Cli/Commands/PluginCommands.cs
@@ -1,0 +1,56 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace MacroDeck.Cli.Commands;
+
+public static class PluginCommands
+{
+    public static Command ListPlugins(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var cmd = new Command("list", "List all installed plugins.");
+        cmd.SetHandler(async ctx =>
+        {
+            Console.WriteLine(await clientFactory(ctx).GetAsync("api/plugins"));
+        });
+        return cmd;
+    }
+
+    public static Command GetPlugin(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var nameArg = new Argument<string>("name", "Plugin name.");
+        var cmd = new Command("get", "Get details and available actions for a plugin.");
+        cmd.AddArgument(nameArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var name = ctx.ParseResult.GetValueForArgument(nameArg);
+            Console.WriteLine(await clientFactory(ctx).GetAsync($"api/plugins/{Uri.EscapeDataString(name)}"));
+        });
+        return cmd;
+    }
+
+    public static Command SearchStore(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var queryArg = new Argument<string>("query", "Search term.");
+        var cmd = new Command("search", "Search the MacroDeck extension store.");
+        cmd.AddArgument(queryArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var q = Uri.EscapeDataString(ctx.ParseResult.GetValueForArgument(queryArg));
+            Console.WriteLine(await clientFactory(ctx).GetAsync($"api/plugins/store/search?q={q}"));
+        });
+        return cmd;
+    }
+
+    public static Command InstallPlugin(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var idArg = new Argument<string>("extensionId", "Extension store ID to install.");
+        var cmd = new Command("install", "Install a plugin from the extension store.");
+        cmd.AddArgument(idArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var id = ctx.ParseResult.GetValueForArgument(idArg);
+            Console.WriteLine(await clientFactory(ctx).PostAsync("api/plugins/store/install", new { extensionId = id }));
+        });
+        return cmd;
+    }
+}

--- a/MacroDeck.Cli/Commands/ProfileCommands.cs
+++ b/MacroDeck.Cli/Commands/ProfileCommands.cs
@@ -1,0 +1,125 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace MacroDeck.Cli.Commands;
+
+public static class ProfileCommands
+{
+    public static Command ListProfiles(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var cmd = new Command("list", "List all profiles.");
+        cmd.SetHandler(async ctx =>
+        {
+            var result = await clientFactory(ctx).GetAsync("api/profiles");
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+
+    public static Command GetProfile(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID to inspect.");
+        var cmd = new Command("get", "Get a profile with its folders.");
+        cmd.AddArgument(profileIdArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var id = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            Console.WriteLine(await clientFactory(ctx).GetAsync($"api/profiles/{id}"));
+        });
+        return cmd;
+    }
+
+    public static Command CreateProfile(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var nameOpt = new Option<string>("--name", "Profile display name.") { IsRequired = true };
+        var rowsOpt = new Option<int>("--rows", () => 3, "Number of button rows.");
+        var colsOpt = new Option<int>("--columns", () => 5, "Number of button columns.");
+        var cmd = new Command("create", "Create a new profile.");
+        cmd.AddOption(nameOpt);
+        cmd.AddOption(rowsOpt);
+        cmd.AddOption(colsOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var result = await clientFactory(ctx).PostAsync("api/profiles", new
+            {
+                displayName = ctx.ParseResult.GetValueForOption(nameOpt),
+                rows = ctx.ParseResult.GetValueForOption(rowsOpt),
+                columns = ctx.ParseResult.GetValueForOption(colsOpt),
+                buttonSpacing = 10,
+                buttonRadius = 40,
+                buttonBackground = true,
+            });
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+
+    public static Command DeleteProfile(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID to delete.");
+        var cmd = new Command("delete", "Delete a profile.");
+        cmd.AddArgument(profileIdArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var id = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            var ok = await clientFactory(ctx).DeleteAsync($"api/profiles/{id}");
+            Console.WriteLine(ok ? "Deleted." : "Not found or cannot delete.");
+        });
+        return cmd;
+    }
+
+    public static Command ListFolders(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID.");
+        var cmd = new Command("list-folders", "List folders in a profile.");
+        cmd.AddArgument(profileIdArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var id = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            Console.WriteLine(await clientFactory(ctx).GetAsync($"api/profiles/{id}/folders"));
+        });
+        return cmd;
+    }
+
+    public static Command CreateFolder(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID.");
+        var nameOpt = new Option<string>("--name", "Folder display name.") { IsRequired = true };
+        var parentOpt = new Option<string?>("--parent", "Parent folder ID (omit for root).");
+        var appOpt = new Option<string>("--app", () => "", "Windows process name to auto-switch to this folder.");
+        var cmd = new Command("create-folder", "Create a folder inside a profile.");
+        cmd.AddArgument(profileIdArg);
+        cmd.AddOption(nameOpt);
+        cmd.AddOption(parentOpt);
+        cmd.AddOption(appOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var id = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            var result = await clientFactory(ctx).PostAsync($"api/profiles/{id}/folders", new
+            {
+                displayName = ctx.ParseResult.GetValueForOption(nameOpt),
+                parentFolderId = ctx.ParseResult.GetValueForOption(parentOpt),
+                applicationToTrigger = ctx.ParseResult.GetValueForOption(appOpt),
+            });
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+
+    public static Command DeleteFolder(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var profileIdArg = new Argument<string>("profileId", "Profile ID.");
+        var folderIdArg = new Argument<string>("folderId", "Folder ID to delete.");
+        var cmd = new Command("delete-folder", "Delete a folder and all its children.");
+        cmd.AddArgument(profileIdArg);
+        cmd.AddArgument(folderIdArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var pid = ctx.ParseResult.GetValueForArgument(profileIdArg);
+            var fid = ctx.ParseResult.GetValueForArgument(folderIdArg);
+            var ok = await clientFactory(ctx).DeleteAsync($"api/profiles/{pid}/folders/{fid}");
+            Console.WriteLine(ok ? "Folder deleted." : "Not found.");
+        });
+        return cmd;
+    }
+}

--- a/MacroDeck.Cli/Commands/VariableCommands.cs
+++ b/MacroDeck.Cli/Commands/VariableCommands.cs
@@ -1,0 +1,69 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace MacroDeck.Cli.Commands;
+
+public static class VariableCommands
+{
+    public static Command ListVariables(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var cmd = new Command("list", "List all variables.");
+        cmd.SetHandler(async ctx =>
+        {
+            Console.WriteLine(await clientFactory(ctx).GetAsync("api/variables"));
+        });
+        return cmd;
+    }
+
+    public static Command GetVariable(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var nameArg = new Argument<string>("name", "Variable name.");
+        var cmd = new Command("get", "Get a single variable.");
+        cmd.AddArgument(nameArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var name = ctx.ParseResult.GetValueForArgument(nameArg);
+            Console.WriteLine(await clientFactory(ctx).GetAsync($"api/variables/{Uri.EscapeDataString(name)}"));
+        });
+        return cmd;
+    }
+
+    public static Command SetVariable(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var nameArg = new Argument<string>("name", "Variable name.");
+        var valueOpt = new Option<string>("--value", "Variable value.") { IsRequired = true };
+        var typeOpt = new Option<string>("--type", () => "String", "Variable type: String, Integer, Float, Bool.");
+        var creatorOpt = new Option<string>("--creator", () => "CLI", "Creator label.");
+        var cmd = new Command("set", "Create or update a variable.");
+        cmd.AddArgument(nameArg);
+        cmd.AddOption(valueOpt);
+        cmd.AddOption(typeOpt);
+        cmd.AddOption(creatorOpt);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var name = ctx.ParseResult.GetValueForArgument(nameArg);
+            var result = await clientFactory(ctx).PutAsync($"api/variables/{Uri.EscapeDataString(name)}", new
+            {
+                value = ctx.ParseResult.GetValueForOption(valueOpt),
+                type = ctx.ParseResult.GetValueForOption(typeOpt),
+                creator = ctx.ParseResult.GetValueForOption(creatorOpt),
+            });
+            Console.WriteLine(result);
+        });
+        return cmd;
+    }
+
+    public static Command DeleteVariable(Func<InvocationContext, ApiClient> clientFactory)
+    {
+        var nameArg = new Argument<string>("name", "Variable name.");
+        var cmd = new Command("delete", "Delete a variable.");
+        cmd.AddArgument(nameArg);
+        cmd.SetHandler(async (InvocationContext ctx) =>
+        {
+            var name = ctx.ParseResult.GetValueForArgument(nameArg);
+            var ok = await clientFactory(ctx).DeleteAsync($"api/variables/{Uri.EscapeDataString(name)}");
+            Console.WriteLine(ok ? "Variable deleted." : "Not found.");
+        });
+        return cmd;
+    }
+}

--- a/MacroDeck.Cli/MacroDeck.Cli.csproj
+++ b/MacroDeck.Cli/MacroDeck.Cli.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MacroDeck.Cli</RootNamespace>
+    <AssemblyName>macrodeck</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>net8.0</TargetFramework>
+    <Description>MacroDeck CLI – manage profiles, plugins, variables, and devices from the command line.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+  </ItemGroup>
+
+</Project>

--- a/MacroDeck.Cli/Program.cs
+++ b/MacroDeck.Cli/Program.cs
@@ -1,0 +1,69 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using MacroDeck.Cli;
+using MacroDeck.Cli.Commands;
+
+// Global options shared by all commands
+var urlOption = new Option<string?>("--url", "MacroDeck base URL (default: http://localhost:8191 or MACRODECK_URL env var)");
+var keyOption = new Option<string?>("--key", "Admin API key (default: MACRODECK_API_KEY env var)");
+
+var root = new RootCommand("MacroDeck CLI – manage profiles, plugins, variables, and devices.")
+{
+    urlOption,
+    keyOption,
+};
+
+// Helper to build an ApiClient from the parsed global options
+ApiClient BuildClient(InvocationContext ctx) =>
+    ApiClient.FromEnvironment(
+        ctx.ParseResult.GetValueForOption(urlOption),
+        ctx.ParseResult.GetValueForOption(keyOption));
+
+// ---- profile ----
+var profileCmd = new Command("profile", "Manage profiles and folders.");
+profileCmd.AddCommand(ProfileCommands.ListProfiles(BuildClient));
+profileCmd.AddCommand(ProfileCommands.GetProfile(BuildClient));
+profileCmd.AddCommand(ProfileCommands.CreateProfile(BuildClient));
+profileCmd.AddCommand(ProfileCommands.DeleteProfile(BuildClient));
+profileCmd.AddCommand(ProfileCommands.ListFolders(BuildClient));
+profileCmd.AddCommand(ProfileCommands.CreateFolder(BuildClient));
+profileCmd.AddCommand(ProfileCommands.DeleteFolder(BuildClient));
+root.AddCommand(profileCmd);
+
+// ---- button ----
+var buttonCmd = new Command("button", "Manage action buttons inside profile folders.");
+buttonCmd.AddCommand(ButtonCommands.ListButtons(BuildClient));
+buttonCmd.AddCommand(ButtonCommands.CreateButton(BuildClient));
+buttonCmd.AddCommand(ButtonCommands.DeleteButton(BuildClient));
+root.AddCommand(buttonCmd);
+
+// ---- plugin ----
+var pluginCmd = new Command("plugin", "Manage installed plugins and the Extension Store.");
+pluginCmd.AddCommand(PluginCommands.ListPlugins(BuildClient));
+pluginCmd.AddCommand(PluginCommands.GetPlugin(BuildClient));
+pluginCmd.AddCommand(PluginCommands.SearchStore(BuildClient));
+pluginCmd.AddCommand(PluginCommands.InstallPlugin(BuildClient));
+root.AddCommand(pluginCmd);
+
+// ---- variable ----
+var varCmd = new Command("variable", "Manage MacroDeck variables.");
+varCmd.AddCommand(VariableCommands.ListVariables(BuildClient));
+varCmd.AddCommand(VariableCommands.GetVariable(BuildClient));
+varCmd.AddCommand(VariableCommands.SetVariable(BuildClient));
+varCmd.AddCommand(VariableCommands.DeleteVariable(BuildClient));
+root.AddCommand(varCmd);
+
+// ---- device ----
+var deviceCmd = new Command("device", "Manage connected devices.");
+deviceCmd.AddCommand(DeviceCommands.ListDevices(BuildClient));
+deviceCmd.AddCommand(DeviceCommands.AssignProfile(BuildClient));
+deviceCmd.AddCommand(DeviceCommands.SetBlocked(BuildClient));
+root.AddCommand(deviceCmd);
+
+// ---- config ----
+var configCmd = new Command("config", "Read or update MacroDeck server configuration.");
+configCmd.AddCommand(ConfigCommands.GetConfig(BuildClient));
+configCmd.AddCommand(ConfigCommands.UpdateConfig(BuildClient));
+root.AddCommand(configCmd);
+
+return await root.InvokeAsync(args);

--- a/MacroDeck.Mcp/MacroDeck.Mcp.csproj
+++ b/MacroDeck.Mcp/MacroDeck.Mcp.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MacroDeck.Mcp</RootNamespace>
+    <AssemblyName>MacroDeck.Mcp</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Override global TargetFramework – MCP server is cross-platform -->
+    <TargetFramework>net8.0</TargetFramework>
+    <Description>MacroDeck MCP (Model Context Protocol) server – exposes MacroDeck management as LLM-callable tools via the stdio transport.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+  </ItemGroup>
+
+</Project>

--- a/MacroDeck.Mcp/MacroDeckApiClient.cs
+++ b/MacroDeck.Mcp/MacroDeckApiClient.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace MacroDeck.Mcp;
+
+/// <summary>
+/// Typed HTTP client for the MacroDeck admin REST API.
+/// </summary>
+public class MacroDeckApiClient
+{
+    private readonly HttpClient _http;
+
+    public MacroDeckApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<string> GetJsonAsync(string path)
+    {
+        var response = await _http.GetAsync(path);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<string> PostJsonAsync(string path, object body)
+    {
+        var json = JsonSerializer.Serialize(body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync(path, content);
+        var responseText = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"POST {path} failed ({(int)response.StatusCode}): {responseText}");
+        return responseText;
+    }
+
+    public async Task<string> PutJsonAsync(string path, object body)
+    {
+        var json = JsonSerializer.Serialize(body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _http.PutAsync(path, content);
+        var responseText = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"PUT {path} failed ({(int)response.StatusCode}): {responseText}");
+        return responseText;
+    }
+
+    public async Task<string> PatchJsonAsync(string path, object body)
+    {
+        var json = JsonSerializer.Serialize(body, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Patch, path) { Content = content };
+        var response = await _http.SendAsync(request);
+        var responseText = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException($"PATCH {path} failed ({(int)response.StatusCode}): {responseText}");
+        return responseText;
+    }
+
+    public async Task<bool> DeleteAsync(string path)
+    {
+        var response = await _http.DeleteAsync(path);
+        return response.IsSuccessStatusCode;
+    }
+}

--- a/MacroDeck.Mcp/Program.cs
+++ b/MacroDeck.Mcp/Program.cs
@@ -1,0 +1,33 @@
+using System.Net.Http.Headers;
+using MacroDeck.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// The MCP server communicates over stdio (stdin/stdout) so that any MCP-compatible
+// client (Claude Desktop, VS Code Copilot, etc.) can launch it as a subprocess.
+// Configure the MacroDeck server URL and admin key via environment variables:
+//   MACRODECK_URL      (default: http://localhost:8191)
+//   MACRODECK_API_KEY  (found in MacroDeck's config.json as "AdminApiKey")
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
+
+// HTTP client for MacroDeck admin REST API
+builder.Services.AddHttpClient<MacroDeckApiClient>(client =>
+{
+    var url = Environment.GetEnvironmentVariable("MACRODECK_URL") ?? "http://localhost:8191";
+    var key = Environment.GetEnvironmentVariable("MACRODECK_API_KEY") ?? string.Empty;
+    client.BaseAddress = new Uri(url.TrimEnd('/') + "/");
+    client.DefaultRequestHeaders.Add("X-MacroDeck-Admin-Key", key);
+    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+});
+
+// Register all MCP tools
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly(typeof(Program).Assembly);
+
+await builder.Build().RunAsync();

--- a/MacroDeck.Mcp/Tools/ConfigTools.cs
+++ b/MacroDeck.Mcp/Tools/ConfigTools.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using MacroDeck.Mcp;
+using ModelContextProtocol.Server;
+
+/// <summary>MCP tools for reading and updating MacroDeck server configuration.</summary>
+[McpServerToolType]
+public class ConfigTools
+{
+    private readonly MacroDeckApiClient _api;
+    public ConfigTools(MacroDeckApiClient api) => _api = api;
+
+    [McpServerTool, Description(
+        "Get the current MacroDeck server configuration: port, SSL, auto-update settings, ADB, language, and connection policies.")]
+    public async Task<string> GetConfiguration() =>
+        await _api.GetJsonAsync("api/config");
+
+    [McpServerTool, Description(
+        "Update one or more MacroDeck configuration settings. Only provide the fields you want to change. " +
+        "Supported fields: autoUpdates (bool), updateBetaVersions (bool), enableAdbServer (bool), " +
+        "enableAdbAutoStartApp (bool), askOnNewConnections (bool), blockNewConnections (bool), language (string).")]
+    public async Task<string> UpdateConfiguration(
+        [Description("JSON object with only the fields to update, e.g. {\"blockNewConnections\":true}.")] string settingsJson) =>
+        await _api.PatchJsonAsync("api/config", settingsJson);
+}

--- a/MacroDeck.Mcp/Tools/ConfigTools.cs
+++ b/MacroDeck.Mcp/Tools/ConfigTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using MacroDeck.Mcp;
 using ModelContextProtocol.Server;
 
@@ -19,6 +20,20 @@ public class ConfigTools
         "Supported fields: autoUpdates (bool), updateBetaVersions (bool), enableAdbServer (bool), " +
         "enableAdbAutoStartApp (bool), askOnNewConnections (bool), blockNewConnections (bool), language (string).")]
     public async Task<string> UpdateConfiguration(
-        [Description("JSON object with only the fields to update, e.g. {\"blockNewConnections\":true}.")] string settingsJson) =>
-        await _api.PatchJsonAsync("api/config", settingsJson);
+        [Description("JSON object with only the fields to update, e.g. {\"blockNewConnections\":true}.")] string settingsJson)
+    {
+        try
+        {
+            // Parse the JSON string into a dictionary for flexibility
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            var patch = JsonSerializer.Deserialize<Dictionary<string, object>>(settingsJson, options)
+                ?? throw new ArgumentException("Invalid JSON in settingsJson parameter");
+            
+            return await _api.PatchJsonAsync("api/config", patch);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException($"Invalid JSON in settingsJson: {ex.Message}", ex);
+        }
+    }
 }

--- a/MacroDeck.Mcp/Tools/DeviceTools.cs
+++ b/MacroDeck.Mcp/Tools/DeviceTools.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+using MacroDeck.Mcp;
+using ModelContextProtocol.Server;
+
+/// <summary>MCP tools for managing connected MacroDeck devices.</summary>
+[McpServerToolType]
+public class DeviceTools
+{
+    private readonly MacroDeckApiClient _api;
+    public DeviceTools(MacroDeckApiClient api) => _api = api;
+
+    [McpServerTool, Description(
+        "List all known MacroDeck devices (phones, tablets, web clients). " +
+        "Returns clientId, display name, assigned profile, device type, and whether the device is currently online.")]
+    public async Task<string> ListDevices() =>
+        await _api.GetJsonAsync("api/devices");
+
+    [McpServerTool, Description("Assign a different profile to a device. The change takes effect immediately for connected devices.")]
+    public async Task<string> AssignProfileToDevice(
+        [Description("The clientId of the device (from list_devices).")] string clientId,
+        [Description("The profileId to assign (from list_profiles).")] string profileId) =>
+        await _api.PutJsonAsync($"api/devices/{Uri.EscapeDataString(clientId)}/profile", new { profileId });
+
+    [McpServerTool, Description("Block or unblock a device. Blocked devices cannot connect to MacroDeck.")]
+    public async Task<string> SetDeviceBlocked(
+        [Description("The clientId of the device.")] string clientId,
+        [Description("true to block, false to unblock.")] bool blocked)
+    {
+        var result = await _api.GetJsonAsync($"api/devices/{Uri.EscapeDataString(clientId)}/blocked?blocked={blocked}");
+        return result;
+    }
+}

--- a/MacroDeck.Mcp/Tools/IconTools.cs
+++ b/MacroDeck.Mcp/Tools/IconTools.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using MacroDeck.Mcp;
+using ModelContextProtocol.Server;
+
+/// <summary>MCP tools for browsing installed MacroDeck icon packs and their icons.</summary>
+[McpServerToolType]
+public class IconTools
+{
+    private readonly MacroDeckApiClient _api;
+    public IconTools(MacroDeckApiClient api) => _api = api;
+
+    [McpServerTool, Description(
+        "List all installed icon packs. Returns each pack's name, author, version, and icon count. " +
+        "Use the pack 'name' value with list_icons to discover valid icon IDs. " +
+        "IMPORTANT: Always call list_icons before assigning an icon to a button — icon IDs must match exactly.")]
+    public async Task<string> ListIconPacks() =>
+        await _api.GetJsonAsync("api/icons");
+
+    [McpServerTool, Description(
+        "List all icons in a specific icon pack. Returns each icon's 'iconId' and the ready-to-use 'iconString' " +
+        "(format: 'PackName.iconId') to supply as iconOff or iconOn in update_button. " +
+        "Always use this to verify icon IDs before assigning — guessed names will silently show nothing.")]
+    public async Task<string> ListIcons(
+        [Description("The exact icon pack name as returned by list_icon_packs (e.g. 'Fluent').")] string iconPackName) =>
+        await _api.GetJsonAsync($"api/icons/{Uri.EscapeDataString(iconPackName)}");
+}

--- a/MacroDeck.Mcp/Tools/PluginTools.cs
+++ b/MacroDeck.Mcp/Tools/PluginTools.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using MacroDeck.Mcp;
+using ModelContextProtocol.Server;
+
+/// <summary>MCP tools for browsing and installing MacroDeck plugins.</summary>
+[McpServerToolType]
+public class PluginTools
+{
+    private readonly MacroDeckApiClient _api;
+    public PluginTools(MacroDeckApiClient api) => _api = api;
+
+    [McpServerTool, Description(
+        "List all installed MacroDeck plugins. Returns plugin name, author, version, whether it can be configured, " +
+        "and – most importantly – the list of available action classes with their names and descriptions. " +
+        "Use this to discover what pluginName and actionClass values to use when creating buttons.")]
+    public async Task<string> ListPlugins() =>
+        await _api.GetJsonAsync("api/plugins");
+
+    [McpServerTool, Description(
+        "Get details for a single installed plugin, including all its available action classes.")]
+    public async Task<string> GetPlugin(
+        [Description("The exact plugin name as returned by list_plugins.")] string pluginName) =>
+        await _api.GetJsonAsync($"api/plugins/{Uri.EscapeDataString(pluginName)}");
+
+    [McpServerTool, Description(
+        "Search the MacroDeck Extension Store for plugins or icon packs by keyword. " +
+        "Returns a list of available packages with their packageId, name, author, and description. " +
+        "After finding a desired plugin, use install_plugin to install it.")]
+    public async Task<string> SearchExtensionStore(
+        [Description("Search term (e.g. 'obs studio', 'spotify', 'volume').")] string query,
+        [Description("Type to search: 'Plugin' or 'IconPack'. Default is 'Plugin'.")] string type = "Plugin") =>
+        await _api.GetJsonAsync($"api/plugins/store/search?q={Uri.EscapeDataString(query)}&type={Uri.EscapeDataString(type)}");
+
+    [McpServerTool, Description(
+        "Install a MacroDeck plugin from the Extension Store by its packageId. " +
+        "The plugin will be downloaded and staged; MacroDeck must be restarted for it to become active.")]
+    public async Task<string> InstallPlugin(
+        [Description("The packageId of the plugin (from search_extension_store results).")] string packageId) =>
+        await _api.PostJsonAsync("api/plugins/store/install", new { packageId });
+}

--- a/MacroDeck.Mcp/Tools/ProfileTools.cs
+++ b/MacroDeck.Mcp/Tools/ProfileTools.cs
@@ -91,7 +91,7 @@ public class ProfileTools
         [Description("Zero-based column (X) position of the button in the grid.")] int positionX,
         [Description("Zero-based row (Y) position of the button in the grid.")] int positionY,
         [Description("JSON array of action objects to run on short press. Each: {\"pluginName\":\"...\",\"actionClass\":\"...\",\"configuration\":\"...\"}. Use empty array [] for a display-only button.")] string actionsJson = "[]",
-        [Description("Label displayed when button state is OFF. Supports Cottle templates, e.g. '{volume_level}%'.")] string? labelOffText = null,
+        [Description("Label displayed when button state is OFF. Supports Cottle templates, e.g. '{volume_level}%' or '{round(speedtestdownload, 2)} Mbps'.")] string? labelOffText = null,
         [Description("Label displayed when button state is ON.")] string? labelOnText = null,
         [Description("Variable name to auto-sync button state to (e.g. 'my_toggle'). Leave empty to disable.")] string? stateBindingVariable = null)
     {
@@ -108,7 +108,7 @@ public class ProfileTools
     }
 
     [McpServerTool, Description(
-        "Update an existing button with partial fields. Provide only what you want to change in updateJson, e.g. {\"labelOffText\":\"⬇ Download\\n{speed}\"}. Existing values are preserved for omitted fields.")]
+        "Update an existing button with partial fields. Provide only what you want to change in updateJson, e.g. {\"labelOffText\":\"⬇ Download\\n{round(speedtestdownload, 2)} Mbps\",\"backgroundColorOff\":\"#3498DB\"}. Existing values are preserved for omitted fields.")]
     public async Task<string> UpdateButton(
         [Description("The profileId of the profile.")] string profileId,
         [Description("The folderId of the folder.")] string folderId,
@@ -153,6 +153,25 @@ public class ProfileTools
         if (patch.TryGetPropertyValue("stateBindingVariable", out var stateBindingVariableNode))
             merged.StateBindingVariable = stateBindingVariableNode?.GetValue<string>();
 
+        if (patch.TryGetPropertyValue("iconPack", out var iconPackNode))
+            merged.IconPack = iconPackNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("iconName", out var iconNameNode))
+            merged.IconName = iconNameNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("iconNameOn", out var iconNameOnNode))
+            merged.IconNameOn = iconNameOnNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("iconOff", out var iconOffNode))
+            merged.IconOff = iconOffNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("iconOn", out var iconOnNode))
+            merged.IconOn = iconOnNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("backgroundColorOff", out var backgroundColorOffNode))
+            merged.BackgroundColorOff = backgroundColorOffNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("backgroundColorOn", out var backgroundColorOnNode))
+            merged.BackgroundColorOn = backgroundColorOnNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("labelColorOff", out var labelColorOffNode))
+            merged.LabelColorOff = labelColorOffNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("labelColorOn", out var labelColorOnNode))
+            merged.LabelColorOn = labelColorOnNode?.GetValue<string>();
+
         return await _api.PutJsonAsync(
             $"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}", merged);
     }
@@ -168,6 +187,15 @@ public class ProfileTools
         public string? LabelOffText { get; set; }
         public string? LabelOnText { get; set; }
         public string? StateBindingVariable { get; set; }
+        public string? IconPack { get; set; }
+        public string? IconName { get; set; }
+        public string? IconNameOn { get; set; }
+        public string? IconOff { get; set; }
+        public string? IconOn { get; set; }
+        public string? BackgroundColorOff { get; set; }
+        public string? BackgroundColorOn { get; set; }
+        public string? LabelColorOff { get; set; }
+        public string? LabelColorOn { get; set; }
     }
 
     private sealed class ActionAssignment

--- a/MacroDeck.Mcp/Tools/ProfileTools.cs
+++ b/MacroDeck.Mcp/Tools/ProfileTools.cs
@@ -1,0 +1,128 @@
+using System.ComponentModel;
+using MacroDeck.Mcp;
+using ModelContextProtocol.Server;
+
+/// <summary>MCP tools for managing MacroDeck profiles, folders, and action buttons.</summary>
+[McpServerToolType]
+public class ProfileTools
+{
+    private readonly MacroDeckApiClient _api;
+    public ProfileTools(MacroDeckApiClient api) => _api = api;
+
+    [McpServerTool, Description(
+        "List all MacroDeck profiles. Returns an array of profiles with their ID, display name, grid dimensions (rows × columns), and folder count.")]
+    public async Task<string> ListProfiles() =>
+        await _api.GetJsonAsync("api/profiles");
+
+    [McpServerTool, Description(
+        "Get the full structure (all folders and buttons) of a specific profile by its profileId.")]
+    public async Task<string> GetProfile(
+        [Description("The profileId returned by list_profiles.")] string profileId) =>
+        await _api.GetJsonAsync($"api/profiles/{profileId}");
+
+    [McpServerTool, Description(
+        "Create a new MacroDeck profile with the specified display name and optional grid layout.")]
+    public async Task<string> CreateProfile(
+        [Description("Human-readable name for the new profile.")] string displayName,
+        [Description("Number of button rows (default 3).")] int rows = 3,
+        [Description("Number of button columns (default 5).")] int columns = 5,
+        [Description("Spacing in pixels between buttons (default 10).")] int buttonSpacing = 10,
+        [Description("Corner radius of buttons in pixels (default 40).")] int buttonRadius = 40)
+    {
+        return await _api.PostJsonAsync("api/profiles", new
+        {
+            displayName, rows, columns, buttonSpacing, buttonRadius, buttonBackground = true
+        });
+    }
+
+    [McpServerTool, Description("Delete a profile by its profileId. At least two profiles must exist.")]
+    public async Task<string> DeleteProfile(
+        [Description("The profileId to delete.")] string profileId)
+    {
+        var ok = await _api.DeleteAsync($"api/profiles/{profileId}");
+        return ok ? "Profile deleted." : "Profile not found or cannot be deleted (must keep ≥1 profile).";
+    }
+
+    [McpServerTool, Description(
+        "List all folders in a profile. Each folder has a folderId, displayName, button count, and child folder IDs.")]
+    public async Task<string> ListFolders(
+        [Description("The profileId of the profile.")] string profileId) =>
+        await _api.GetJsonAsync($"api/profiles/{profileId}/folders");
+
+    [McpServerTool, Description(
+        "Create a new folder inside a profile. Optionally specify a parent folder ID (otherwise adds under root) and a Windows process name to auto-switch to this folder when that app is focused.")]
+    public async Task<string> CreateFolder(
+        [Description("The profileId of the target profile.")] string profileId,
+        [Description("Display name for the new folder.")] string displayName,
+        [Description("Optional parent folder ID. Omit to add under root.")] string? parentFolderId = null,
+        [Description("Optional Windows process name (e.g. 'chrome') to trigger auto-switch to this folder.")] string applicationToTrigger = "")
+    {
+        return await _api.PostJsonAsync($"api/profiles/{profileId}/folders", new
+        {
+            displayName, parentFolderId, applicationToTrigger
+        });
+    }
+
+    [McpServerTool, Description("Delete a folder and all its child folders and buttons.")]
+    public async Task<string> DeleteFolder(
+        [Description("The profileId of the profile.")] string profileId,
+        [Description("The folderId to delete.")] string folderId)
+    {
+        var ok = await _api.DeleteAsync($"api/profiles/{profileId}/folders/{folderId}");
+        return ok ? "Folder deleted." : "Folder not found or cannot delete root folder.";
+    }
+
+    [McpServerTool, Description(
+        "List all action buttons in a folder. Each button shows its grid position, state, label text, and the list of assigned plugin actions.")]
+    public async Task<string> ListButtons(
+        [Description("The profileId of the profile.")] string profileId,
+        [Description("The folderId of the folder.")] string folderId) =>
+        await _api.GetJsonAsync($"api/profiles/{profileId}/folders/{folderId}/buttons");
+
+    [McpServerTool, Description(
+        "Create an action button at a grid position in a folder. Assign one or more plugin actions that execute when the button is pressed. " +
+        "Each action needs a pluginName and actionClass (from list_plugins). " +
+        "Optionally provide label text (supports Cottle templates with {variable_name} syntax) and a variable name to bind the button state to.")]
+    public async Task<string> CreateButton(
+        [Description("The profileId of the profile.")] string profileId,
+        [Description("The folderId of the folder.")] string folderId,
+        [Description("Zero-based column (X) position of the button in the grid.")] int positionX,
+        [Description("Zero-based row (Y) position of the button in the grid.")] int positionY,
+        [Description("JSON array of action objects to run on short press. Each: {\"pluginName\":\"...\",\"actionClass\":\"...\",\"configuration\":\"...\"}. Use empty array [] for a display-only button.")] string actionsJson = "[]",
+        [Description("Label displayed when button state is OFF. Supports Cottle templates, e.g. '{volume_level}%'.")] string? labelOffText = null,
+        [Description("Label displayed when button state is ON.")] string? labelOnText = null,
+        [Description("Variable name to auto-sync button state to (e.g. 'my_toggle'). Leave empty to disable.")] string? stateBindingVariable = null)
+    {
+        var actions = System.Text.Json.JsonSerializer.Deserialize<object[]>(actionsJson) ?? [];
+        return await _api.PostJsonAsync($"api/profiles/{profileId}/folders/{folderId}/buttons", new
+        {
+            positionX, positionY,
+            actions,
+            actionsRelease = Array.Empty<object>(),
+            actionsLongPress = Array.Empty<object>(),
+            actionsLongPressRelease = Array.Empty<object>(),
+            labelOffText, labelOnText, stateBindingVariable
+        });
+    }
+
+    [McpServerTool, Description("Update an existing button's actions or labels.")]
+    public async Task<string> UpdateButton(
+        [Description("The profileId of the profile.")] string profileId,
+        [Description("The folderId of the folder.")] string folderId,
+        [Description("The buttonGuid to update.")] string buttonGuid,
+        [Description("JSON object matching the CreateButton parameters to update.")] string updateJson)
+    {
+        return await _api.PutJsonAsync(
+            $"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}", updateJson);
+    }
+
+    [McpServerTool, Description("Delete a button from a folder.")]
+    public async Task<string> DeleteButton(
+        [Description("The profileId of the profile.")] string profileId,
+        [Description("The folderId of the folder.")] string folderId,
+        [Description("The buttonGuid to delete.")] string buttonGuid)
+    {
+        var ok = await _api.DeleteAsync($"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}");
+        return ok ? "Button deleted." : "Button not found.";
+    }
+}

--- a/MacroDeck.Mcp/Tools/ProfileTools.cs
+++ b/MacroDeck.Mcp/Tools/ProfileTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json.Nodes;
 using MacroDeck.Mcp;
 using ModelContextProtocol.Server;
 
@@ -105,15 +106,37 @@ public class ProfileTools
         });
     }
 
-    [McpServerTool, Description("Update an existing button's actions or labels.")]
+    [McpServerTool, Description(
+        "Update an existing button with partial fields. Provide only what you want to change in updateJson, e.g. {\"labelOffText\":\"⬇ Download\\n{speed}\"}. Existing values are preserved for omitted fields.")]
     public async Task<string> UpdateButton(
         [Description("The profileId of the profile.")] string profileId,
         [Description("The folderId of the folder.")] string folderId,
         [Description("The buttonGuid to update.")] string buttonGuid,
-        [Description("JSON object matching the CreateButton parameters to update.")] string updateJson)
+        [Description("JSON patch object with fields to update. Example: {\"labelOffText\":\"My label\"}")] string updateJson)
     {
+        JsonObject patch;
+        try
+        {
+            patch = JsonNode.Parse(updateJson)?.AsObject()
+                    ?? throw new ArgumentException("updateJson must be a JSON object.");
+        }
+        catch (Exception ex)
+        {
+            throw new ArgumentException(
+                "updateJson is not valid JSON. Pass an object like {\"labelOffText\":\"⬇ Download\\n{speed}\"}.", ex);
+        }
+
+        var existingRaw = await _api.GetJsonAsync($"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}");
+        var merged = JsonNode.Parse(existingRaw)?.AsObject()
+                     ?? throw new InvalidOperationException("Unable to load existing button state.");
+
+        foreach (var (key, value) in patch)
+        {
+            merged[key] = value?.DeepClone();
+        }
+
         return await _api.PutJsonAsync(
-            $"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}", updateJson);
+            $"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}", merged);
     }
 
     [McpServerTool, Description("Delete a button from a folder.")]

--- a/MacroDeck.Mcp/Tools/ProfileTools.cs
+++ b/MacroDeck.Mcp/Tools/ProfileTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using MacroDeck.Mcp;
 using ModelContextProtocol.Server;
@@ -127,16 +128,53 @@ public class ProfileTools
         }
 
         var existingRaw = await _api.GetJsonAsync($"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}");
-        var merged = JsonNode.Parse(existingRaw)?.AsObject()
+        var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var merged = JsonSerializer.Deserialize<ButtonUpdateRequest>(existingRaw, jsonOptions)
                      ?? throw new InvalidOperationException("Unable to load existing button state.");
 
-        foreach (var (key, value) in patch)
-        {
-            merged[key] = value?.DeepClone();
-        }
+        if (patch.TryGetPropertyValue("positionX", out var positionXNode) && positionXNode is not null)
+            merged.PositionX = positionXNode.GetValue<int>();
+        if (patch.TryGetPropertyValue("positionY", out var positionYNode) && positionYNode is not null)
+            merged.PositionY = positionYNode.GetValue<int>();
+
+        if (patch.TryGetPropertyValue("actions", out var actionsNode))
+            merged.Actions = actionsNode?.Deserialize<List<ActionAssignment>>() ?? new List<ActionAssignment>();
+        if (patch.TryGetPropertyValue("actionsRelease", out var actionsReleaseNode))
+            merged.ActionsRelease = actionsReleaseNode?.Deserialize<List<ActionAssignment>>() ?? new List<ActionAssignment>();
+        if (patch.TryGetPropertyValue("actionsLongPress", out var actionsLongPressNode))
+            merged.ActionsLongPress = actionsLongPressNode?.Deserialize<List<ActionAssignment>>() ?? new List<ActionAssignment>();
+        if (patch.TryGetPropertyValue("actionsLongPressRelease", out var actionsLongPressReleaseNode))
+            merged.ActionsLongPressRelease = actionsLongPressReleaseNode?.Deserialize<List<ActionAssignment>>() ?? new List<ActionAssignment>();
+
+        if (patch.TryGetPropertyValue("labelOffText", out var labelOffTextNode))
+            merged.LabelOffText = labelOffTextNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("labelOnText", out var labelOnTextNode))
+            merged.LabelOnText = labelOnTextNode?.GetValue<string>();
+        if (patch.TryGetPropertyValue("stateBindingVariable", out var stateBindingVariableNode))
+            merged.StateBindingVariable = stateBindingVariableNode?.GetValue<string>();
 
         return await _api.PutJsonAsync(
             $"api/profiles/{profileId}/folders/{folderId}/buttons/{buttonGuid}", merged);
+    }
+
+    private sealed class ButtonUpdateRequest
+    {
+        public int PositionX { get; set; }
+        public int PositionY { get; set; }
+        public List<ActionAssignment> Actions { get; set; } = new();
+        public List<ActionAssignment> ActionsRelease { get; set; } = new();
+        public List<ActionAssignment> ActionsLongPress { get; set; } = new();
+        public List<ActionAssignment> ActionsLongPressRelease { get; set; } = new();
+        public string? LabelOffText { get; set; }
+        public string? LabelOnText { get; set; }
+        public string? StateBindingVariable { get; set; }
+    }
+
+    private sealed class ActionAssignment
+    {
+        public string PluginName { get; set; } = string.Empty;
+        public string ActionClass { get; set; } = string.Empty;
+        public string Configuration { get; set; } = string.Empty;
     }
 
     [McpServerTool, Description("Delete a button from a folder.")]

--- a/MacroDeck.Mcp/Tools/ProfileTools.cs
+++ b/MacroDeck.Mcp/Tools/ProfileTools.cs
@@ -96,6 +96,8 @@ public class ProfileTools
         [Description("Variable name to auto-sync button state to (e.g. 'my_toggle'). Leave empty to disable.")] string? stateBindingVariable = null)
     {
         var actions = System.Text.Json.JsonSerializer.Deserialize<object[]>(actionsJson) ?? [];
+        labelOffText = NormalizeNewlines(labelOffText);
+        labelOnText = NormalizeNewlines(labelOnText);
         return await _api.PostJsonAsync($"api/profiles/{profileId}/folders/{folderId}/buttons", new
         {
             positionX, positionY,
@@ -147,9 +149,9 @@ public class ProfileTools
             merged.ActionsLongPressRelease = actionsLongPressReleaseNode?.Deserialize<List<ActionAssignment>>() ?? new List<ActionAssignment>();
 
         if (patch.TryGetPropertyValue("labelOffText", out var labelOffTextNode))
-            merged.LabelOffText = labelOffTextNode?.GetValue<string>();
+            merged.LabelOffText = NormalizeNewlines(labelOffTextNode?.GetValue<string>());
         if (patch.TryGetPropertyValue("labelOnText", out var labelOnTextNode))
-            merged.LabelOnText = labelOnTextNode?.GetValue<string>();
+            merged.LabelOnText = NormalizeNewlines(labelOnTextNode?.GetValue<string>());
         if (patch.TryGetPropertyValue("stateBindingVariable", out var stateBindingVariableNode))
             merged.StateBindingVariable = stateBindingVariableNode?.GetValue<string>();
 
@@ -203,6 +205,17 @@ public class ProfileTools
         public string PluginName { get; set; } = string.Empty;
         public string ActionClass { get; set; } = string.Empty;
         public string Configuration { get; set; } = string.Empty;
+    }
+
+    private static string? NormalizeNewlines(string? value)
+    {
+        if (value is null) return null;
+
+        // Be tolerant of clients that pass escaped newline sequences instead of actual line breaks.
+        return value
+            .Replace("\\r\\n", "\n")
+            .Replace("\\n", "\n")
+            .Replace("\\r", "\n");
     }
 
     [McpServerTool, Description("Delete a button from a folder.")]

--- a/MacroDeck.Mcp/Tools/VariableTools.cs
+++ b/MacroDeck.Mcp/Tools/VariableTools.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using MacroDeck.Mcp;
+using ModelContextProtocol.Server;
+
+/// <summary>MCP tools for managing MacroDeck variables.</summary>
+[McpServerToolType]
+public class VariableTools
+{
+    private readonly MacroDeckApiClient _api;
+    public VariableTools(MacroDeckApiClient api) => _api = api;
+
+    [McpServerTool, Description(
+        "List all MacroDeck variables. Variables can be referenced in button label templates using {variable_name} syntax. " +
+        "Returns name, current value, type (Integer/Float/String/Bool), and the creator plugin.")]
+    public async Task<string> ListVariables() =>
+        await _api.GetJsonAsync("api/variables");
+
+    [McpServerTool, Description("Get the current value and metadata of a single variable by name.")]
+    public async Task<string> GetVariable(
+        [Description("The exact variable name (case-insensitive).")] string name) =>
+        await _api.GetJsonAsync($"api/variables/{Uri.EscapeDataString(name)}");
+
+    [McpServerTool, Description(
+        "Create or update a MacroDeck variable. " +
+        "Variables can be used to drive button label templates and state bindings. " +
+        "Type must be one of: Integer, Float, String, Bool.")]
+    public async Task<string> SetVariable(
+        [Description("Variable name (letters, numbers, underscores).")] string name,
+        [Description("New value to set.")] string value,
+        [Description("Data type: Integer, Float, String, or Bool. Default is String.")] string type = "String",
+        [Description("Creator label (default 'User').")] string creator = "User") =>
+        await _api.PutJsonAsync("api/variables", new { name, value, type, creator });
+
+    [McpServerTool, Description("Delete a variable by name.")]
+    public async Task<string> DeleteVariable(
+        [Description("The variable name to delete.")] string name)
+    {
+        var ok = await _api.DeleteAsync($"api/variables/{Uri.EscapeDataString(name)}");
+        return ok ? "Variable deleted." : "Variable not found.";
+    }
+}

--- a/MacroDeck.Server/Controllers/Admin/ConfigController.cs
+++ b/MacroDeck.Server/Controllers/Admin/ConfigController.cs
@@ -1,0 +1,26 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MacroDeck.Server.Controllers.Admin;
+
+[ApiController]
+[Route("api/config")]
+public class ConfigController : ControllerBase
+{
+    private readonly IConfigAdminService _config;
+
+    public ConfigController(IConfigAdminService config)
+    {
+        _config = config;
+    }
+
+    [HttpGet]
+    public ActionResult<ConfigDto> GetConfig() =>
+        Ok(_config.GetConfig());
+
+    [HttpPatch]
+    public ActionResult<ConfigDto> UpdateConfig([FromBody] UpdateConfigRequest request) =>
+        Ok(_config.UpdateConfig(request));
+}

--- a/MacroDeck.Server/Controllers/Admin/DevicesController.cs
+++ b/MacroDeck.Server/Controllers/Admin/DevicesController.cs
@@ -1,0 +1,43 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MacroDeck.Server.Controllers.Admin;
+
+[ApiController]
+[Route("api/devices")]
+public class DevicesController : ControllerBase
+{
+    private readonly IDeviceAdminService _devices;
+
+    public DevicesController(IDeviceAdminService devices)
+    {
+        _devices = devices;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<DeviceDto>> GetDevices() =>
+        Ok(_devices.ListDevices());
+
+    [HttpGet("{clientId}")]
+    public ActionResult<DeviceDto> GetDevice(string clientId)
+    {
+        var device = _devices.GetDevice(clientId);
+        return device is null ? NotFound() : Ok(device);
+    }
+
+    [HttpPut("{clientId}/profile")]
+    public IActionResult AssignProfile(string clientId, [FromBody] AssignProfileRequest request)
+    {
+        return _devices.AssignProfile(clientId, request.ProfileId)
+            ? NoContent()
+            : NotFound("Device or profile not found.");
+    }
+
+    [HttpPut("{clientId}/blocked")]
+    public IActionResult SetBlocked(string clientId, [FromQuery] bool blocked)
+    {
+        return _devices.SetBlocked(clientId, blocked) ? NoContent() : NotFound();
+    }
+}

--- a/MacroDeck.Server/Controllers/Admin/IconsController.cs
+++ b/MacroDeck.Server/Controllers/Admin/IconsController.cs
@@ -1,0 +1,30 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MacroDeck.Server.Controllers.Admin;
+
+[ApiController]
+[Route("api/icons")]
+public class IconsController : ControllerBase
+{
+    private readonly IIconAdminService _icons;
+
+    public IconsController(IIconAdminService icons)
+    {
+        _icons = icons;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<IconPackDto>> GetIconPacks() =>
+        Ok(_icons.ListIconPacks());
+
+    [HttpGet("{iconPackName}")]
+    public ActionResult<IReadOnlyList<IconDto>> GetIcons(string iconPackName)
+    {
+        var icons = _icons.ListIcons(iconPackName);
+        return icons.Count == 0 && !_icons.ListIconPacks().Any(p => p.Name == iconPackName)
+            ? NotFound()
+            : Ok(icons);
+    }
+}

--- a/MacroDeck.Server/Controllers/Admin/PluginsController.cs
+++ b/MacroDeck.Server/Controllers/Admin/PluginsController.cs
@@ -1,0 +1,44 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MacroDeck.Server.Controllers.Admin;
+
+[ApiController]
+[Route("api/plugins")]
+public class PluginsController : ControllerBase
+{
+    private readonly IPluginAdminService _plugins;
+
+    public PluginsController(IPluginAdminService plugins)
+    {
+        _plugins = plugins;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<PluginDto>> GetPlugins() =>
+        Ok(_plugins.ListPlugins());
+
+    [HttpGet("{pluginName}")]
+    public ActionResult<PluginDto> GetPlugin(string pluginName)
+    {
+        var plugin = _plugins.GetPlugin(pluginName);
+        return plugin is null ? NotFound() : Ok(plugin);
+    }
+
+    [HttpGet("store/search")]
+    public async Task<ActionResult<string>> SearchStore([FromQuery] string q, [FromQuery] string type = "Plugin")
+    {
+        var results = await _plugins.SearchExtensionStoreAsync(q, type);
+        return Content(results, "application/json");
+    }
+
+    [HttpPost("store/install")]
+    public async Task<IActionResult> InstallPlugin([FromBody] InstallExtensionRequest request)
+    {
+        var success = await _plugins.InstallPluginAsync(request.PackageId);
+        return success ? Ok(new { message = "Plugin queued for install. Restart MacroDeck to apply." })
+                       : BadRequest(new { error = "Install failed. Check the package ID." });
+    }
+}

--- a/MacroDeck.Server/Controllers/Admin/ProfilesController.cs
+++ b/MacroDeck.Server/Controllers/Admin/ProfilesController.cs
@@ -1,0 +1,114 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MacroDeck.Server.Controllers.Admin;
+
+[ApiController]
+[Route("api/profiles")]
+public class ProfilesController : ControllerBase
+{
+    private readonly IProfileAdminService _profiles;
+
+    public ProfilesController(IProfileAdminService profiles)
+    {
+        _profiles = profiles;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<ProfileDto>> GetProfiles() =>
+        Ok(_profiles.ListProfiles());
+
+    [HttpGet("{profileId}")]
+    public ActionResult<ProfileDto> GetProfile(string profileId)
+    {
+        var profile = _profiles.GetProfile(profileId);
+        return profile is null ? NotFound() : Ok(profile);
+    }
+
+    [HttpPost]
+    public ActionResult<ProfileDto> CreateProfile([FromBody] CreateProfileRequest request)
+    {
+        var created = _profiles.CreateProfile(request);
+        return CreatedAtAction(nameof(GetProfile), new { profileId = created.ProfileId }, created);
+    }
+
+    [HttpDelete("{profileId}")]
+    public IActionResult DeleteProfile(string profileId)
+    {
+        return _profiles.DeleteProfile(profileId) ? NoContent() : NotFound();
+    }
+
+    // --- Folders ---
+
+    [HttpGet("{profileId}/folders")]
+    public ActionResult<IReadOnlyList<FolderDto>> GetFolders(string profileId)
+    {
+        if (_profiles.GetProfile(profileId) is null) return NotFound();
+        return Ok(_profiles.ListFolders(profileId));
+    }
+
+    [HttpGet("{profileId}/folders/{folderId}")]
+    public ActionResult<FolderDto> GetFolder(string profileId, string folderId)
+    {
+        var folder = _profiles.GetFolder(profileId, folderId);
+        return folder is null ? NotFound() : Ok(folder);
+    }
+
+    [HttpPost("{profileId}/folders")]
+    public ActionResult<FolderDto> CreateFolder(string profileId, [FromBody] CreateFolderRequest request)
+    {
+        if (_profiles.GetProfile(profileId) is null) return NotFound("Profile not found.");
+        var folder = _profiles.CreateFolder(profileId, request);
+        if (folder is null) return Conflict("A folder with that name already exists or parent was not found.");
+        return CreatedAtAction(nameof(GetFolder), new { profileId, folderId = folder.FolderId }, folder);
+    }
+
+    [HttpDelete("{profileId}/folders/{folderId}")]
+    public IActionResult DeleteFolder(string profileId, string folderId)
+    {
+        return _profiles.DeleteFolder(profileId, folderId) ? NoContent() : NotFound();
+    }
+
+    // --- Buttons ---
+
+    [HttpGet("{profileId}/folders/{folderId}/buttons")]
+    public ActionResult<IReadOnlyList<ButtonDto>> GetButtons(string profileId, string folderId)
+    {
+        if (_profiles.GetFolder(profileId, folderId) is null) return NotFound();
+        return Ok(_profiles.ListButtons(profileId, folderId));
+    }
+
+    [HttpGet("{profileId}/folders/{folderId}/buttons/{buttonGuid}")]
+    public ActionResult<ButtonDto> GetButton(string profileId, string folderId, string buttonGuid)
+    {
+        var button = _profiles.GetButton(profileId, folderId, buttonGuid);
+        return button is null ? NotFound() : Ok(button);
+    }
+
+    [HttpPost("{profileId}/folders/{folderId}/buttons")]
+    public ActionResult<ButtonDto> CreateButton(string profileId, string folderId,
+        [FromBody] CreateButtonRequest request)
+    {
+        if (_profiles.GetFolder(profileId, folderId) is null) return NotFound("Folder not found.");
+        var button = _profiles.CreateButton(profileId, folderId, request);
+        if (button is null) return Conflict("A button at that position already exists or action class was not found.");
+        return CreatedAtAction(nameof(GetButton),
+            new { profileId, folderId, buttonGuid = button.Guid }, button);
+    }
+
+    [HttpPut("{profileId}/folders/{folderId}/buttons/{buttonGuid}")]
+    public ActionResult<ButtonDto> UpdateButton(string profileId, string folderId, string buttonGuid,
+        [FromBody] CreateButtonRequest request)
+    {
+        var button = _profiles.UpdateButton(profileId, folderId, buttonGuid, request);
+        return button is null ? NotFound() : Ok(button);
+    }
+
+    [HttpDelete("{profileId}/folders/{folderId}/buttons/{buttonGuid}")]
+    public IActionResult DeleteButton(string profileId, string folderId, string buttonGuid)
+    {
+        return _profiles.DeleteButton(profileId, folderId, buttonGuid) ? NoContent() : NotFound();
+    }
+}

--- a/MacroDeck.Server/Controllers/Admin/VariablesController.cs
+++ b/MacroDeck.Server/Controllers/Admin/VariablesController.cs
@@ -1,0 +1,39 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MacroDeck.Server.Controllers.Admin;
+
+[ApiController]
+[Route("api/variables")]
+public class VariablesController : ControllerBase
+{
+    private readonly IVariableAdminService _variables;
+
+    public VariablesController(IVariableAdminService variables)
+    {
+        _variables = variables;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyList<VariableDto>> GetVariables() =>
+        Ok(_variables.ListVariables());
+
+    [HttpGet("{name}")]
+    public ActionResult<VariableDto> GetVariable(string name)
+    {
+        var variable = _variables.GetVariable(name);
+        return variable is null ? NotFound() : Ok(variable);
+    }
+
+    [HttpPut]
+    public ActionResult<VariableDto> UpsertVariable([FromBody] UpsertVariableRequest request) =>
+        Ok(_variables.UpsertVariable(request));
+
+    [HttpDelete("{name}")]
+    public IActionResult DeleteVariable(string name)
+    {
+        return _variables.DeleteVariable(name) ? NoContent() : NotFound();
+    }
+}

--- a/MacroDeck.Server/Dto/ButtonDto.cs
+++ b/MacroDeck.Server/Dto/ButtonDto.cs
@@ -21,4 +21,13 @@ public class ButtonDto
     public string? LabelOffText { get; set; }
     public string? LabelOnText { get; set; }
     public string? StateBindingVariable { get; set; }
+    public string? IconPack { get; set; }
+    public string? IconName { get; set; }
+    public string? IconNameOn { get; set; }
+    public string? IconOff { get; set; }
+    public string? IconOn { get; set; }
+    public string? BackgroundColorOff { get; set; }
+    public string? BackgroundColorOn { get; set; }
+    public string? LabelColorOff { get; set; }
+    public string? LabelColorOn { get; set; }
 }

--- a/MacroDeck.Server/Dto/ButtonDto.cs
+++ b/MacroDeck.Server/Dto/ButtonDto.cs
@@ -1,0 +1,24 @@
+namespace MacroDeck.Server.Dto;
+
+public class ActionDto
+{
+    public string PluginName { get; set; } = string.Empty;
+    public string ActionClass { get; set; } = string.Empty;
+    public string Configuration { get; set; } = string.Empty;
+    public string ConfigurationSummary { get; set; } = string.Empty;
+}
+
+public class ButtonDto
+{
+    public string Guid { get; set; } = string.Empty;
+    public int PositionX { get; set; }
+    public int PositionY { get; set; }
+    public bool State { get; set; }
+    public List<ActionDto> Actions { get; set; } = new();
+    public List<ActionDto> ActionsRelease { get; set; } = new();
+    public List<ActionDto> ActionsLongPress { get; set; } = new();
+    public List<ActionDto> ActionsLongPressRelease { get; set; } = new();
+    public string? LabelOffText { get; set; }
+    public string? LabelOnText { get; set; }
+    public string? StateBindingVariable { get; set; }
+}

--- a/MacroDeck.Server/Dto/ConfigDto.cs
+++ b/MacroDeck.Server/Dto/ConfigDto.cs
@@ -1,0 +1,17 @@
+namespace MacroDeck.Server.Dto;
+
+public class ConfigDto
+{
+    public bool AutoStart { get; set; }
+    public bool AutoUpdates { get; set; }
+    public bool UpdateBetaVersions { get; set; }
+    public bool EnableAdbServer { get; set; }
+    public bool EnableAdbAutoStartApp { get; set; }
+    public bool EnableSsl { get; set; }
+    public string? SslCertificatePath { get; set; }
+    public string HostAddress { get; set; } = string.Empty;
+    public int HostPort { get; set; }
+    public bool AskOnNewConnections { get; set; }
+    public bool BlockNewConnections { get; set; }
+    public string Language { get; set; } = string.Empty;
+}

--- a/MacroDeck.Server/Dto/DeviceDto.cs
+++ b/MacroDeck.Server/Dto/DeviceDto.cs
@@ -1,0 +1,19 @@
+namespace MacroDeck.Server.Dto;
+
+public class DeviceConfigDto
+{
+    public float Brightness { get; set; }
+    public bool AutoConnect { get; set; }
+    public string WakeLockMethod { get; set; } = string.Empty;
+}
+
+public class DeviceDto
+{
+    public string ClientId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string ProfileId { get; set; } = string.Empty;
+    public string DeviceType { get; set; } = string.Empty;
+    public bool Blocked { get; set; }
+    public bool Available { get; set; }
+    public DeviceConfigDto? Configuration { get; set; }
+}

--- a/MacroDeck.Server/Dto/FolderDto.cs
+++ b/MacroDeck.Server/Dto/FolderDto.cs
@@ -1,0 +1,11 @@
+namespace MacroDeck.Server.Dto;
+
+public class FolderDto
+{
+    public string FolderId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public bool IsRootFolder { get; set; }
+    public List<string> ChildFolderIds { get; set; } = new();
+    public int ButtonCount { get; set; }
+    public string ApplicationToTrigger { get; set; } = string.Empty;
+}

--- a/MacroDeck.Server/Dto/IconDto.cs
+++ b/MacroDeck.Server/Dto/IconDto.cs
@@ -1,0 +1,18 @@
+namespace MacroDeck.Server.Dto;
+
+public class IconPackDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string PackageId { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public int IconCount { get; set; }
+}
+
+public class IconDto
+{
+    public string IconId { get; set; } = string.Empty;
+    public string IconPackName { get; set; } = string.Empty;
+    /// <summary>Convenience combined string usable directly in update_button iconOff/iconOn fields.</summary>
+    public string IconString { get; set; } = string.Empty;
+}

--- a/MacroDeck.Server/Dto/PluginDto.cs
+++ b/MacroDeck.Server/Dto/PluginDto.cs
@@ -1,0 +1,19 @@
+namespace MacroDeck.Server.Dto;
+
+public class PluginActionInfoDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public bool CanConfigure { get; set; }
+    public string ActionClass { get; set; } = string.Empty;
+}
+
+public class PluginDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public bool CanConfigure { get; set; }
+    public bool IsProtected { get; set; }
+    public List<PluginActionInfoDto> Actions { get; set; } = new();
+}

--- a/MacroDeck.Server/Dto/ProfileDto.cs
+++ b/MacroDeck.Server/Dto/ProfileDto.cs
@@ -1,0 +1,14 @@
+namespace MacroDeck.Server.Dto;
+
+public class ProfileDto
+{
+    public string ProfileId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public int Rows { get; set; }
+    public int Columns { get; set; }
+    public int ButtonSpacing { get; set; }
+    public int ButtonRadius { get; set; }
+    public bool ButtonBackground { get; set; }
+    public string ProfileTarget { get; set; } = string.Empty;
+    public int FolderCount { get; set; }
+}

--- a/MacroDeck.Server/Dto/Requests/AdminRequests.cs
+++ b/MacroDeck.Server/Dto/Requests/AdminRequests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MacroDeck.Server.Dto.Requests;
+
+public class CreateProfileRequest
+{
+    [Required, MinLength(1)]
+    public string DisplayName { get; set; } = string.Empty;
+    public int Rows { get; set; } = 3;
+    public int Columns { get; set; } = 5;
+    public int ButtonSpacing { get; set; } = 10;
+    public int ButtonRadius { get; set; } = 40;
+    public bool ButtonBackground { get; set; } = true;
+    /// <summary>SoftwareClient or Macro_Deck_DIY_OLED_6_V1</summary>
+    public string ProfileTarget { get; set; } = "SoftwareClient";
+}
+
+public class CreateFolderRequest
+{
+    [Required, MinLength(1)]
+    public string DisplayName { get; set; } = string.Empty;
+    /// <summary>Parent folder ID. Omit or null to add under root folder.</summary>
+    public string? ParentFolderId { get; set; }
+    public string ApplicationToTrigger { get; set; } = string.Empty;
+}
+
+public class CreateButtonRequest
+{
+    public int PositionX { get; set; }
+    public int PositionY { get; set; }
+    /// <summary>Actions to execute on short press. Each item references PluginName + ActionClass + optional Configuration JSON.</summary>
+    public List<ActionAssignmentRequest> Actions { get; set; } = new();
+    public List<ActionAssignmentRequest> ActionsRelease { get; set; } = new();
+    public List<ActionAssignmentRequest> ActionsLongPress { get; set; } = new();
+    public List<ActionAssignmentRequest> ActionsLongPressRelease { get; set; } = new();
+    public string? LabelOffText { get; set; }
+    public string? LabelOnText { get; set; }
+    public string? StateBindingVariable { get; set; }
+}
+
+public class ActionAssignmentRequest
+{
+    [Required]
+    public string PluginName { get; set; } = string.Empty;
+    [Required]
+    public string ActionClass { get; set; } = string.Empty;
+    /// <summary>Plugin-specific configuration as a JSON string.</summary>
+    public string Configuration { get; set; } = string.Empty;
+}
+
+public class UpsertVariableRequest
+{
+    [Required, MinLength(1)]
+    public string Name { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    /// <summary>Integer, Float, String, or Bool</summary>
+    public string Type { get; set; } = "String";
+    public string Creator { get; set; } = "User";
+}
+
+public class UpdateConfigRequest
+{
+    public bool? AutoStart { get; set; }
+    public bool? AutoUpdates { get; set; }
+    public bool? UpdateBetaVersions { get; set; }
+    public bool? EnableAdbServer { get; set; }
+    public bool? EnableAdbAutoStartApp { get; set; }
+    public bool? AskOnNewConnections { get; set; }
+    public bool? BlockNewConnections { get; set; }
+    public string? Language { get; set; }
+}
+
+public class AssignProfileRequest
+{
+    [Required]
+    public string ProfileId { get; set; } = string.Empty;
+}
+
+public class InstallExtensionRequest
+{
+    [Required]
+    public string PackageId { get; set; } = string.Empty;
+}

--- a/MacroDeck.Server/Dto/Requests/AdminRequests.cs
+++ b/MacroDeck.Server/Dto/Requests/AdminRequests.cs
@@ -36,11 +36,19 @@ public class CreateButtonRequest
     public string? LabelOffText { get; set; }
     public string? LabelOnText { get; set; }
     public string? StateBindingVariable { get; set; }
+    public string? IconPack { get; set; }
+    public string? IconName { get; set; }
+    public string? IconNameOn { get; set; }
+    public string? IconOff { get; set; }
+    public string? IconOn { get; set; }
+    public string? BackgroundColorOff { get; set; }
+    public string? BackgroundColorOn { get; set; }
+    public string? LabelColorOff { get; set; }
+    public string? LabelColorOn { get; set; }
 }
 
 public class ActionAssignmentRequest
 {
-    [Required]
     public string PluginName { get; set; } = string.Empty;
     [Required]
     public string ActionClass { get; set; } = string.Empty;

--- a/MacroDeck.Server/Dto/VariableDto.cs
+++ b/MacroDeck.Server/Dto/VariableDto.cs
@@ -1,0 +1,9 @@
+namespace MacroDeck.Server.Dto;
+
+public class VariableDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Creator { get; set; } = string.Empty;
+}

--- a/MacroDeck.Server/MacroDeckServerHelper.cs
+++ b/MacroDeck.Server/MacroDeckServerHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -11,7 +12,12 @@ public static class MacroDeckServerHelper
     
     internal static bool UseHttps { get; private set; }
     
-    public static async Task Setup(int port, bool enableSsl, string? certificatePath, string? certificatePassword)
+    public static async Task Setup(
+        int port,
+        bool enableSsl,
+        string? certificatePath,
+        string? certificatePassword,
+        Action<IServiceCollection>? configureAdminServices = null)
     {
         if (_host is not null)
         {
@@ -38,7 +44,12 @@ public static class MacroDeckServerHelper
                         options.ListenAnyIP(port);
                     }
                 });
-            }).Build();
+            })
+            .ConfigureServices(services =>
+            {
+                configureAdminServices?.Invoke(services);
+            })
+            .Build();
 
         await _host.RunAsync();
     }

--- a/MacroDeck.Server/Middleware/AdminApiKeyMiddleware.cs
+++ b/MacroDeck.Server/Middleware/AdminApiKeyMiddleware.cs
@@ -1,0 +1,34 @@
+using MacroDeck.Server.Services;
+using Microsoft.AspNetCore.Http;
+
+namespace MacroDeck.Server.Middleware;
+
+/// <summary>
+/// Enforces X-MacroDeck-Admin-Key header on all /api/* requests.
+/// </summary>
+public class AdminApiKeyMiddleware
+{
+    private const string ApiKeyHeader = "X-MacroDeck-Admin-Key";
+    private readonly RequestDelegate _next;
+
+    public AdminApiKeyMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, IConfigAdminService config)
+    {
+        if (context.Request.Path.StartsWithSegments("/api"))
+        {
+            if (!context.Request.Headers.TryGetValue(ApiKeyHeader, out var providedKey)
+                || !string.Equals(providedKey, config.GetAdminApiKey(), StringComparison.Ordinal))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsJsonAsync(new { error = "Invalid or missing admin API key." });
+                return;
+            }
+        }
+
+        await _next(context);
+    }
+}

--- a/MacroDeck.Server/Services/IConfigAdminService.cs
+++ b/MacroDeck.Server/Services/IConfigAdminService.cs
@@ -1,0 +1,11 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+
+namespace MacroDeck.Server.Services;
+
+public interface IConfigAdminService
+{
+    ConfigDto GetConfig();
+    ConfigDto UpdateConfig(UpdateConfigRequest request);
+    string GetAdminApiKey();
+}

--- a/MacroDeck.Server/Services/IDeviceAdminService.cs
+++ b/MacroDeck.Server/Services/IDeviceAdminService.cs
@@ -1,0 +1,12 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+
+namespace MacroDeck.Server.Services;
+
+public interface IDeviceAdminService
+{
+    IReadOnlyList<DeviceDto> ListDevices();
+    DeviceDto? GetDevice(string clientId);
+    bool AssignProfile(string clientId, string profileId);
+    bool SetBlocked(string clientId, bool blocked);
+}

--- a/MacroDeck.Server/Services/IIconAdminService.cs
+++ b/MacroDeck.Server/Services/IIconAdminService.cs
@@ -1,0 +1,9 @@
+using MacroDeck.Server.Dto;
+
+namespace MacroDeck.Server.Services;
+
+public interface IIconAdminService
+{
+    IReadOnlyList<IconPackDto> ListIconPacks();
+    IReadOnlyList<IconDto> ListIcons(string iconPackName);
+}

--- a/MacroDeck.Server/Services/IPluginAdminService.cs
+++ b/MacroDeck.Server/Services/IPluginAdminService.cs
@@ -1,0 +1,15 @@
+using MacroDeck.Server.Dto;
+
+namespace MacroDeck.Server.Services;
+
+public interface IPluginAdminService
+{
+    IReadOnlyList<PluginDto> ListPlugins();
+    PluginDto? GetPlugin(string pluginName);
+
+    /// <summary>Installs a plugin package from the Extension Store by packageId.</summary>
+    Task<bool> InstallPluginAsync(string packageId);
+
+    /// <summary>Searches the Extension Store. Returns JSON string list of results.</summary>
+    Task<string> SearchExtensionStoreAsync(string query, string type = "Plugin");
+}

--- a/MacroDeck.Server/Services/IProfileAdminService.cs
+++ b/MacroDeck.Server/Services/IProfileAdminService.cs
@@ -1,0 +1,23 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+
+namespace MacroDeck.Server.Services;
+
+public interface IProfileAdminService
+{
+    IReadOnlyList<ProfileDto> ListProfiles();
+    ProfileDto? GetProfile(string profileId);
+    ProfileDto CreateProfile(CreateProfileRequest request);
+    bool DeleteProfile(string profileId);
+
+    IReadOnlyList<FolderDto> ListFolders(string profileId);
+    FolderDto? GetFolder(string profileId, string folderId);
+    FolderDto? CreateFolder(string profileId, CreateFolderRequest request);
+    bool DeleteFolder(string profileId, string folderId);
+
+    IReadOnlyList<ButtonDto> ListButtons(string profileId, string folderId);
+    ButtonDto? GetButton(string profileId, string folderId, string buttonGuid);
+    ButtonDto? CreateButton(string profileId, string folderId, CreateButtonRequest request);
+    ButtonDto? UpdateButton(string profileId, string folderId, string buttonGuid, CreateButtonRequest request);
+    bool DeleteButton(string profileId, string folderId, string buttonGuid);
+}

--- a/MacroDeck.Server/Services/IVariableAdminService.cs
+++ b/MacroDeck.Server/Services/IVariableAdminService.cs
@@ -1,0 +1,12 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+
+namespace MacroDeck.Server.Services;
+
+public interface IVariableAdminService
+{
+    IReadOnlyList<VariableDto> ListVariables();
+    VariableDto? GetVariable(string name);
+    VariableDto UpsertVariable(UpsertVariableRequest request);
+    bool DeleteVariable(string name);
+}

--- a/MacroDeck.Server/Startup.cs
+++ b/MacroDeck.Server/Startup.cs
@@ -1,4 +1,5 @@
-﻿using MacroDeck.Server.StartupConfig;
+﻿using MacroDeck.Server.Middleware;
+using MacroDeck.Server.StartupConfig;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,7 @@ public class Startup
         {
             KeepAliveInterval = TimeSpan.FromMinutes(2)
         });
+        app.UseMiddleware<AdminApiKeyMiddleware>();
         app.UseRouting();
         app.UseEndpoints(endpoints =>
         {

--- a/MacroDeck.sln
+++ b/MacroDeck.sln
@@ -24,6 +24,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MacroDeck.Setup", "MacroDec
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MacroDeck.Server", "MacroDeck.Server\MacroDeck.Server.csproj", "{FE95B83C-1BB5-45C2-8F91-A3CD1B8B6D97}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MacroDeck.Mcp", "MacroDeck.Mcp\MacroDeck.Mcp.csproj", "{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MacroDeck.Cli", "MacroDeck.Cli\MacroDeck.Cli.csproj", "{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{4B7E0868-7875-41AA-8670-479175ADBEAC}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
@@ -62,6 +66,22 @@ Global
 		{FE95B83C-1BB5-45C2-8F91-A3CD1B8B6D97}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FE95B83C-1BB5-45C2-8F91-A3CD1B8B6D97}.Release|x64.ActiveCfg = Release|Any CPU
 		{FE95B83C-1BB5-45C2-8F91-A3CD1B8B6D97}.Release|x64.Build.0 = Release|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1F5E6A3-8B2D-4F8E-A1C9-5D8E9B3C4F5A}.Release|x64.Build.0 = Release|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Debug|x64.Build.0 = Debug|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{D2G6F7B4-9C3E-5G9F-B2D0-6E9F0C4D5G6B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MacroDeck/ActionButton/ActionButton.cs
+++ b/MacroDeck/ActionButton/ActionButton.cs
@@ -133,7 +133,8 @@ public class ActionButton : IDisposable
         set
         {
             _iconOff = value;
-            IconChanged?.Invoke(this, EventArgs.Empty);
+                MacroDeckServer.UpdateState(this);
+                IconChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -143,7 +144,8 @@ public class ActionButton : IDisposable
         set
         {
             _iconOn = value;
-            IconChanged?.Invoke(this, EventArgs.Empty);
+                MacroDeckServer.UpdateState(this);
+                IconChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 

--- a/MacroDeck/Configuration/MainConfiguration.cs
+++ b/MacroDeck/Configuration/MainConfiguration.cs
@@ -70,6 +70,9 @@ public class MainConfiguration
     [JsonProperty("Language")]
     public string Language { get; set; } = "English";
 
+    [JsonProperty("AdminApiKey")]
+    public string AdminApiKey { get; set; } = Guid.NewGuid().ToString("N");
+
     public void Save(string path)
     {
         var serializer = new JsonSerializer

--- a/MacroDeck/GUI/MainWindowViews/SettingsView.Designer.cs
+++ b/MacroDeck/GUI/MainWindowViews/SettingsView.Designer.cs
@@ -80,10 +80,13 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             btnCopyApiKey = new ButtonPrimary();
             btnRegenerateApiKey = new ButtonPrimary();
             lblMcpSection = new Label();
-            lblMcpDesc = new Label();
+            lblMcpIntro = new Label();
+            lblMcpDesc = new TextBox();
+            lblMcpFooter = new Label();
             btnOpenMcpDocs = new ButtonPrimary();
             lblCliSection = new Label();
-            lblCliDesc = new Label();
+            lblCliIntro = new Label();
+            lblCliDesc = new TextBox();
             btnOpenCliDocs = new ButtonPrimary();
             tabAbout = new TabPage();
             btnGitHub = new PictureButton();
@@ -635,9 +638,12 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             tabApiAccess.BackColor = Color.FromArgb(45, 45, 45);
             tabApiAccess.Controls.Add(btnOpenCliDocs);
             tabApiAccess.Controls.Add(lblCliDesc);
+            tabApiAccess.Controls.Add(lblCliIntro);
             tabApiAccess.Controls.Add(lblCliSection);
             tabApiAccess.Controls.Add(btnOpenMcpDocs);
+            tabApiAccess.Controls.Add(lblMcpFooter);
             tabApiAccess.Controls.Add(lblMcpDesc);
+            tabApiAccess.Controls.Add(lblMcpIntro);
             tabApiAccess.Controls.Add(lblMcpSection);
             tabApiAccess.Controls.Add(btnRegenerateApiKey);
             tabApiAccess.Controls.Add(btnCopyApiKey);
@@ -744,7 +750,7 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             btnRegenerateApiKey.Name = "btnRegenerateApiKey";
             btnRegenerateApiKey.Progress = 0;
             btnRegenerateApiKey.ProgressColor = Color.FromArgb(0, 46, 94);
-            btnRegenerateApiKey.Size = new Size(150, 30);
+            btnRegenerateApiKey.Size = new Size(165, 30);
             btnRegenerateApiKey.TabIndex = 5;
             btnRegenerateApiKey.Text = "Regenerate";
             btnRegenerateApiKey.UseMnemonic = false;
@@ -764,15 +770,41 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             lblMcpSection.Text = "MCP Server";
             lblMcpSection.UseMnemonic = false;
             // 
+            // lblMcpIntro
+            // 
+            lblMcpIntro.Font = new Font("Tahoma", 10.5F);
+            lblMcpIntro.ForeColor = Color.Gray;
+            lblMcpIntro.Location = new Point(5, 172);
+            lblMcpIntro.Name = "lblMcpIntro";
+            lblMcpIntro.Size = new Size(800, 36);
+            lblMcpIntro.TabIndex = 7;
+            lblMcpIntro.UseMnemonic = false;
+            // 
             // lblMcpDesc
             // 
+            lblMcpDesc.BackColor = Color.FromArgb(58, 58, 58);
+            lblMcpDesc.BorderStyle = BorderStyle.FixedSingle;
+            lblMcpDesc.Cursor = Cursors.IBeam;
             lblMcpDesc.Font = new Font("Tahoma", 10.5F);
-            lblMcpDesc.ForeColor = Color.Gray;
-            lblMcpDesc.Location = new Point(5, 172);
+            lblMcpDesc.ForeColor = Color.WhiteSmoke;
+            lblMcpDesc.Location = new Point(5, 212);
+            lblMcpDesc.Multiline = true;
             lblMcpDesc.Name = "lblMcpDesc";
-            lblMcpDesc.Size = new Size(900, 100);
-            lblMcpDesc.TabIndex = 7;
-            lblMcpDesc.UseMnemonic = false;
+            lblMcpDesc.ReadOnly = true;
+            lblMcpDesc.ScrollBars = ScrollBars.None;
+            lblMcpDesc.Size = new Size(800, 40);
+            lblMcpDesc.TabIndex = 8;
+            lblMcpDesc.TabStop = true;
+            // 
+            // lblMcpFooter
+            // 
+            lblMcpFooter.Font = new Font("Tahoma", 10.5F);
+            lblMcpFooter.ForeColor = Color.Gray;
+            lblMcpFooter.Location = new Point(5, 262);
+            lblMcpFooter.Name = "lblMcpFooter";
+            lblMcpFooter.Size = new Size(800, 18);
+            lblMcpFooter.TabIndex = 9;
+            lblMcpFooter.UseMnemonic = false;
             // 
             // btnOpenMcpDocs
             // 
@@ -784,12 +816,12 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             btnOpenMcpDocs.ForeColor = Color.White;
             btnOpenMcpDocs.HoverColor = Color.FromArgb(0, 89, 184);
             btnOpenMcpDocs.Icon = null;
-            btnOpenMcpDocs.Location = new Point(5, 280);
+            btnOpenMcpDocs.Location = new Point(5, 285);
             btnOpenMcpDocs.Name = "btnOpenMcpDocs";
             btnOpenMcpDocs.Progress = 0;
             btnOpenMcpDocs.ProgressColor = Color.FromArgb(0, 46, 94);
             btnOpenMcpDocs.Size = new Size(180, 30);
-            btnOpenMcpDocs.TabIndex = 8;
+            btnOpenMcpDocs.TabIndex = 10;
             btnOpenMcpDocs.Text = "Open MCP docs";
             btnOpenMcpDocs.UseMnemonic = false;
             btnOpenMcpDocs.UseVisualStyleBackColor = false;
@@ -802,21 +834,37 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             lblCliSection.AutoSize = true;
             lblCliSection.Font = new Font("Tahoma", 14.25F);
             lblCliSection.ForeColor = Color.Gray;
-            lblCliSection.Location = new Point(3, 330);
+            lblCliSection.Location = new Point(3, 323);
             lblCliSection.Name = "lblCliSection";
-            lblCliSection.TabIndex = 9;
+            lblCliSection.TabIndex = 11;
             lblCliSection.Text = "CLI Tool";
             lblCliSection.UseMnemonic = false;
             // 
+            // lblCliIntro
+            // 
+            lblCliIntro.Font = new Font("Tahoma", 10.5F);
+            lblCliIntro.ForeColor = Color.Gray;
+            lblCliIntro.Location = new Point(5, 350);
+            lblCliIntro.Name = "lblCliIntro";
+            lblCliIntro.Size = new Size(800, 20);
+            lblCliIntro.TabIndex = 12;
+            lblCliIntro.UseMnemonic = false;
+            // 
             // lblCliDesc
             // 
+            lblCliDesc.BackColor = Color.FromArgb(58, 58, 58);
+            lblCliDesc.BorderStyle = BorderStyle.FixedSingle;
+            lblCliDesc.Cursor = Cursors.IBeam;
             lblCliDesc.Font = new Font("Tahoma", 10.5F);
-            lblCliDesc.ForeColor = Color.Gray;
-            lblCliDesc.Location = new Point(5, 357);
+            lblCliDesc.ForeColor = Color.WhiteSmoke;
+            lblCliDesc.Location = new Point(5, 374);
+            lblCliDesc.Multiline = true;
             lblCliDesc.Name = "lblCliDesc";
-            lblCliDesc.Size = new Size(900, 80);
-            lblCliDesc.TabIndex = 10;
-            lblCliDesc.UseMnemonic = false;
+            lblCliDesc.ReadOnly = true;
+            lblCliDesc.ScrollBars = ScrollBars.None;
+            lblCliDesc.Size = new Size(800, 24);
+            lblCliDesc.TabIndex = 13;
+            lblCliDesc.TabStop = true;
             // 
             // btnOpenCliDocs
             // 
@@ -828,12 +876,12 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             btnOpenCliDocs.ForeColor = Color.White;
             btnOpenCliDocs.HoverColor = Color.FromArgb(0, 89, 184);
             btnOpenCliDocs.Icon = null;
-            btnOpenCliDocs.Location = new Point(5, 445);
+            btnOpenCliDocs.Location = new Point(5, 414);
             btnOpenCliDocs.Name = "btnOpenCliDocs";
             btnOpenCliDocs.Progress = 0;
             btnOpenCliDocs.ProgressColor = Color.FromArgb(0, 46, 94);
             btnOpenCliDocs.Size = new Size(180, 30);
-            btnOpenCliDocs.TabIndex = 11;
+            btnOpenCliDocs.TabIndex = 14;
             btnOpenCliDocs.Text = "Open CLI docs";
             btnOpenCliDocs.UseMnemonic = false;
             btnOpenCliDocs.UseVisualStyleBackColor = false;
@@ -1101,10 +1149,13 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
         private ButtonPrimary btnCopyApiKey;
         private ButtonPrimary btnRegenerateApiKey;
         private Label lblMcpSection;
-        private Label lblMcpDesc;
+        private Label lblMcpIntro;
+        private TextBox lblMcpDesc;
+        private Label lblMcpFooter;
         private ButtonPrimary btnOpenMcpDocs;
         private Label lblCliSection;
-        private Label lblCliDesc;
+        private Label lblCliIntro;
+        private TextBox lblCliDesc;
         private ButtonPrimary btnOpenCliDocs;
         private FlowLayoutPanel backupsPanel;
         private ButtonPrimary btnCreateBackup;

--- a/MacroDeck/GUI/MainWindowViews/SettingsView.Designer.cs
+++ b/MacroDeck/GUI/MainWindowViews/SettingsView.Designer.cs
@@ -72,6 +72,19 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             btnCreateBackup = new ButtonPrimary();
             backupsPanel = new FlowLayoutPanel();
             lblBackups = new Label();
+            tabApiAccess = new TabPage();
+            lblApiAccess = new Label();
+            lblApiKeySection = new Label();
+            lblApiKeyDesc = new Label();
+            txtAdminKey = new RoundedTextBox();
+            btnCopyApiKey = new ButtonPrimary();
+            btnRegenerateApiKey = new ButtonPrimary();
+            lblMcpSection = new Label();
+            lblMcpDesc = new Label();
+            btnOpenMcpDocs = new ButtonPrimary();
+            lblCliSection = new Label();
+            lblCliDesc = new Label();
+            btnOpenCliDocs = new ButtonPrimary();
             tabAbout = new TabPage();
             btnGitHub = new PictureButton();
             label1 = new Label();
@@ -93,6 +106,7 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             ((ISupportInitialize)port).BeginInit();
             tabUpdater.SuspendLayout();
             tabBackups.SuspendLayout();
+            tabApiAccess.SuspendLayout();
             tabAbout.SuspendLayout();
             ((ISupportInitialize)btnGitHub).BeginInit();
             ((ISupportInitialize)pictureBox1).BeginInit();
@@ -106,6 +120,7 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             verticalTabControl.Controls.Add(tabConnection);
             verticalTabControl.Controls.Add(tabUpdater);
             verticalTabControl.Controls.Add(tabBackups);
+            verticalTabControl.Controls.Add(tabApiAccess);
             verticalTabControl.Controls.Add(tabAbout);
             verticalTabControl.Font = new Font("Tahoma", 12F);
             verticalTabControl.ImageList = tabIcons;
@@ -615,6 +630,217 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             lblBackups.Text = "Backups";
             lblBackups.UseMnemonic = false;
             // 
+            // tabApiAccess
+            // 
+            tabApiAccess.BackColor = Color.FromArgb(45, 45, 45);
+            tabApiAccess.Controls.Add(btnOpenCliDocs);
+            tabApiAccess.Controls.Add(lblCliDesc);
+            tabApiAccess.Controls.Add(lblCliSection);
+            tabApiAccess.Controls.Add(btnOpenMcpDocs);
+            tabApiAccess.Controls.Add(lblMcpDesc);
+            tabApiAccess.Controls.Add(lblMcpSection);
+            tabApiAccess.Controls.Add(btnRegenerateApiKey);
+            tabApiAccess.Controls.Add(btnCopyApiKey);
+            tabApiAccess.Controls.Add(txtAdminKey);
+            tabApiAccess.Controls.Add(lblApiKeyDesc);
+            tabApiAccess.Controls.Add(lblApiKeySection);
+            tabApiAccess.Controls.Add(lblApiAccess);
+            tabApiAccess.Font = new Font("Tahoma", 12F);
+            tabApiAccess.ForeColor = Color.White;
+            tabApiAccess.Location = new Point(204, 4);
+            tabApiAccess.Name = "tabApiAccess";
+            tabApiAccess.Padding = new Padding(3);
+            tabApiAccess.Size = new Size(923, 526);
+            tabApiAccess.TabIndex = 5;
+            tabApiAccess.Text = "API Access";
+            // 
+            // lblApiAccess
+            // 
+            lblApiAccess.AutoSize = true;
+            lblApiAccess.Font = new Font("Tahoma", 15.75F);
+            lblApiAccess.Location = new Point(3, 0);
+            lblApiAccess.Name = "lblApiAccess";
+            lblApiAccess.Size = new Size(115, 25);
+            lblApiAccess.TabIndex = 0;
+            lblApiAccess.Text = "API Access";
+            lblApiAccess.UseMnemonic = false;
+            // 
+            // lblApiKeySection
+            // 
+            lblApiKeySection.AutoSize = true;
+            lblApiKeySection.Font = new Font("Tahoma", 14.25F);
+            lblApiKeySection.ForeColor = Color.Gray;
+            lblApiKeySection.Location = new Point(3, 40);
+            lblApiKeySection.Name = "lblApiKeySection";
+            lblApiKeySection.TabIndex = 1;
+            lblApiKeySection.Text = "Admin API Key";
+            lblApiKeySection.UseMnemonic = false;
+            // 
+            // lblApiKeyDesc
+            // 
+            lblApiKeyDesc.AutoSize = true;
+            lblApiKeyDesc.Font = new Font("Tahoma", 10.5F);
+            lblApiKeyDesc.ForeColor = Color.Gray;
+            lblApiKeyDesc.Location = new Point(5, 67);
+            lblApiKeyDesc.Name = "lblApiKeyDesc";
+            lblApiKeyDesc.TabIndex = 2;
+            lblApiKeyDesc.Text = "This key authenticates the CLI tool and MCP server. Keep it private.";
+            lblApiKeyDesc.UseMnemonic = false;
+            // 
+            // txtAdminKey
+            // 
+            txtAdminKey.BackColor = Color.FromArgb(65, 65, 65);
+            txtAdminKey.Font = new Font("Tahoma", 12F);
+            txtAdminKey.Icon = null;
+            txtAdminKey.Location = new Point(5, 93);
+            txtAdminKey.MaxCharacters = 32767;
+            txtAdminKey.Multiline = false;
+            txtAdminKey.Name = "txtAdminKey";
+            txtAdminKey.Padding = new Padding(8, 5, 8, 5);
+            txtAdminKey.PasswordChar = false;
+            txtAdminKey.PlaceHolderColor = Color.Gray;
+            txtAdminKey.PlaceHolderText = "";
+            txtAdminKey.ReadOnly = true;
+            txtAdminKey.ScrollBars = ScrollBars.None;
+            txtAdminKey.SelectionStart = 0;
+            txtAdminKey.Size = new Size(530, 30);
+            txtAdminKey.TabIndex = 3;
+            txtAdminKey.TextAlignment = HorizontalAlignment.Left;
+            // 
+            // btnCopyApiKey
+            // 
+            btnCopyApiKey.BorderRadius = 8;
+            btnCopyApiKey.Cursor = Cursors.Hand;
+            btnCopyApiKey.FlatAppearance.BorderSize = 0;
+            btnCopyApiKey.FlatStyle = FlatStyle.Flat;
+            btnCopyApiKey.Font = new Font("Tahoma", 9.75F);
+            btnCopyApiKey.ForeColor = Color.White;
+            btnCopyApiKey.HoverColor = Color.FromArgb(0, 89, 184);
+            btnCopyApiKey.Icon = null;
+            btnCopyApiKey.Location = new Point(543, 93);
+            btnCopyApiKey.Name = "btnCopyApiKey";
+            btnCopyApiKey.Progress = 0;
+            btnCopyApiKey.ProgressColor = Color.FromArgb(0, 46, 94);
+            btnCopyApiKey.Size = new Size(90, 30);
+            btnCopyApiKey.TabIndex = 4;
+            btnCopyApiKey.Text = "Copy";
+            btnCopyApiKey.UseMnemonic = false;
+            btnCopyApiKey.UseVisualStyleBackColor = false;
+            btnCopyApiKey.UseWindowsAccentColor = true;
+            btnCopyApiKey.WriteProgress = true;
+            btnCopyApiKey.Click += BtnCopyApiKey_Click;
+            // 
+            // btnRegenerateApiKey
+            // 
+            btnRegenerateApiKey.BorderRadius = 8;
+            btnRegenerateApiKey.Cursor = Cursors.Hand;
+            btnRegenerateApiKey.FlatAppearance.BorderSize = 0;
+            btnRegenerateApiKey.FlatStyle = FlatStyle.Flat;
+            btnRegenerateApiKey.Font = new Font("Tahoma", 9.75F);
+            btnRegenerateApiKey.ForeColor = Color.White;
+            btnRegenerateApiKey.HoverColor = Color.FromArgb(0, 89, 184);
+            btnRegenerateApiKey.Icon = null;
+            btnRegenerateApiKey.Location = new Point(641, 93);
+            btnRegenerateApiKey.Name = "btnRegenerateApiKey";
+            btnRegenerateApiKey.Progress = 0;
+            btnRegenerateApiKey.ProgressColor = Color.FromArgb(0, 46, 94);
+            btnRegenerateApiKey.Size = new Size(150, 30);
+            btnRegenerateApiKey.TabIndex = 5;
+            btnRegenerateApiKey.Text = "Regenerate";
+            btnRegenerateApiKey.UseMnemonic = false;
+            btnRegenerateApiKey.UseVisualStyleBackColor = false;
+            btnRegenerateApiKey.UseWindowsAccentColor = true;
+            btnRegenerateApiKey.WriteProgress = true;
+            btnRegenerateApiKey.Click += BtnRegenerateApiKey_Click;
+            // 
+            // lblMcpSection
+            // 
+            lblMcpSection.AutoSize = true;
+            lblMcpSection.Font = new Font("Tahoma", 14.25F);
+            lblMcpSection.ForeColor = Color.Gray;
+            lblMcpSection.Location = new Point(3, 145);
+            lblMcpSection.Name = "lblMcpSection";
+            lblMcpSection.TabIndex = 6;
+            lblMcpSection.Text = "MCP Server";
+            lblMcpSection.UseMnemonic = false;
+            // 
+            // lblMcpDesc
+            // 
+            lblMcpDesc.Font = new Font("Tahoma", 10.5F);
+            lblMcpDesc.ForeColor = Color.Gray;
+            lblMcpDesc.Location = new Point(5, 172);
+            lblMcpDesc.Name = "lblMcpDesc";
+            lblMcpDesc.Size = new Size(900, 100);
+            lblMcpDesc.TabIndex = 7;
+            lblMcpDesc.UseMnemonic = false;
+            // 
+            // btnOpenMcpDocs
+            // 
+            btnOpenMcpDocs.BorderRadius = 8;
+            btnOpenMcpDocs.Cursor = Cursors.Hand;
+            btnOpenMcpDocs.FlatAppearance.BorderSize = 0;
+            btnOpenMcpDocs.FlatStyle = FlatStyle.Flat;
+            btnOpenMcpDocs.Font = new Font("Tahoma", 9.75F);
+            btnOpenMcpDocs.ForeColor = Color.White;
+            btnOpenMcpDocs.HoverColor = Color.FromArgb(0, 89, 184);
+            btnOpenMcpDocs.Icon = null;
+            btnOpenMcpDocs.Location = new Point(5, 280);
+            btnOpenMcpDocs.Name = "btnOpenMcpDocs";
+            btnOpenMcpDocs.Progress = 0;
+            btnOpenMcpDocs.ProgressColor = Color.FromArgb(0, 46, 94);
+            btnOpenMcpDocs.Size = new Size(180, 30);
+            btnOpenMcpDocs.TabIndex = 8;
+            btnOpenMcpDocs.Text = "Open MCP docs";
+            btnOpenMcpDocs.UseMnemonic = false;
+            btnOpenMcpDocs.UseVisualStyleBackColor = false;
+            btnOpenMcpDocs.UseWindowsAccentColor = true;
+            btnOpenMcpDocs.WriteProgress = true;
+            btnOpenMcpDocs.Click += BtnOpenMcpDocs_Click;
+            // 
+            // lblCliSection
+            // 
+            lblCliSection.AutoSize = true;
+            lblCliSection.Font = new Font("Tahoma", 14.25F);
+            lblCliSection.ForeColor = Color.Gray;
+            lblCliSection.Location = new Point(3, 330);
+            lblCliSection.Name = "lblCliSection";
+            lblCliSection.TabIndex = 9;
+            lblCliSection.Text = "CLI Tool";
+            lblCliSection.UseMnemonic = false;
+            // 
+            // lblCliDesc
+            // 
+            lblCliDesc.Font = new Font("Tahoma", 10.5F);
+            lblCliDesc.ForeColor = Color.Gray;
+            lblCliDesc.Location = new Point(5, 357);
+            lblCliDesc.Name = "lblCliDesc";
+            lblCliDesc.Size = new Size(900, 80);
+            lblCliDesc.TabIndex = 10;
+            lblCliDesc.UseMnemonic = false;
+            // 
+            // btnOpenCliDocs
+            // 
+            btnOpenCliDocs.BorderRadius = 8;
+            btnOpenCliDocs.Cursor = Cursors.Hand;
+            btnOpenCliDocs.FlatAppearance.BorderSize = 0;
+            btnOpenCliDocs.FlatStyle = FlatStyle.Flat;
+            btnOpenCliDocs.Font = new Font("Tahoma", 9.75F);
+            btnOpenCliDocs.ForeColor = Color.White;
+            btnOpenCliDocs.HoverColor = Color.FromArgb(0, 89, 184);
+            btnOpenCliDocs.Icon = null;
+            btnOpenCliDocs.Location = new Point(5, 445);
+            btnOpenCliDocs.Name = "btnOpenCliDocs";
+            btnOpenCliDocs.Progress = 0;
+            btnOpenCliDocs.ProgressColor = Color.FromArgb(0, 46, 94);
+            btnOpenCliDocs.Size = new Size(180, 30);
+            btnOpenCliDocs.TabIndex = 11;
+            btnOpenCliDocs.Text = "Open CLI docs";
+            btnOpenCliDocs.UseMnemonic = false;
+            btnOpenCliDocs.UseVisualStyleBackColor = false;
+            btnOpenCliDocs.UseWindowsAccentColor = true;
+            btnOpenCliDocs.WriteProgress = true;
+            btnOpenCliDocs.Click += BtnOpenCliDocs_Click;
+            // 
             // tabAbout
             // 
             tabAbout.BackColor = Color.FromArgb(45, 45, 45);
@@ -822,6 +1048,8 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
             tabUpdater.PerformLayout();
             tabBackups.ResumeLayout(false);
             tabBackups.PerformLayout();
+            tabApiAccess.ResumeLayout(false);
+            tabApiAccess.PerformLayout();
             tabAbout.ResumeLayout(false);
             tabAbout.PerformLayout();
             ((ISupportInitialize)btnGitHub).EndInit();
@@ -865,6 +1093,19 @@ namespace SuchByte.MacroDeck.GUI.MainWindowContents
         private CheckBox checkAutoUpdate;
         private TabPage tabBackups;
         private Label lblBackups;
+        private TabPage tabApiAccess;
+        private Label lblApiAccess;
+        private Label lblApiKeySection;
+        private Label lblApiKeyDesc;
+        private RoundedTextBox txtAdminKey;
+        private ButtonPrimary btnCopyApiKey;
+        private ButtonPrimary btnRegenerateApiKey;
+        private Label lblMcpSection;
+        private Label lblMcpDesc;
+        private ButtonPrimary btnOpenMcpDocs;
+        private Label lblCliSection;
+        private Label lblCliDesc;
+        private ButtonPrimary btnOpenCliDocs;
         private FlowLayoutPanel backupsPanel;
         private ButtonPrimary btnCreateBackup;
         private PictureButton btnGitHub;

--- a/MacroDeck/GUI/MainWindowViews/SettingsView.cs
+++ b/MacroDeck/GUI/MainWindowViews/SettingsView.cs
@@ -288,14 +288,17 @@ public partial class SettingsView : UserControl
         var key = MacroDeck.Configuration.AdminApiKey;
         txtAdminKey.Text = key;
         var url = $"http://localhost:{MacroDeck.Configuration.HostPort}";
+        lblMcpIntro.Text =
+            "Run MacroDeck.Mcp.exe with environment variables to expose MacroDeck tools to any MCP-capable LLM client (Claude Desktop, VS Code Copilot, etc.).";
         lblMcpDesc.Text =
-            $"Run MacroDeck.Mcp.exe with environment variables to expose MacroDeck tools to any MCP-capable LLM client (Claude Desktop, VS Code Copilot, etc.).\r\n\r\n" +
-            $"  MACRODECK_URL = {url}\r\n" +
-            $"  MACRODECK_API_KEY = {key}\r\n\r\n" +
-            "See the MCP docs for cloud setup instructions (Claude Desktop, VS Code).";
+            $"MACRODECK_URL = {url}\r\n" +
+            $"MACRODECK_API_KEY = {key}";
+        lblMcpFooter.Text = "See the MCP docs for cloud setup instructions (Claude Desktop, VS Code).";
+
+        lblCliIntro.Text =
+            "Use the macrodeck CLI to manage profiles, buttons, variables and plugins from a terminal or shell scripts.";
         lblCliDesc.Text =
-            $"Use the macrodeck CLI to manage profiles, buttons, variables and plugins from a terminal or shell scripts.\r\n\r\n" +
-            $"  macrodeck --url {url} --key {key} profile list";
+            $"macrodeck --url {url} --key {key} profile list";
     }
 
     private void BtnCopyApiKey_Click(object sender, EventArgs e)

--- a/MacroDeck/GUI/MainWindowViews/SettingsView.cs
+++ b/MacroDeck/GUI/MainWindowViews/SettingsView.cs
@@ -71,6 +71,7 @@ public partial class SettingsView : UserControl
         LoadNetworkConfiguration();
         LoadAutoUpdate();
         LoadBackups();
+        LoadApiAccess();
 
         lblInstalledVersion.Text = MacroDeck.Version.ToString();
         lblWebsocketAPIVersion.Text = MacroDeck.ApiVersion.ToString();
@@ -280,6 +281,61 @@ public partial class SettingsView : UserControl
     private void BackupManager_DeleteSuccess(object sender, EventArgs e)
     {
         LoadBackups();
+    }
+
+    private void LoadApiAccess()
+    {
+        var key = MacroDeck.Configuration.AdminApiKey;
+        txtAdminKey.Text = key;
+        var url = $"http://localhost:{MacroDeck.Configuration.HostPort}";
+        lblMcpDesc.Text =
+            $"Run MacroDeck.Mcp.exe with environment variables to expose MacroDeck tools to any MCP-capable LLM client (Claude Desktop, VS Code Copilot, etc.).\r\n\r\n" +
+            $"  MACRODECK_URL = {url}\r\n" +
+            $"  MACRODECK_API_KEY = {key}\r\n\r\n" +
+            "See the MCP docs for cloud setup instructions (Claude Desktop, VS Code).";
+        lblCliDesc.Text =
+            $"Use the macrodeck CLI to manage profiles, buttons, variables and plugins from a terminal or shell scripts.\r\n\r\n" +
+            $"  macrodeck --url {url} --key {key} profile list";
+    }
+
+    private void BtnCopyApiKey_Click(object sender, EventArgs e)
+    {
+        Clipboard.SetText(MacroDeck.Configuration.AdminApiKey);
+    }
+
+    private void BtnRegenerateApiKey_Click(object sender, EventArgs e)
+    {
+        using var msgBox = new MessageBox();
+        if (msgBox.ShowDialog(
+            "Regenerate API Key",
+            "This will invalidate the current key. You will need to update any CLI or MCP server configurations. Continue?",
+            MessageBoxButtons.YesNo) != DialogResult.Yes) return;
+
+        MacroDeck.Configuration.AdminApiKey = Guid.NewGuid().ToString("N");
+        MacroDeck.Configuration.Save(ApplicationPaths.MainConfigFilePath);
+        LoadApiAccess();
+    }
+
+    private void BtnOpenMcpDocs_Click(object sender, EventArgs e)
+    {
+        new Process
+        {
+            StartInfo = new ProcessStartInfo("https://github.com/Macro-Deck-App/Macro-Deck/blob/main/docs/mcp-usage.md")
+            {
+                UseShellExecute = true,
+            }
+        }.Start();
+    }
+
+    private void BtnOpenCliDocs_Click(object sender, EventArgs e)
+    {
+        new Process
+        {
+            StartInfo = new ProcessStartInfo("https://github.com/Macro-Deck-App/Macro-Deck/blob/main/docs/cli-usage.md")
+            {
+                UseShellExecute = true,
+            }
+        }.Start();
     }
 
     private void BtnGitHub_Click(object sender, EventArgs e)

--- a/MacroDeck/MacroDeck.cs
+++ b/MacroDeck/MacroDeck.cs
@@ -94,6 +94,13 @@ public class MacroDeck : NativeWindow
         
         Configuration = MainConfiguration.LoadFromFile(ApplicationPaths.MainConfigFilePath);
         LanguageManager.SetLanguage(Configuration.Language);
+        
+        // Migrate old configs that don't have AdminApiKey
+        if (!File.ReadAllText(ApplicationPaths.MainConfigFilePath).Contains("AdminApiKey"))
+        {
+            Configuration.Save(ApplicationPaths.MainConfigFilePath);
+            MacroDeckLogger.Info("Config migrated: AdminApiKey added");
+        }
         _ = new HotkeyManager();
         VariableManager.Initialize();
         PluginManager.Load();

--- a/MacroDeck/Server/AdminServices/ConfigAdminService.cs
+++ b/MacroDeck/Server/AdminServices/ConfigAdminService.cs
@@ -1,0 +1,49 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using SuchByte.MacroDeck.Startup;
+
+namespace SuchByte.MacroDeck.Server.AdminServices;
+
+public class ConfigAdminService : IConfigAdminService
+{
+    public ConfigDto GetConfig()
+    {
+        var cfg = MacroDeck.Configuration;
+        return new ConfigDto
+        {
+            AutoStart = cfg.AutoStart,
+            AutoUpdates = cfg.AutoUpdates,
+            UpdateBetaVersions = cfg.UpdateBetaVersions,
+            EnableAdbServer = cfg.EnableAdbServer,
+            EnableAdbAutoStartApp = cfg.EnableAdbAutoStartApp,
+            EnableSsl = cfg.EnableSsl,
+            SslCertificatePath = cfg.SslCertificatePath,
+            HostAddress = cfg.HostAddress,
+            HostPort = cfg.HostPort,
+            AskOnNewConnections = cfg.AskOnNewConnections,
+            BlockNewConnections = cfg.BlockNewConnections,
+            Language = cfg.Language,
+        };
+    }
+
+    public ConfigDto UpdateConfig(UpdateConfigRequest request)
+    {
+        var cfg = MacroDeck.Configuration;
+
+        if (request.AutoStart.HasValue) cfg.AutoStart = request.AutoStart.Value;
+        if (request.AutoUpdates.HasValue) cfg.AutoUpdates = request.AutoUpdates.Value;
+        if (request.UpdateBetaVersions.HasValue) cfg.UpdateBetaVersions = request.UpdateBetaVersions.Value;
+        if (request.EnableAdbServer.HasValue) cfg.EnableAdbServer = request.EnableAdbServer.Value;
+        if (request.EnableAdbAutoStartApp.HasValue) cfg.EnableAdbAutoStartApp = request.EnableAdbAutoStartApp.Value;
+        if (request.AskOnNewConnections.HasValue) cfg.AskOnNewConnections = request.AskOnNewConnections.Value;
+        if (request.BlockNewConnections.HasValue) cfg.BlockNewConnections = request.BlockNewConnections.Value;
+        if (request.Language is not null) cfg.Language = request.Language;
+
+        cfg.Save(ApplicationPaths.MainConfigFilePath);
+
+        return GetConfig();
+    }
+
+    public string GetAdminApiKey() => MacroDeck.Configuration.AdminApiKey;
+}

--- a/MacroDeck/Server/AdminServices/DeviceAdminService.cs
+++ b/MacroDeck/Server/AdminServices/DeviceAdminService.cs
@@ -1,0 +1,53 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using SuchByte.MacroDeck.Device;
+using SuchByte.MacroDeck.Profiles;
+
+namespace SuchByte.MacroDeck.Server.AdminServices;
+
+public class DeviceAdminService : IDeviceAdminService
+{
+    public IReadOnlyList<DeviceDto> ListDevices() =>
+        DeviceManager.GetKnownDevices().Select(ToDto).ToList();
+
+    public DeviceDto? GetDevice(string clientId)
+    {
+        var device = DeviceManager.GetMacroDeckDevice(clientId);
+        return device is null ? null : ToDto(device);
+    }
+
+    public bool AssignProfile(string clientId, string profileId)
+    {
+        var device = DeviceManager.GetMacroDeckDevice(clientId);
+        if (device is null) return false;
+        var profile = ProfileManager.FindProfileById(profileId);
+        if (profile is null) return false;
+        DeviceManager.SetProfile(device, profile);
+        return true;
+    }
+
+    public bool SetBlocked(string clientId, bool blocked)
+    {
+        var device = DeviceManager.GetMacroDeckDevice(clientId);
+        if (device is null) return false;
+        DeviceManager.SetBlocked(device, blocked);
+        return true;
+    }
+
+    private static DeviceDto ToDto(MacroDeckDevice d) => new()
+    {
+        ClientId = d.ClientId,
+        DisplayName = d.DisplayName,
+        ProfileId = d.ProfileId ?? string.Empty,
+        DeviceType = d.DeviceType.ToString(),
+        Blocked = d.Blocked,
+        Available = d.Available,
+        Configuration = d.Configuration is null ? null : new DeviceConfigDto
+        {
+            Brightness = d.Configuration.Brightness,
+            AutoConnect = d.Configuration.AutoConnect,
+            WakeLockMethod = d.Configuration.WakeLockMethod.ToString(),
+        },
+    };
+}

--- a/MacroDeck/Server/AdminServices/IconAdminService.cs
+++ b/MacroDeck/Server/AdminServices/IconAdminService.cs
@@ -1,0 +1,35 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Services;
+using SuchByte.MacroDeck.Icons;
+
+namespace SuchByte.MacroDeck.Server.AdminServices;
+
+public class IconAdminService : IIconAdminService
+{
+    public IReadOnlyList<IconPackDto> ListIconPacks() =>
+        IconManager.IconPacks
+            .Select(p => new IconPackDto
+            {
+                Name = p.Name,
+                PackageId = p.PackageId ?? string.Empty,
+                Author = p.Author ?? string.Empty,
+                Version = p.Version ?? string.Empty,
+                IconCount = p.Icons?.Count ?? 0,
+            })
+            .ToList();
+
+    public IReadOnlyList<IconDto> ListIcons(string iconPackName)
+    {
+        var pack = IconManager.IconPacks.Find(p => p.Name == iconPackName);
+        if (pack?.Icons is null) return [];
+
+        return pack.Icons
+            .Select(icon => new IconDto
+            {
+                IconId = icon.IconId,
+                IconPackName = pack.Name,
+                IconString = $"{pack.Name}.{icon.IconId}",
+            })
+            .ToList();
+    }
+}

--- a/MacroDeck/Server/AdminServices/PluginAdminService.cs
+++ b/MacroDeck/Server/AdminServices/PluginAdminService.cs
@@ -1,0 +1,66 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Services;
+using SuchByte.MacroDeck.ExtensionStore;
+using SuchByte.MacroDeck.Plugins;
+
+namespace SuchByte.MacroDeck.Server.AdminServices;
+
+public class PluginAdminService : IPluginAdminService
+{
+    private static readonly HttpClient _http = new();
+
+    public IReadOnlyList<PluginDto> ListPlugins() =>
+        PluginManager.Plugins.Values.Select(ToDto).ToList();
+
+    public PluginDto? GetPlugin(string pluginName)
+    {
+        if (!PluginManager.Plugins.TryGetValue(pluginName, out var plugin)) return null;
+        return ToDto(plugin);
+    }
+
+    public async Task<bool> InstallPluginAsync(string packageId)
+    {
+        try
+        {
+            // Queue the install via ExtensionStoreHelper on the background task
+            await Task.Run(() => ExtensionStoreHelper.InstallPluginById(packageId));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<string> SearchExtensionStoreAsync(string query, string type = "Plugin")
+    {
+        var url = $"{Constants.ExtensionStoreApiBaseUrl}/v2/extensions?query={Uri.EscapeDataString(query)}&type={Uri.EscapeDataString(type)}";
+        try
+        {
+            var response = await _http.GetStringAsync(url);
+            return response;
+        }
+        catch
+        {
+            return "[]";
+        }
+    }
+
+    private static PluginDto ToDto(MacroDeckPlugin p) => new()
+    {
+        Name = p.Name,
+        Author = p.Author ?? string.Empty,
+        Version = p.Version ?? string.Empty,
+        CanConfigure = p.CanConfigure,
+        IsProtected = PluginManager.ProtectedPlugins.Contains(p),
+        Actions = p.Actions.Select(a => new PluginActionInfoDto
+        {
+            Name = a.Name,
+            Description = a.Description,
+            CanConfigure = a.CanConfigure,
+            ActionClass = a.GetType().Name,
+        }).ToList(),
+    };
+}

--- a/MacroDeck/Server/AdminServices/ProfileAdminService.cs
+++ b/MacroDeck/Server/AdminServices/ProfileAdminService.cs
@@ -1,6 +1,7 @@
 using MacroDeck.Server.Dto;
 using MacroDeck.Server.Dto.Requests;
 using MacroDeck.Server.Services;
+using System.Drawing;
 using SuchByte.MacroDeck.Device;
 using SuchByte.MacroDeck.Folders;
 using SuchByte.MacroDeck.Plugins;
@@ -123,6 +124,8 @@ public class ProfileAdminService : IProfileAdminService
             ActionsLongPressRelease = ResolveActions(request.ActionsLongPressRelease),
         };
 
+        ApplyButtonStyle(button, request);
+
         folder.ActionButtons.Add(button);
         ProfileManager.Save();
         return ToDto(button);
@@ -143,6 +146,8 @@ public class ProfileAdminService : IProfileAdminService
         button.ActionsRelease = ResolveActions(request.ActionsRelease);
         button.ActionsLongPress = ResolveActions(request.ActionsLongPress);
         button.ActionsLongPressRelease = ResolveActions(request.ActionsLongPressRelease);
+
+        ApplyButtonStyle(button, request);
 
         ProfileManager.Save();
         return ToDto(button);
@@ -171,15 +176,74 @@ public class ProfileAdminService : IProfileAdminService
         requests
             .Select(r =>
             {
-                if (!PluginManager.Plugins.TryGetValue(r.PluginName, out var plugin)) return null;
+                // Prefer explicit plugin name, but support legacy payloads where pluginName is empty.
+                var pluginFound = !string.IsNullOrWhiteSpace(r.PluginName)
+                    && PluginManager.Plugins.TryGetValue(r.PluginName, out var namedPlugin);
+
+                var plugin = pluginFound
+                    ? namedPlugin
+                    : PluginManager.Plugins.Values.FirstOrDefault(p =>
+                        p.Actions.Any(a => a.GetType().Name == r.ActionClass));
+
+                if (plugin is null) return null;
+
                 var action = plugin.Actions.FirstOrDefault(a => a.GetType().Name == r.ActionClass);
                 if (action is null) return null;
+
                 var instance = (PluginAction)Activator.CreateInstance(action.GetType())!;
                 instance.Configuration = r.Configuration;
                 return instance;
             })
             .Where(a => a is not null)
             .ToList()!;
+
+    private static void ApplyButtonStyle(ActionButton.ActionButton button, CreateButtonRequest request)
+    {
+        if (button.LabelOff == null) button.LabelOff = new ActionButton.ButtonLabel();
+        if (button.LabelOn == null) button.LabelOn = new ActionButton.ButtonLabel();
+
+        var iconOff = BuildIconString(request.IconPack, request.IconName) ?? request.IconOff;
+        var iconOn = BuildIconString(request.IconPack, request.IconNameOn) ?? request.IconOn;
+
+        if (!string.IsNullOrWhiteSpace(iconOff)) button.IconOff = iconOff;
+        if (!string.IsNullOrWhiteSpace(iconOn)) button.IconOn = iconOn;
+
+        if (TryParseColor(request.BackgroundColorOff, out var bgOff)) button.BackColorOff = bgOff;
+        if (TryParseColor(request.BackgroundColorOn, out var bgOn)) button.BackColorOn = bgOn;
+        if (TryParseColor(request.LabelColorOff, out var labelOff)) button.LabelOff.LabelColor = labelOff;
+        if (TryParseColor(request.LabelColorOn, out var labelOn)) button.LabelOn.LabelColor = labelOn;
+    }
+
+    private static bool TryParseColor(string? value, out Color color)
+    {
+        color = Color.Empty;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        try
+        {
+            color = ColorTranslator.FromHtml(value);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string? BuildIconString(string? iconPack, string? iconName)
+    {
+        if (string.IsNullOrWhiteSpace(iconPack) || string.IsNullOrWhiteSpace(iconName)) return null;
+        return $"{iconPack}.{iconName}";
+    }
+
+    private static string ToHex(Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+
+    private static (string? pack, string? name) SplitIconString(string? icon)
+    {
+        if (string.IsNullOrWhiteSpace(icon)) return (null, null);
+        var idx = icon.IndexOf('.');
+        if (idx <= 0 || idx == icon.Length - 1) return (null, null);
+        return (icon[..idx], icon[(idx + 1)..]);
+    }
 
     private static ProfileDto ToDto(MacroDeckProfile p) => new()
     {
@@ -204,26 +268,41 @@ public class ProfileAdminService : IProfileAdminService
         ApplicationToTrigger = f.ApplicationToTrigger ?? string.Empty,
     };
 
-    private static ButtonDto ToDto(ActionButton.ActionButton b) => new()
+    private static ButtonDto ToDto(ActionButton.ActionButton b)
     {
-        Guid = b.Guid,
-        PositionX = b.Position_X,
-        PositionY = b.Position_Y,
-        State = b.State,
-        LabelOffText = b.LabelOff?.LabelText,
-        LabelOnText = b.LabelOn?.LabelText,
-        StateBindingVariable = b.StateBindingVariable,
-        Actions = b.Actions?.Select(ActionToDto).ToList() ?? [],
-        ActionsRelease = b.ActionsRelease?.Select(ActionToDto).ToList() ?? [],
-        ActionsLongPress = b.ActionsLongPress?.Select(ActionToDto).ToList() ?? [],
-        ActionsLongPressRelease = b.ActionsLongPressRelease?.Select(ActionToDto).ToList() ?? [],
-    };
+        var (iconPack, iconName) = SplitIconString(b.IconOff);
+        var (_, iconNameOn) = SplitIconString(b.IconOn);
+
+        return new ButtonDto
+        {
+            Guid = b.Guid,
+            PositionX = b.Position_X,
+            PositionY = b.Position_Y,
+            State = b.State,
+            LabelOffText = b.LabelOff?.LabelText,
+            LabelOnText = b.LabelOn?.LabelText,
+            StateBindingVariable = b.StateBindingVariable,
+            IconPack = iconPack,
+            IconName = iconName,
+            IconNameOn = iconNameOn,
+            IconOff = b.IconOff,
+            IconOn = b.IconOn,
+            BackgroundColorOff = ToHex(b.BackColorOff),
+            BackgroundColorOn = ToHex(b.BackColorOn),
+            LabelColorOff = b.LabelOff is null ? null : ToHex(b.LabelOff.LabelColor),
+            LabelColorOn = b.LabelOn is null ? null : ToHex(b.LabelOn.LabelColor),
+            Actions = b.Actions?.Select(ActionToDto).ToList() ?? [],
+            ActionsRelease = b.ActionsRelease?.Select(ActionToDto).ToList() ?? [],
+            ActionsLongPress = b.ActionsLongPress?.Select(ActionToDto).ToList() ?? [],
+            ActionsLongPressRelease = b.ActionsLongPressRelease?.Select(ActionToDto).ToList() ?? [],
+        };
+    }
 
     private static ActionDto ActionToDto(PluginAction a) => new()
     {
-        PluginName = a.ActionButton?.Actions.Any() == true
-            ? PluginManager.Plugins.FirstOrDefault(kv => kv.Value.Actions.Contains(a)).Key ?? string.Empty
-            : string.Empty,
+        PluginName = PluginManager.Plugins
+            .FirstOrDefault(kv => kv.Value.Actions.Any(pa => pa.GetType().Name == a.GetType().Name)).Key
+            ?? string.Empty,
         ActionClass = a.GetType().Name,
         Configuration = a.Configuration ?? string.Empty,
         ConfigurationSummary = a.ConfigurationSummary ?? string.Empty,

--- a/MacroDeck/Server/AdminServices/ProfileAdminService.cs
+++ b/MacroDeck/Server/AdminServices/ProfileAdminService.cs
@@ -177,12 +177,14 @@ public class ProfileAdminService : IProfileAdminService
             .Select(r =>
             {
                 // Prefer explicit plugin name, but support legacy payloads where pluginName is empty.
-                var pluginFound = !string.IsNullOrWhiteSpace(r.PluginName)
-                    && PluginManager.Plugins.TryGetValue(r.PluginName, out var namedPlugin);
+                SuchByte.MacroDeck.Plugins.MacroDeckPlugin? plugin = null;
 
-                var plugin = pluginFound
-                    ? namedPlugin
-                    : PluginManager.Plugins.Values.FirstOrDefault(p =>
+                if (!string.IsNullOrWhiteSpace(r.PluginName))
+                {
+                    PluginManager.Plugins.TryGetValue(r.PluginName, out plugin);
+                }
+
+                plugin ??= PluginManager.Plugins.Values.FirstOrDefault(p =>
                         p.Actions.Any(a => a.GetType().Name == r.ActionClass));
 
                 if (plugin is null) return null;
@@ -218,9 +220,37 @@ public class ProfileAdminService : IProfileAdminService
     {
         color = Color.Empty;
         if (string.IsNullOrWhiteSpace(value)) return false;
+
+        var raw = value.Trim();
+
+        // Some clients pass colors as quoted JSON fragments (e.g. "#1DB954").
+        if (raw.Length >= 2 && raw[0] == '"' && raw[^1] == '"')
+        {
+            raw = raw[1..^1].Trim();
+        }
+
+        // Accept plain hex without leading '#'.
+        var isHex = raw.Length == 6 || raw.Length == 8;
+        if (isHex)
+        {
+            foreach (var ch in raw)
+            {
+                if (!Uri.IsHexDigit(ch))
+                {
+                    isHex = false;
+                    break;
+                }
+            }
+
+            if (isHex)
+            {
+                raw = "#" + raw;
+            }
+        }
+
         try
         {
-            color = ColorTranslator.FromHtml(value);
+            color = ColorTranslator.FromHtml(raw);
             return true;
         }
         catch

--- a/MacroDeck/Server/AdminServices/ProfileAdminService.cs
+++ b/MacroDeck/Server/AdminServices/ProfileAdminService.cs
@@ -1,0 +1,231 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using SuchByte.MacroDeck.Device;
+using SuchByte.MacroDeck.Folders;
+using SuchByte.MacroDeck.Plugins;
+using SuchByte.MacroDeck.Profiles;
+
+namespace SuchByte.MacroDeck.Server.AdminServices;
+
+public class ProfileAdminService : IProfileAdminService
+{
+    // ---------- Profiles ----------
+
+    public IReadOnlyList<ProfileDto> ListProfiles() =>
+        ProfileManager.Profiles.Select(ToDto).ToList();
+
+    public ProfileDto? GetProfile(string profileId) =>
+        ProfileManager.Profiles.Select(ToDto).FirstOrDefault(p => p.ProfileId == profileId);
+
+    public ProfileDto CreateProfile(CreateProfileRequest request)
+    {
+        var profile = ProfileManager.CreateProfile(request.DisplayName);
+        profile.Rows = request.Rows;
+        profile.Columns = request.Columns;
+        profile.ButtonSpacing = request.ButtonSpacing;
+        profile.ButtonRadius = request.ButtonRadius;
+        profile.ButtonBackground = request.ButtonBackground;
+        if (Enum.TryParse<DeviceClass>(request.ProfileTarget, out var deviceClass))
+            profile.ProfileTarget = deviceClass;
+        ProfileManager.Save();
+        return ToDto(profile);
+    }
+
+    public bool DeleteProfile(string profileId)
+    {
+        var profile = ProfileManager.FindProfileById(profileId);
+        if (profile is null) return false;
+        ProfileManager.DeleteProfile(profile);
+        return true;
+    }
+
+    // ---------- Folders ----------
+
+    public IReadOnlyList<FolderDto> ListFolders(string profileId)
+    {
+        var profile = ProfileManager.FindProfileById(profileId);
+        return profile is null ? [] : profile.Folders.Select(ToDto).ToList();
+    }
+
+    public FolderDto? GetFolder(string profileId, string folderId)
+    {
+        var profile = ProfileManager.FindProfileById(profileId);
+        if (profile is null) return null;
+        var folder = ProfileManager.FindFolderById(folderId, profile);
+        return folder is null ? null : ToDto(folder);
+    }
+
+    public FolderDto? CreateFolder(string profileId, CreateFolderRequest request)
+    {
+        var profile = ProfileManager.FindProfileById(profileId);
+        if (profile is null) return null;
+
+        var parent = string.IsNullOrWhiteSpace(request.ParentFolderId)
+            ? profile.Folders.FirstOrDefault(f => f.IsRootFolder)
+            : ProfileManager.FindFolderById(request.ParentFolderId, profile);
+        if (parent is null) return null;
+
+        var folder = ProfileManager.CreateFolder(request.DisplayName, parent, profile);
+        if (folder is null) return null;
+
+        if (!string.IsNullOrWhiteSpace(request.ApplicationToTrigger))
+        {
+            folder.ApplicationToTrigger = request.ApplicationToTrigger;
+            ProfileManager.Save();
+        }
+        return ToDto(folder);
+    }
+
+    public bool DeleteFolder(string profileId, string folderId)
+    {
+        var profile = ProfileManager.FindProfileById(profileId);
+        if (profile is null) return false;
+        var folder = ProfileManager.FindFolderById(folderId, profile);
+        if (folder is null) return false;
+        ProfileManager.DeleteFolder(folder, profile);
+        return true;
+    }
+
+    // ---------- Buttons ----------
+
+    public IReadOnlyList<ButtonDto> ListButtons(string profileId, string folderId)
+    {
+        var folder = ResolveFolder(profileId, folderId);
+        return folder is null ? [] : folder.ActionButtons.Select(ToDto).ToList();
+    }
+
+    public ButtonDto? GetButton(string profileId, string folderId, string buttonGuid)
+    {
+        var folder = ResolveFolder(profileId, folderId);
+        var btn = folder?.ActionButtons.FirstOrDefault(b => b.Guid == buttonGuid);
+        return btn is null ? null : ToDto(btn);
+    }
+
+    public ButtonDto? CreateButton(string profileId, string folderId, CreateButtonRequest request)
+    {
+        var folder = ResolveFolder(profileId, folderId);
+        if (folder is null) return null;
+        if (folder.ActionButtons.Any(b => b.Position_X == request.PositionX && b.Position_Y == request.PositionY))
+            return null;
+
+        var button = new ActionButton.ActionButton
+        {
+            Guid = System.Guid.NewGuid().ToString(),
+            Position_X = request.PositionX,
+            Position_Y = request.PositionY,
+            LabelOff = new ActionButton.ButtonLabel { LabelText = request.LabelOffText ?? string.Empty },
+            LabelOn = new ActionButton.ButtonLabel { LabelText = request.LabelOnText ?? string.Empty },
+            StateBindingVariable = request.StateBindingVariable ?? string.Empty,
+            Actions = ResolveActions(request.Actions),
+            ActionsRelease = ResolveActions(request.ActionsRelease),
+            ActionsLongPress = ResolveActions(request.ActionsLongPress),
+            ActionsLongPressRelease = ResolveActions(request.ActionsLongPressRelease),
+        };
+
+        folder.ActionButtons.Add(button);
+        ProfileManager.Save();
+        return ToDto(button);
+    }
+
+    public ButtonDto? UpdateButton(string profileId, string folderId, string buttonGuid, CreateButtonRequest request)
+    {
+        var folder = ResolveFolder(profileId, folderId);
+        var button = folder?.ActionButtons.FirstOrDefault(b => b.Guid == buttonGuid);
+        if (button is null) return null;
+
+        button.Position_X = request.PositionX;
+        button.Position_Y = request.PositionY;
+        if (button.LabelOff != null) button.LabelOff.LabelText = request.LabelOffText ?? string.Empty;
+        if (button.LabelOn != null) button.LabelOn.LabelText = request.LabelOnText ?? string.Empty;
+        button.StateBindingVariable = request.StateBindingVariable ?? string.Empty;
+        button.Actions = ResolveActions(request.Actions);
+        button.ActionsRelease = ResolveActions(request.ActionsRelease);
+        button.ActionsLongPress = ResolveActions(request.ActionsLongPress);
+        button.ActionsLongPressRelease = ResolveActions(request.ActionsLongPressRelease);
+
+        ProfileManager.Save();
+        return ToDto(button);
+    }
+
+    public bool DeleteButton(string profileId, string folderId, string buttonGuid)
+    {
+        var folder = ResolveFolder(profileId, folderId);
+        var button = folder?.ActionButtons.FirstOrDefault(b => b.Guid == buttonGuid);
+        if (button is null) return false;
+        button.Dispose();
+        folder!.ActionButtons.Remove(button);
+        ProfileManager.Save();
+        return true;
+    }
+
+    // ---------- Helpers ----------
+
+    private static MacroDeckFolder? ResolveFolder(string profileId, string folderId)
+    {
+        var profile = ProfileManager.FindProfileById(profileId);
+        return profile is null ? null : ProfileManager.FindFolderById(folderId, profile);
+    }
+
+    private static List<PluginAction> ResolveActions(List<ActionAssignmentRequest> requests) =>
+        requests
+            .Select(r =>
+            {
+                if (!PluginManager.Plugins.TryGetValue(r.PluginName, out var plugin)) return null;
+                var action = plugin.Actions.FirstOrDefault(a => a.GetType().Name == r.ActionClass);
+                if (action is null) return null;
+                var instance = (PluginAction)Activator.CreateInstance(action.GetType())!;
+                instance.Configuration = r.Configuration;
+                return instance;
+            })
+            .Where(a => a is not null)
+            .ToList()!;
+
+    private static ProfileDto ToDto(MacroDeckProfile p) => new()
+    {
+        ProfileId = p.ProfileId,
+        DisplayName = p.DisplayName,
+        Rows = p.Rows,
+        Columns = p.Columns,
+        ButtonSpacing = p.ButtonSpacing,
+        ButtonRadius = p.ButtonRadius,
+        ButtonBackground = p.ButtonBackground,
+        ProfileTarget = p.ProfileTarget.ToString(),
+        FolderCount = p.Folders.Count,
+    };
+
+    private static FolderDto ToDto(MacroDeckFolder f) => new()
+    {
+        FolderId = f.FolderId,
+        DisplayName = f.DisplayName,
+        IsRootFolder = f.IsRootFolder,
+        ChildFolderIds = f.Childs,
+        ButtonCount = f.ActionButtons.Count,
+        ApplicationToTrigger = f.ApplicationToTrigger ?? string.Empty,
+    };
+
+    private static ButtonDto ToDto(ActionButton.ActionButton b) => new()
+    {
+        Guid = b.Guid,
+        PositionX = b.Position_X,
+        PositionY = b.Position_Y,
+        State = b.State,
+        LabelOffText = b.LabelOff?.LabelText,
+        LabelOnText = b.LabelOn?.LabelText,
+        StateBindingVariable = b.StateBindingVariable,
+        Actions = b.Actions?.Select(ActionToDto).ToList() ?? [],
+        ActionsRelease = b.ActionsRelease?.Select(ActionToDto).ToList() ?? [],
+        ActionsLongPress = b.ActionsLongPress?.Select(ActionToDto).ToList() ?? [],
+        ActionsLongPressRelease = b.ActionsLongPressRelease?.Select(ActionToDto).ToList() ?? [],
+    };
+
+    private static ActionDto ActionToDto(PluginAction a) => new()
+    {
+        PluginName = a.ActionButton?.Actions.Any() == true
+            ? PluginManager.Plugins.FirstOrDefault(kv => kv.Value.Actions.Contains(a)).Key ?? string.Empty
+            : string.Empty,
+        ActionClass = a.GetType().Name,
+        Configuration = a.Configuration ?? string.Empty,
+        ConfigurationSummary = a.ConfigurationSummary ?? string.Empty,
+    };
+}

--- a/MacroDeck/Server/AdminServices/ProfileAdminService.cs
+++ b/MacroDeck/Server/AdminServices/ProfileAdminService.cs
@@ -127,6 +127,7 @@ public class ProfileAdminService : IProfileAdminService
         ApplyButtonStyle(button, request);
 
         folder.ActionButtons.Add(button);
+        ProfileManager.UpdateVariableLabels(button);
         ProfileManager.Save();
         return ToDto(button);
     }
@@ -149,6 +150,7 @@ public class ProfileAdminService : IProfileAdminService
 
         ApplyButtonStyle(button, request);
 
+        ProfileManager.UpdateVariableLabels(button);
         ProfileManager.Save();
         return ToDto(button);
     }

--- a/MacroDeck/Server/AdminServices/VariableAdminService.cs
+++ b/MacroDeck/Server/AdminServices/VariableAdminService.cs
@@ -1,0 +1,51 @@
+using MacroDeck.Server.Dto;
+using MacroDeck.Server.Dto.Requests;
+using MacroDeck.Server.Services;
+using SuchByte.MacroDeck.Variables;
+
+namespace SuchByte.MacroDeck.Server.AdminServices;
+
+public class VariableAdminService : IVariableAdminService
+{
+    public IReadOnlyList<VariableDto> ListVariables() =>
+        VariableManager.Variables.Select(ToDto).ToList();
+
+    public VariableDto? GetVariable(string name)
+    {
+        var v = VariableManager.Variables
+            .FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+        return v is null ? null : ToDto(v);
+    }
+
+    public VariableDto UpsertVariable(UpsertVariableRequest request)
+    {
+        if (!Enum.TryParse<VariableType>(request.Type, ignoreCase: true, out var type))
+            type = VariableType.String;
+
+        VariableManager.SetValue(request.Name, request.Value, type, request.Creator);
+        return new VariableDto
+        {
+            Name = VariableManager.ConvertNameString(request.Name),
+            Value = request.Value,
+            Type = type.ToString(),
+            Creator = request.Creator,
+        };
+    }
+
+    public bool DeleteVariable(string name)
+    {
+        var exists = VariableManager.Variables
+            .Any(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (!exists) return false;
+        VariableManager.DeleteVariable(name);
+        return true;
+    }
+
+    private static VariableDto ToDto(Variable v) => new()
+    {
+        Name = v.Name,
+        Value = v.Value,
+        Type = v.Type,
+        Creator = v.Creator,
+    };
+}

--- a/MacroDeck/Server/MacroDeckServer.cs
+++ b/MacroDeck/Server/MacroDeckServer.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
 using MacroDeck.Server;
 using MacroDeck.Server.DataTypes;
+using MacroDeck.Server.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using SuchByte.MacroDeck.Configuration;
 using SuchByte.MacroDeck.Device;
@@ -11,6 +13,7 @@ using SuchByte.MacroDeck.JSON;
 using SuchByte.MacroDeck.Language;
 using SuchByte.MacroDeck.Logging;
 using SuchByte.MacroDeck.Profiles;
+using SuchByte.MacroDeck.Server.AdminServices;
 using SuchByte.MacroDeck.Utils;
 
 namespace SuchByte.MacroDeck.Server;
@@ -42,7 +45,15 @@ public static class MacroDeckServer
         var certificatePassword = MacroDeck.Configuration.SslCertificatePassword;
         try
         {
-            await MacroDeckServerHelper.Setup(port, enableSsl, certificatePath, certificatePassword);
+            await MacroDeckServerHelper.Setup(port, enableSsl, certificatePath, certificatePassword,
+                services =>
+                {
+                    services.AddSingleton<IProfileAdminService, ProfileAdminService>();
+                    services.AddSingleton<IVariableAdminService, VariableAdminService>();
+                    services.AddSingleton<IPluginAdminService, PluginAdminService>();
+                    services.AddSingleton<IDeviceAdminService, DeviceAdminService>();
+                    services.AddSingleton<IConfigAdminService, ConfigAdminService>();
+                });
         }
         catch (Exception ex)
         {

--- a/MacroDeck/Server/MacroDeckServer.cs
+++ b/MacroDeck/Server/MacroDeckServer.cs
@@ -53,6 +53,7 @@ public static class MacroDeckServer
                     services.AddSingleton<IPluginAdminService, PluginAdminService>();
                     services.AddSingleton<IDeviceAdminService, DeviceAdminService>();
                     services.AddSingleton<IConfigAdminService, ConfigAdminService>();
+                    services.AddSingleton<IIconAdminService, IconAdminService>();
                 });
         }
         catch (Exception ex)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@
 # Download
 https://macrodeck.org/download
 
+# CLI & MCP Server
+
+Macro Deck ships a command-line tool and an MCP (Model Context Protocol) server that let you manage profiles, buttons, variables, and plugins programmatically or through natural language via LLM clients (Claude Desktop, VS Code Copilot, etc.).
+
+- **[CLI usage guide](docs/cli-usage.md)** — manage MacroDeck from a terminal or shell scripts
+- **[MCP server usage guide](docs/mcp-usage.md)** — connect any MCP-capable LLM client to MacroDeck
+
+The Admin API key required to connect is displayed in MacroDeck → Settings → **API Access**.
+
 # Create own plugins
 Learn how to create your own plugins in the wiki: https://github.com/SuchByte/Macro-Deck/wiki/Plugin-API
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,0 +1,237 @@
+# MacroDeck CLI Usage Guide
+
+The `macrodeck` CLI lets you manage MacroDeck profiles, buttons, variables, plugins, and devices from a terminal or shell scripts — no GUI required.
+
+## Prerequisites
+
+- MacroDeck running with the admin REST API enabled
+- `macrodeck.exe` (or `macrodeck` on Linux/macOS) built or on your `PATH`
+- Your **Admin API Key** — find it in MacroDeck → Settings → **API Access**
+
+## Configuration
+
+Supply connection details via global options on every command, or set environment variables once:
+
+```bash
+# Environment variables (recommended)
+set MACRODECK_URL=http://localhost:8191
+set MACRODECK_API_KEY=your-api-key-here
+
+# Or per-command options
+macrodeck --url http://localhost:8191 --key your-api-key-here profile list
+```
+
+## Command Reference
+
+### Global Options
+
+| Option | Env var | Description |
+|---|---|---|
+| `--url <url>` | `MACRODECK_URL` | MacroDeck server URL (default: `http://localhost:8191`) |
+| `--key <key>` | `MACRODECK_API_KEY` | Admin API key |
+
+---
+
+### `profile` — Profile management
+
+```
+macrodeck profile list
+macrodeck profile get <profileId>
+macrodeck profile create --name <name> [--rows <n>] [--columns <n>]
+macrodeck profile delete <profileId>
+
+macrodeck profile list-folders <profileId>
+macrodeck profile create-folder <profileId> --name <name> [--parent <folderId>] [--app <processName>]
+macrodeck profile delete-folder <profileId> <folderId>
+```
+
+**Examples:**
+
+```bash
+# List all profiles
+macrodeck profile list
+
+# Create a new profile
+macrodeck profile create --name "Streaming" --rows 3 --columns 6
+
+# List folders in a profile
+macrodeck profile list-folders abc123
+
+# Create a nested folder that auto-activates for OBS
+macrodeck profile create-folder abc123 --name "OBS Controls" --app obs64
+```
+
+---
+
+### `button` — Button management
+
+```
+macrodeck button list <profileId> <folderId>
+macrodeck button create <profileId> <folderId> --x <col> --y <row> [--label <text>] [--label-on <text>] [--actions-json <json>]
+macrodeck button delete <profileId> <folderId> <buttonGuid>
+```
+
+**Examples:**
+
+```bash
+# List all buttons in a folder
+macrodeck button list abc123 root-folder-id
+
+# Create a button at column 0, row 0 with a label
+macrodeck button create abc123 root-folder-id --x 0 --y 0 --label "Mute"
+
+# Create a button with an action assignment (JSON inline)
+macrodeck button create abc123 root-folder-id --x 1 --y 0 --label "Scene 1" \
+  --actions-json '[{"pluginName":"OBS Plugin","actionClass":"SwitchSceneAction","configuration":{"scene":"Gaming"}}]'
+```
+
+The `--actions-json` parameter takes an array of action assignment objects:
+
+```json
+[
+  {
+    "pluginName": "Plugin Display Name",
+    "actionClass": "ActionClassName",
+    "configuration": {
+      "key": "value"
+    }
+  }
+]
+```
+
+Use `macrodeck plugin get <name>` to see the available action class names for a plugin.
+
+---
+
+### `plugin` — Plugin management
+
+```
+macrodeck plugin list
+macrodeck plugin get <name>
+macrodeck plugin search <query>
+macrodeck plugin install <extensionId>
+```
+
+**Examples:**
+
+```bash
+# List all installed plugins
+macrodeck plugin list
+
+# Inspect a plugin's available actions
+macrodeck plugin get "OBS Plugin"
+
+# Search the extension store
+macrodeck plugin search obs
+
+# Install a plugin by extension store ID
+macrodeck plugin install com.example.myplugin
+```
+
+---
+
+### `variable` — Variable management
+
+```
+macrodeck variable list
+macrodeck variable get <name>
+macrodeck variable set <name> --value <value> [--type String|Integer|Float|Bool] [--creator <label>]
+macrodeck variable delete <name>
+```
+
+**Examples:**
+
+```bash
+# List all variables
+macrodeck variable list
+
+# Create/update a boolean variable
+macrodeck variable set is_streaming --value true --type Bool --creator CLI
+
+# Create/update an integer counter
+macrodeck variable set scene_index --value 0 --type Integer
+
+# Delete a variable
+macrodeck variable delete old_var
+```
+
+---
+
+### `device` — Device management
+
+```
+macrodeck device list
+macrodeck device assign-profile <clientId> --profile <profileId>
+macrodeck device set-blocked <clientId> --blocked <true|false>
+```
+
+**Examples:**
+
+```bash
+# List all known devices
+macrodeck device list
+
+# Assign a specific profile to a device
+macrodeck device assign-profile my-phone-client-id --profile streaming-profile-id
+
+# Block a device from connecting
+macrodeck device set-blocked unknown-device --blocked true
+```
+
+---
+
+### `config` — Configuration management
+
+```
+macrodeck config get
+macrodeck config update [--host <address>] [--port <n>] [--adb <true|false>] [--ssl <true|false>] [--auto-start <true|false>]
+```
+
+**Examples:**
+
+```bash
+# View current configuration
+macrodeck config get
+
+# Change the listening port (requires restart)
+macrodeck config update --port 9000
+
+# Enable ADB support for Android USB connections
+macrodeck config update --adb true
+```
+
+---
+
+## Shell Scripting Examples
+
+### Create a Gaming profile with a full button layout
+
+```bash
+#!/bin/bash
+export MACRODECK_URL=http://localhost:8191
+export MACRODECK_API_KEY=your-key-here
+
+# Create profile and capture the returned ID
+PROFILE=$(macrodeck profile create --name "Gaming" --rows 3 --columns 5)
+echo "Created: $PROFILE"
+
+# Get the profile ID from the JSON output using jq
+PROFILE_ID=$(echo "$PROFILE" | jq -r '.profileId')
+
+# List folders to find the root folder
+macrodeck profile list-folders "$PROFILE_ID"
+```
+
+### Scripted variable setup
+
+```bash
+# Initialize a set of streaming state variables
+macrodeck variable set is_streaming --value false --type Bool --creator Setup
+macrodeck variable set stream_uptime --value 0 --type Integer --creator Setup
+macrodeck variable set viewer_count --value 0 --type Integer --creator Setup
+echo "Variables initialized."
+```
+
+## Security
+
+The Admin API key is stored in MacroDeck's `config.json`. Treat it like a password — do not commit it to source control. Use environment variables instead of --key flags in scripts to avoid exposing the key in process listings. You can regenerate the key at any time from Settings → API Access; after regeneration, update all your scripts and MCP server configurations.

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -184,7 +184,7 @@ macrodeck device set-blocked unknown-device --blocked true
 
 ```
 macrodeck config get
-macrodeck config update [--host <address>] [--port <n>] [--adb <true|false>] [--ssl <true|false>] [--auto-start <true|false>]
+macrodeck config update [--auto-start <true|false>] [--auto-updates <true|false>] [--update-beta-versions <true|false>] [--enable-adb-server <true|false>] [--enable-adb-auto-start-app <true|false>] [--ask-on-new-connections <true|false>] [--block-new-connections <true|false>] [--language <name>]
 ```
 
 **Examples:**
@@ -193,11 +193,17 @@ macrodeck config update [--host <address>] [--port <n>] [--adb <true|false>] [--
 # View current configuration
 macrodeck config get
 
-# Change the listening port (requires restart)
-macrodeck config update --port 9000
-
 # Enable ADB support for Android USB connections
-macrodeck config update --adb true
+macrodeck config update --enable-adb-server true
+
+# Auto-start Macro Deck Client app when connected via ADB
+macrodeck config update --enable-adb-auto-start-app true
+
+# Block new device connections
+macrodeck config update --block-new-connections true
+
+# Change language
+macrodeck config update --language German
 ```
 
 ---

--- a/docs/mcp-usage.md
+++ b/docs/mcp-usage.md
@@ -123,8 +123,20 @@ Once connected, you can prompt the LLM naturally:
 ## Notes For `update_button`
 
 - The tool expects `updateJson` to be a JSON object (not an array or scalar).
-- Only request fields are applied during update: `positionX`, `positionY`, `actions`, `actionsRelease`, `actionsLongPress`, `actionsLongPressRelease`, `labelOffText`, `labelOnText`, `stateBindingVariable`.
+- Only request fields are applied during update: `positionX`, `positionY`, `actions`, `actionsRelease`, `actionsLongPress`, `actionsLongPressRelease`, `labelOffText`, `labelOnText`, `stateBindingVariable`, `iconPack`, `iconName`, `iconNameOn`, `iconOff`, `iconOn`, `backgroundColorOff`, `backgroundColorOn`, `labelColorOff`, `labelColorOn`.
 - Fields you omit are preserved from the current button state.
+
+## Label Formatting (Cottle)
+
+MacroDeck label templates use Cottle syntax. For built-in functions and formatting helpers, see:
+
+- [Cottle built-in functions](https://cottle.readthedocs.io/en/stable/page/03-builtin.html)
+
+Recommended patterns:
+
+- Numeric formatting: `{round(speedtestdownload, 2)} {speedtestdownloadunit}`
+- Conditional fallback: `{default(spotify_playing_title, 'No Track')}`
+- Multi-line label text in JSON: `"labelOffText":"Download\n{round(speedtestdownload, 2)} Mbps"`
 
 ## Debugging MCP Process Exit
 

--- a/docs/mcp-usage.md
+++ b/docs/mcp-usage.md
@@ -74,7 +74,7 @@ Add to your `.vscode/mcp.json` (or user-level MCP settings):
 | `delete_folder` | Delete a folder and all its child folders |
 | `list_buttons` | List buttons in a folder |
 | `create_button` | Place a button at a grid position with action assignments |
-| `update_button` | Update a button's labels or actions |
+| `update_button` | Update a button partially (patch-style) while preserving omitted fields |
 | `delete_button` | Remove a button |
 
 ### Plugin Management
@@ -119,6 +119,21 @@ Once connected, you can prompt the LLM naturally:
 - *"Add a button at position 0,0 in the root folder of the Gaming profile that runs the 'Launch Application' action from the System plugin"*
 - *"Set a variable called 'game_mode' to true"*
 - *"Search the extension store for OBS plugins and install the first result"*
+
+## Notes For `update_button`
+
+- The tool expects `updateJson` to be a JSON object (not an array or scalar).
+- Only request fields are applied during update: `positionX`, `positionY`, `actions`, `actionsRelease`, `actionsLongPress`, `actionsLongPressRelease`, `labelOffText`, `labelOnText`, `stateBindingVariable`.
+- Fields you omit are preserved from the current button state.
+
+## Debugging MCP Process Exit
+
+If your MCP client reports that the server transport closed unexpectedly:
+
+- Verify `MACRODECK_URL` and `MACRODECK_API_KEY` are set correctly.
+- Ensure MacroDeck is running and reachable from the configured URL.
+- Rebuild and restart `MacroDeck.Mcp.exe` after code changes.
+- Run the server manually and capture stderr output for diagnosis.
 
 ## Security
 

--- a/docs/mcp-usage.md
+++ b/docs/mcp-usage.md
@@ -1,0 +1,125 @@
+# MacroDeck MCP Server Usage Guide
+
+The `MacroDeck.Mcp` project exposes MacroDeck's admin API as [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools, letting any MCP-capable LLM client (Claude Desktop, VS Code Copilot, etc.) manage profiles, buttons, variables, plugins, and device configuration through natural language.
+
+## Prerequisites
+
+- MacroDeck running with the admin REST API enabled (all versions that include this feature)
+- `MacroDeck.Mcp.exe` built or downloaded
+- Your **Admin API Key** — find it in MacroDeck → Settings → **API Access**
+
+## Configuration
+
+The MCP server reads two environment variables:
+
+| Variable | Description | Example |
+|---|---|---|
+| `MACRODECK_URL` | Base URL of the running MacroDeck instance | `http://localhost:8191` |
+| `MACRODECK_API_KEY` | Admin API key from Settings → API Access | `a1b2c3d4...` |
+
+## Claude Desktop Integration
+
+Add an entry under `mcpServers` in your Claude Desktop config file:
+
+**macOS / Linux:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "macrodeck": {
+      "command": "C:\\path\\to\\MacroDeck.Mcp.exe",
+      "env": {
+        "MACRODECK_URL": "http://localhost:8191",
+        "MACRODECK_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+After saving, restart Claude Desktop. You should see MacroDeck tools available in the tool picker.
+
+## VS Code / GitHub Copilot Integration
+
+Add to your `.vscode/mcp.json` (or user-level MCP settings):
+
+```json
+{
+  "servers": {
+    "macrodeck": {
+      "type": "stdio",
+      "command": "C:\\path\\to\\MacroDeck.Mcp.exe",
+      "env": {
+        "MACRODECK_URL": "http://localhost:8191",
+        "MACRODECK_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Profile Management
+
+| Tool | Description |
+|---|---|
+| `list_profiles` | List all profiles with metadata |
+| `get_profile` | Get a profile including all its folders |
+| `create_profile` | Create a new profile with specified rows/columns |
+| `delete_profile` | Delete a profile by ID |
+| `list_folders` | List folders inside a profile |
+| `create_folder` | Create a folder (optionally nested under a parent) |
+| `delete_folder` | Delete a folder and all its child folders |
+| `list_buttons` | List buttons in a folder |
+| `create_button` | Place a button at a grid position with action assignments |
+| `update_button` | Update a button's labels or actions |
+| `delete_button` | Remove a button |
+
+### Plugin Management
+
+| Tool | Description |
+|---|---|
+| `list_plugins` | List all installed plugins with available actions |
+| `get_plugin` | Get details and action list for a specific plugin |
+| `search_extension_store` | Search the MacroDeck extension store |
+| `install_plugin` | Install a plugin from the extension store |
+
+### Variable Management
+
+| Tool | Description |
+|---|---|
+| `list_variables` | List all variables |
+| `get_variable` | Get a specific variable |
+| `set_variable` | Create or update a variable (String, Integer, Float, Bool) |
+| `delete_variable` | Delete a variable |
+
+### Device Management
+
+| Tool | Description |
+|---|---|
+| `list_devices` | List all known devices |
+| `assign_profile_to_device` | Assign a profile to a specific device |
+| `set_device_blocked` | Block or unblock a device |
+
+### Configuration
+
+| Tool | Description |
+|---|---|
+| `get_configuration` | Get current MacroDeck configuration |
+| `update_configuration` | Update configuration fields (port, SSL, ADB, etc.) |
+
+## Example Prompts
+
+Once connected, you can prompt the LLM naturally:
+
+- *"Create a new profile called 'Gaming' with 4 rows and 6 columns"*
+- *"Show me all installed plugins and their available actions"*
+- *"Add a button at position 0,0 in the root folder of the Gaming profile that runs the 'Launch Application' action from the System plugin"*
+- *"Set a variable called 'game_mode' to true"*
+- *"Search the extension store for OBS plugins and install the first result"*
+
+## Security
+
+The Admin API key is a randomly generated secret stored in MacroDeck's `config.json`. Keep it private — anyone with the key and network access to the MacroDeck port can manage your installation. You can regenerate the key at any time from Settings → API Access.


### PR DESCRIPTION
Admin REST API (MacroDeck.Server):
- Define IProfileAdminService, IVariableAdminService, IPluginAdminService,
  IDeviceAdminService, IConfigAdminService interfaces
- Implement admin controllers for profiles, folders, buttons, variables,
  plugins, devices, and configuration
- Add AdminApiKeyMiddleware to protect all /api/* routes with
  X-MacroDeck-Admin-Key header
- Extend MacroDeckServerHelper.Setup() with DI delegate for injecting
  service implementations from the host project (avoids circular deps)

Service implementations (MacroDeck):
- ProfileAdminService, VariableAdminService, PluginAdminService,
  DeviceAdminService, ConfigAdminService wrapping existing static managers
- Add AdminApiKey (auto-generated GUID) to MainConfiguration / config.json

MCP Server (MacroDeck.Mcp):
- New net8.0 console project using ModelContextProtocol 1.2.0 (stdio)
- Five tool modules (Profile, Plugin, Variable, Device, Config) with
  LLM-friendly natural language descriptions
- Configured via MACRODECK_URL / MACRODECK_API_KEY env vars

CLI Tool (MacroDeck.Cli):
- New net8.0 console project using System.CommandLine
- Commands: profile list/get/create/delete, folder CRUD, button CRUD,
  plugin list/get/search/install, variable list/get/set/delete,
  device list/assign-profile/set-blocked, config get/update
- Configured via --url / --key options or env vars

UI (Settings):
- New 'API Access' tab in Settings between Backups and About
- Shows Admin API key (read-only), copy button, regenerate button
- MCP and CLI setup instructions with links to online documentation

Docs:
- docs/mcp-usage.md: MCP setup guide for Claude Desktop and VS Code
- docs/cli-usage.md: full CLI command reference with examples
- README: link to both guides and the API Access settings page

Build: all projects build cleanly (0 errors)