### PR TITLE
Keep NuGet packages off the GitHub release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,8 @@ name: Publish Release
 
 # Publishes a successful release build: the GitHub release carries the installers and the
 # signed updater payloads, the R2 feed carries only the channel manifests pointing at them,
-# and the NuGet packages go out last, once the release they belong to actually exists.
+# and the NuGet packages go to nuget.org only - never onto the release - last, once the
+# release they belong to actually exists.
 on:
   workflow_run:
     workflows: [Build]
@@ -43,14 +44,6 @@ jobs:
           pattern: macro-deck-*
           path: release-assets
           merge-multiple: true
-          github-token: ${{ github.token }}
-          run-id: ${{ env.SOURCE_RUN_ID }}
-
-      - name: Download NuGet packages
-        uses: actions/download-artifact@v7
-        with:
-          name: nuget-packages
-          path: release-assets/nuget
           github-token: ${{ github.token }}
           run-id: ${{ env.SOURCE_RUN_ID }}
 
@@ -115,9 +108,7 @@ jobs:
               -o -name '*.sha256' \
               -o -name '*.deb' \
               -o -name '*.rpm' \
-              -o -name '*.app.tar.gz' \
-              -o -name '*.nupkg' \
-              -o -name '*.snupkg' \) \
+              -o -name '*.app.tar.gz' \) \
               -print0
           )
 


### PR DESCRIPTION
Closes #

## Summary

The NuGet package family was uploaded twice: once to nuget.org by the publish-nuget job, and once as .nupkg and .snupkg assets on the GitHub release. Only nuget.org is wanted, so the release job no longer stages or attaches them.

- The Download NuGet packages step is gone. It existed solely to place the packages into release-assets/nuget so the asset find would pick them up. The publish-nuget job downloads the nuget-packages artifact itself via the build run id and is unaffected.
- .nupkg and .snupkg are removed from the release asset find. The release now carries the installers, the checksums and the signed updater payloads only.

## Testing

Workflow-only change, verified by reading the publishing path end to end: nothing else consumes release-assets/nuget, and the manifest repointing and R2 upload steps only look at the channel JSONs. The next release run is the real check.

## Notes

engineering/development/releasing.md already describes the release contents without NuGet, so no documentation change was needed.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change