### PR TITLE
Run release jobs in the production environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,6 +367,8 @@ jobs:
     # newer ELF features on the ubuntu-latest (24.04) image, and keeps the
     # declared libc6 floor in tauri.linux.conf.json's deb.depends accurate.
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    # The signing and updater credentials this job reads are production environment secrets.
+    environment: production
     needs: [prepare, test-host, build-ui, publish-host]
     env:
       # Without the updater key the bundle is built without updater artifacts and
@@ -559,6 +561,8 @@ jobs:
   package-windows:
     name: Package Windows (NSIS)
     runs-on: blacksmith-4vcpu-windows-2025
+    # The signing and updater credentials this job reads are production environment secrets.
+    environment: production
     needs: [prepare, test-host, test-host-windows, build-ui, publish-host]
     env:
       HAS_WIN_CERT: ${{ secrets.WINDOWS_SIGN_CERT_PFX_BASE64 != '' }}
@@ -669,6 +673,8 @@ jobs:
   package-macos:
     name: Package macOS (DMG)
     runs-on: blacksmith-6vcpu-macos-26
+    # The signing, notarization and updater credentials this job reads are production environment secrets.
+    environment: production
     needs: [prepare, test-host, test-host-macos, build-ui, publish-host]
     env:
       HAS_MAC_CERT: ${{ secrets.MACOS_SIGN_CERT_P12_BASE64 != '' }}
@@ -880,6 +886,8 @@ jobs:
     # default rule - every job in `needs` succeeded - is exactly that gate, and any condition that lets
     # a partial set through would publish channel files pointing at platforms this run never built.
     needs: [prepare, package-linux, package-windows, package-macos, e2e]
+    # The R2 credentials this job reads are production environment secrets.
+    environment: production
     env:
       HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' }}
     steps:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -36,6 +36,8 @@ jobs:
   publish:
     name: Publish to NuGet
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    # A caller cannot set this - the environment has to be declared where the job is.
+    environment: production
     permissions:
       contents: read
       # Lets the job request the OIDC token nuget.org exchanges for a short-lived API key.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,6 +18,8 @@ jobs:
     name: Publish GitHub release
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'workflow_dispatch' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    # The release announcement webhook is a production environment secret.
+    environment: production
     env:
       GH_TOKEN: ${{ github.token }}
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
The signing, updater, R2 and Discord credentials exist only as production environment secrets, so the packaging, upload, NuGet publish and release jobs read them as empty and silently skipped signing and publishing. Each job that reads one now declares the environment; for the NuGet publish that has to happen in the reusable workflow, because a caller cannot set an environment on a workflow_call job.