### PR TITLE
Reject a migration key that only clears PKCS7 by chance

### DIFF
--- a/host/src/MacroDeckHost.Infrastructure/Migration/MacroDeck2/MacroDeck2StringCipher.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Migration/MacroDeck2/MacroDeck2StringCipher.cs
@@ -32,6 +32,11 @@ internal static class MacroDeck2StringCipher
 
 	private const int DerivationIterations = 1000;
 
+	// A wrong key still clears PKCS7 roughly once every 256 values, and the plaintext that survives is
+	// random bytes, so the decode has to reject them rather than paper over them with U+FFFD.
+	private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false,
+		throwOnInvalidBytes: true);
+
 	/// <summary>
 	/// Decrypts one value, or returns null when it cannot be decrypted with this passphrase. A wrong key
 	/// is an expected outcome - it is what makes the host offer to ask for another one - so it is never
@@ -68,9 +73,13 @@ internal static class MacroDeck2StringCipher
 			using var aes = Aes.Create();
 			aes.Key = DeriveKey(passPhrase, salt);
 
-			return Encoding.UTF8.GetString(aes.DecryptCbc(cipher, iv, PaddingMode.PKCS7));
+			return StrictUtf8.GetString(aes.DecryptCbc(cipher, iv, PaddingMode.PKCS7));
 		}
 		catch (CryptographicException)
+		{
+			return null;
+		}
+		catch (DecoderFallbackException)
 		{
 			return null;
 		}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Migration/MacroDeck2StringCipherTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Migration/MacroDeck2StringCipherTests.cs
@@ -27,6 +27,21 @@ public class MacroDeck2StringCipherTests
 		=> Assert.That(MacroDeck2StringCipher.TryDecrypt(GoldenCipherText, "00000000-0000-0000-0000-000000000000"),
 			Is.Null);
 
+	// Macro Deck 2's format carries no authentication tag, so a wrong key clears PKCS7 padding by chance
+	// for roughly one value in 256. This pair is one of those: the wrong key below decrypts it without a
+	// CryptographicException, leaving bytes that are not text. Accepting them made the host trust a key
+	// that opens nothing, which is what MigrationError.InvalidDecryptionKey exists to prevent.
+	private const string PaddingCollisionCipherText =
+		"Dp9ceQnYiOf79LW4B+9eu8PwZpzt4T0wgUvPmq69v9adhw36YYSy6FPTOencG1qI";
+
+	private const string PaddingCollisionWrongPassPhrase = "11111111-1111-1111-1111-111111111111";
+
+	[Test]
+	public void TryDecrypt_WithAWrongKeyThatClearsPadding_StillReportsFailure()
+		=> Assert.That(MacroDeck2StringCipher.TryDecrypt(PaddingCollisionCipherText,
+				PaddingCollisionWrongPassPhrase),
+			Is.Null);
+
 	// A truncated or hand-edited value must be refused the same way a wrong key is: the migration offers to
 	// carry on without the encrypted data, and that path is only reachable if nothing here throws.
 	[TestCase("")]

--- a/sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests/A19_ManualClockTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests/A19_ManualClockTests.cs
@@ -53,14 +53,18 @@ public class A19_ManualClockTests
 			var before = state.ReconnectAttempt;
 			clock.Advance(ReconnectPolicy.MaxDelay);
 
-			// Full jitter permits a near-zero delay, so a single Advance may legitimately produce no new
-			// attempt - never assert exactly one, only that it never produced more than one.
-			await Task.Delay(TimeSpan.FromMilliseconds(300));
-			var after = state.ReconnectAttempt;
+			// Waited for rather than slept over: a fixed sleep that a loaded machine outruns lets one
+			// Advance's attempt land inside the next iteration's window and read as two.
+			await Wait.UntilAsync(() => state.ReconnectAttempt > before,
+				TimeSpan.FromSeconds(10),
+				because: "advancing past the whole backoff never produced the next reconnect attempt");
 
-			Assert.That(after,
-				Is.EqualTo(before).Or.EqualTo(before + 1),
-				$"a single Advance(MaxDelay) produced more than one further attempt ({before} -> {after})");
+			var afterAdvance = state.ReconnectAttempt;
+			await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+			Assert.That(state.ReconnectAttempt,
+				Is.EqualTo(afterAdvance),
+				"the next attempt was scheduled on real time rather than on the injected clock");
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two unrelated failures of the `Test host` job in [run 34061363805](https://github.com/Macro-Deck-App/Macro-Deck/actions/runs/34061363805), on two consecutive attempts.

**`Read_WithASuppliedKeyThatDoesNotOpenTheCredentials_IsRejected` — a real bug, not a flaky test.** Macro Deck 2's credential format carries no authentication tag, so decrypting with a wrong key clears PKCS7 padding by chance for roughly one value in 256. The random bytes that survived went through `Encoding.UTF8.GetString`, which never throws and turns them into replacement characters, so `TryDecrypt` returned a garbage string and `KeyOpens` accepted a key that opens nothing. The host then migrated garbage credentials instead of answering `MigrationError.InvalidDecryptionKey`. `MacroDeck2StringCipher` now decodes strictly and treats undecodable plaintext the same as a padding failure.

**`A19_ManualClockTests.ManualTimeProvider_drives_reconnect_scheduling_for_an_in_process_plugin` (`1 -> 3`) — a timing-coupled test.** It slept a flat 300 ms after each `clock.Advance(MaxDelay)` and asserted the attempt counter moved by at most one. The counter is incremented on a continuation after a real connect round trip, so on a loaded runner one iteration's attempt lands after its own sleep, inside the next iteration's window, where that window's own `Advance` adds a second. The scenario now waits for each advance's attempt to land and then asserts that real time alone never adds another - the same requirement, without depending on machine speed.

## Testing

- A pinned (ciphertext, wrong key) pair that clears PKCS7 was brute-forced against the real cipher - it took 177 samples, matching the 1/256 estimate - and is asserted as a regression. It fails on the previous decode and passes on the strict one.
- `dotnet test host/tests/MacroDeckHost.Tests.UnitTests -c Release --filter "FullyQualifiedName~MacroDeck2StringCipherTests|FullyQualifiedName~MacroDeck2MigrationSourceTests"`
- `dotnet test sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests -c Release --filter "FullyQualifiedName~A19_ManualClockTests"`, three consecutive runs
- `dotnet build MacroDeck.slnx -c Release -warnaserror`

## Plugin SDK / API compatibility

No public contract changed. The `sdk/` change is a test under `sdk/tests/`; `MacroDeck2StringCipher` is `internal` to the host's infrastructure assembly.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change