### PR TITLE
Make documentation deployment a manual step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,15 @@
 name: Docs
 
 # Rebuilds the plugin documentation site whenever the SDK, the protocol, the UI model
-# or the documentation itself changes, and on demand. Successful builds from main are
-# deployed to the production Cloudflare Worker.
+# or the documentation itself changes, and on demand. Deployment to the production
+# Cloudflare Worker is a manual step: run this workflow from main with "Deploy" enabled.
 on:
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Deploy the built site to https://docs.macro-deck.app'
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
@@ -56,12 +61,9 @@ jobs:
 
   deploy:
     name: Deploy documentation site
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    environment:
-      name: production
-      url: https://docs.macro-deck.app
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Push to main still builds the site so broken links keep failing CI, but deploying to the production Cloudflare Worker now requires a manual workflow_dispatch with the deploy input enabled. Drops the production environment, so the Cloudflare secrets must be repository secrets.
