### PR TITLE
Serve updates from the updater host and separate a failed check from a failed download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,7 +420,7 @@ jobs:
       - name: Write version override
         working-directory: ui/bootstrapper
         run: |
-          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":%s},"plugins":{"updater":{"endpoints":["https://dev.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
+          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":%s},"plugins":{"updater":{"endpoints":["https://updater.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
             "${{ needs.prepare.outputs.version }}" "${{ env.HAS_UPDATER_KEY == 'true' && 'true' || 'false' }}" "${{ needs.prepare.outputs.updater_channel }}" \
             > version-override.json
 
@@ -472,7 +472,7 @@ jobs:
       - name: Write RPM version override
         working-directory: ui/bootstrapper
         run: |
-          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":false,"linux":{"rpm":{"release":"%s"}}},"plugins":{"updater":{"endpoints":["https://dev.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
+          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":false,"linux":{"rpm":{"release":"%s"}}},"plugins":{"updater":{"endpoints":["https://updater.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
             "${{ needs.prepare.outputs.rpm_version }}" "${{ needs.prepare.outputs.rpm_release }}" "${{ needs.prepare.outputs.updater_channel }}" \
             > rpm-version-override.json
 
@@ -617,7 +617,7 @@ jobs:
         shell: bash
         working-directory: ui/bootstrapper
         run: |
-          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":%s},"plugins":{"updater":{"endpoints":["https://dev.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
+          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":%s},"plugins":{"updater":{"endpoints":["https://updater.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
             "${{ needs.prepare.outputs.version }}" "${{ env.HAS_UPDATER_KEY == 'true' && 'true' || 'false' }}" "${{ needs.prepare.outputs.updater_channel }}" \
             > version-override.json
 
@@ -788,7 +788,7 @@ jobs:
       - name: Write version override
         working-directory: ui/bootstrapper
         run: |
-          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":%s},"plugins":{"updater":{"endpoints":["https://dev.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
+          printf '{"version":"%s","bundle":{"createUpdaterArtifacts":%s},"plugins":{"updater":{"endpoints":["https://updater.macro-deck.app/releases/%s-{{target}}.json"]}}}\n' \
             "${{ needs.prepare.outputs.version }}" "${{ env.HAS_UPDATER_KEY == 'true' && 'true' || 'false' }}" "${{ needs.prepare.outputs.updater_channel }}" \
             > version-override.json
 

--- a/ci/scripts/make-update-manifest.mjs
+++ b/ci/scripts/make-update-manifest.mjs
@@ -29,7 +29,7 @@ export const DEFAULT_REPOSITORY = 'Macro-Deck-App/Macro-Deck';
 
 // Where the release feed serves the channel manifests from. Payloads are not
 // published here any more - only these manifests are.
-export const FEED_BASE_URL = 'https://dev.macro-deck.app/releases/';
+export const FEED_BASE_URL = 'https://updater.macro-deck.app/releases/';
 
 // The tag publish-release.yml creates for a version, and the asset base url under it.
 export function releaseAssetBaseUrl(version, repository = DEFAULT_REPOSITORY) {

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.cs.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.cs.resx
@@ -14258,6 +14258,10 @@ Stáhněte jej z webu Macro Deck a aktualizujte nainstalovaný AppImage, DEB neb
     <value>Stahování se nezdařilo. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>Aktualizace se nepodařilo zkontrolovat. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Zrušit stahování</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.de.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.de.resx
@@ -14256,6 +14256,10 @@ Lade es von der Macro-Deck-Website herunter und aktualisiere deine installierte 
     <value>Der Download ist fehlgeschlagen. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>Die Suche nach Updates ist fehlgeschlagen. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Download abbrechen</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.es.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.es.resx
@@ -14258,6 +14258,10 @@ Descárgalo desde el sitio web de Macro Deck y actualiza el AppImage, DEB o RPM 
     <value>La descarga falló. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>No se pudo comprobar si hay actualizaciones. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Cancelar descarga</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.fr.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.fr.resx
@@ -14258,6 +14258,10 @@ Télécharge-le depuis le site web de Macro Deck et mets à jour l'AppImage, le 
     <value>Le téléchargement a échoué. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>Impossible de vérifier les mises à jour. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Annuler le téléchargement</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.it.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.it.resx
@@ -14258,6 +14258,10 @@ Scaricalo dal sito di Macro Deck e aggiorna l'AppImage, il DEB o l'RPM che hai i
     <value>Il download non è riuscito. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>Impossibile controllare gli aggiornamenti. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Annulla download</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.pl.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.pl.resx
@@ -14258,6 +14258,10 @@ Pobierz go ze strony Macro Deck i zaktualizuj zainstalowany pakiet AppImage, DEB
     <value>Pobieranie nie powiodło się. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>Nie udało się sprawdzić dostępności aktualizacji. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Anuluj pobieranie</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.resx
@@ -14257,6 +14257,10 @@ Download it from the Macro Deck website and update the AppImage, DEB or RPM you 
     <value>The download failed. {error}</value>
     <comment>[error:string]</comment>
   </data>
+  <data name="Update.Details.CheckFailed" xml:space="preserve">
+    <value>Couldn't check for updates. {error}</value>
+    <comment>[error:string]</comment>
+  </data>
   <data name="Update.Details.CancelDownloadAction" xml:space="preserve">
     <value>Cancel download</value>
   </data>

--- a/ui/angular/projects/desktop-ui/src/app/app.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/app.component.spec.ts
@@ -165,6 +165,7 @@ describe('AppComponent (desktop-ui) - splash status during an update install (is
       downloadUrl: null,
       partialCheck: null,
       error: null,
+      failure: null,
       progress: null,
       lastCheckedAt: null,
       ...overrides,

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/update-check.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/update-check.component.spec.ts
@@ -23,6 +23,7 @@ function makeState(overrides: Partial<ShellUpdateState> = {}): ShellUpdateState 
     downloadUrl: null,
     partialCheck: null,
     error: null,
+    failure: null,
     progress: null,
     lastCheckedAt: null,
     ...overrides,

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.html
@@ -3,7 +3,9 @@
   [maxWidth]="'520px'"
   (close)="onModalClose()">
   <div class="update-modal">
-    <h3 class="update-modal__version">{{ versionHeading() }}</h3>
+    @if (versionHeading(); as version) {
+      <h3 class="update-modal__version">{{ version }}</h3>
+    }
     <p class="update-modal__current">{{ currentVersionLine() }}</p>
 
     <div class="update-modal__meta">
@@ -15,16 +17,18 @@
       }
     </div>
 
-    <section class="update-modal__changelog-section">
-      <h4 class="update-modal__section-heading">{{ appStrings.Update.Details.ChangelogHeading | translate }}</h4>
-      <div class="update-modal__changelog">
-        @if (hasChangelog()) {
-          <shared-store-markdown [text]="changelogText()" />
-        } @else {
-          <p class="update-modal__no-changelog">{{ appStrings.Update.Details.NoChangelog | translate }}</p>
-        }
-      </div>
-    </section>
+    @if (knownVersion() !== null) {
+      <section class="update-modal__changelog-section">
+        <h4 class="update-modal__section-heading">{{ appStrings.Update.Details.ChangelogHeading | translate }}</h4>
+        <div class="update-modal__changelog">
+          @if (hasChangelog()) {
+            <shared-store-markdown [text]="changelogText()" />
+          } @else {
+            <p class="update-modal__no-changelog">{{ appStrings.Update.Details.NoChangelog | translate }}</p>
+          }
+        </div>
+      </section>
+    }
 
     @switch (updates.phase()) {
       @case ('downloading') {
@@ -45,7 +49,7 @@
         <p class="update-modal__status">{{ appStrings.Update.Details.ReadyStatus | translate }}</p>
       }
       @case ('failed') {
-        <p class="update-modal__status update-modal__status--error">{{ downloadFailedMessage() }}</p>
+        <p class="update-modal__status update-modal__status--error">{{ failureMessage() }}</p>
       }
     }
   </div>

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.spec.ts
@@ -17,6 +17,7 @@ function makeState(overrides: Partial<ShellUpdateState> = {}): ShellUpdateState 
     downloadUrl: 'https://macro-deck.app/download',
     partialCheck: null,
     error: null,
+    failure: null,
     progress: null,
     lastCheckedAt: null,
     ...overrides,
@@ -243,6 +244,55 @@ describe('UpdateModalComponent', () => {
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain('network unreachable');
     expect(text).not.toContain("You're on the latest version");
+  });
+
+  it('words a failed check as a failed check, not as a failed download', async () => {
+    setShell({
+      getUpdateState: () => Promise.resolve(
+        makeState({ phase: 'failed', failure: 'check', version: null, error: 'could not check for updates on any feed (stable, beta)' }),
+      ),
+      onUpdateState: () => Promise.resolve(() => {}),
+    });
+
+    const fixture = await createFixture();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("Couldn't check for updates.");
+    expect(text).toContain('could not check for updates on any feed (stable, beta)');
+    expect(text).not.toContain('The download failed.');
+  });
+
+  it('offers no version and no changelog when a check failed without finding one', async () => {
+    setShell({
+      getUpdateState: () => Promise.resolve(
+        makeState({ phase: 'failed', failure: 'check', version: null, currentVersion: '3.0.0-beta.2', error: 'feed unreachable' }),
+      ),
+      onUpdateState: () => Promise.resolve(() => {}),
+    });
+
+    const fixture = await createFixture();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('You currently have 3.0.0-beta.2');
+    expect(text).not.toContain('Macro Deck 3.0.0-beta.2');
+    expect(text).not.toContain('No release notes were published for this version.');
+    expect(fixture.nativeElement.querySelector('.update-modal__changelog')).toBeNull();
+  });
+
+  it('still words a failed download as a failed download', async () => {
+    setShell({
+      getUpdateState: () => Promise.resolve(
+        makeState({ phase: 'failed', failure: 'install', version: '3.1.0', error: 'connection reset' }),
+      ),
+      onUpdateState: () => Promise.resolve(() => {}),
+    });
+
+    const fixture = await createFixture();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('The download failed.');
+    expect(text).toContain('connection reset');
+    expect(text).toContain('Macro Deck 3.1.0');
   });
 
   it('disables Install while a download/install is in flight', async () => {

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.ts
@@ -23,9 +23,13 @@ export class UpdateModalComponent {
 
   protected readonly heading = computed(() => this.localization.translateKey(AppStrings.Settings.Update.SoftwareUpdateLabel));
 
+  protected readonly knownVersion = computed(() => this.updates.version());
+
   protected readonly versionHeading = computed(() => {
-    const version = this.updates.version() ?? this.updates.currentVersion();
-    return this.localization.translateKey(AppStrings.Update.Details.VersionHeading, { version });
+    const version = this.knownVersion();
+    return version === null
+      ? null
+      : this.localization.translateKey(AppStrings.Update.Details.VersionHeading, { version });
   });
 
   protected readonly currentVersionLine = computed(() =>
@@ -62,10 +66,11 @@ export class UpdateModalComponent {
       : this.localization.translateKey(AppStrings.Update.Details.DownloadingStatus, { percent });
   });
 
-  protected readonly downloadFailedMessage = computed(() =>
-    this.localization.translateKey(AppStrings.Update.Details.DownloadFailed, {
-      error: this.updates.error() ?? '',
-    }));
+  protected readonly failureMessage = computed(() =>
+    this.localization.translateKey(
+      this.updates.checkFailed() ? AppStrings.Update.Details.CheckFailed : AppStrings.Update.Details.DownloadFailed,
+      { error: this.updates.error() ?? '' },
+    ));
 
   install(): void {
     void this.updates.install();

--- a/ui/angular/projects/desktop-ui/src/app/core/shell.d.ts
+++ b/ui/angular/projects/desktop-ui/src/app/core/shell.d.ts
@@ -126,6 +126,7 @@ declare global {
     downloadUrl: string | null;
     partialCheck: string | null;
     error: string | null;
+    failure: 'check' | 'install' | null;
     progress: ShellUpdateProgress | null;
     lastCheckedAt: number | null;
   }

--- a/ui/angular/projects/desktop-ui/src/app/services/update.service.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/services/update.service.spec.ts
@@ -17,6 +17,7 @@ function makeState(overrides: Partial<ShellUpdateState> = {}): ShellUpdateState 
     downloadUrl: null,
     partialCheck: null,
     error: null,
+    failure: null,
     progress: null,
     lastCheckedAt: null,
     ...overrides,

--- a/ui/angular/projects/desktop-ui/src/app/services/update.service.ts
+++ b/ui/angular/projects/desktop-ui/src/app/services/update.service.ts
@@ -21,6 +21,7 @@ const IDLE_STATE: ShellUpdateState = {
   downloadUrl: null,
   partialCheck: null,
   error: null,
+  failure: null,
   progress: null,
   lastCheckedAt: null,
 };
@@ -50,6 +51,7 @@ export class UpdateService {
   readonly downloadUrl = computed(() => this.state().downloadUrl);
   readonly partialCheck = computed(() => this.state().partialCheck);
   readonly error = computed(() => this.state().error);
+  readonly failure = computed(() => this.state().failure);
   readonly progressPercent = computed(() => this.state().progress?.percent ?? null);
   readonly lastCheckedAt = computed(() => this.state().lastCheckedAt);
 
@@ -57,6 +59,7 @@ export class UpdateService {
   readonly canInstall = computed(() => this.phase() === 'available' || this.phase() === 'downloaded');
   readonly externalDownload = computed(() => this.installStrategy() === 'externalDownload');
   readonly installFailed = computed(() => this.phase() === 'failed' && this.installAttempted());
+  readonly checkFailed = computed(() => this.phase() === 'failed' && this.failure() === 'check');
 
   constructor() {
     const bridge = window.macroDeckShell;
@@ -131,6 +134,7 @@ export class UpdateService {
         this.state.update(current => ({
           ...current,
           phase: 'failed',
+          failure: 'install',
           error: installErrorMessage(error),
         }));
       })

--- a/ui/bootstrapper/src/update_state.rs
+++ b/ui/bootstrapper/src/update_state.rs
@@ -115,6 +115,16 @@ impl UpdatePhase {
     }
 }
 
+// Which attempt the `Failed` phase came from. The phase alone cannot say: a
+// feed that could not be reached and a download that died both land on
+// `Failed`, and the UI has to word them differently.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum UpdateFailure {
+    Check,
+    Install,
+}
+
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DownloadProgress {
@@ -152,6 +162,7 @@ pub(crate) struct UpdateSnapshot {
     pub(crate) download_url: &'static str,
     pub(crate) partial_check: Option<String>,
     pub(crate) error: Option<String>,
+    pub(crate) failure: Option<UpdateFailure>,
     pub(crate) progress: Option<DownloadProgress>,
     pub(crate) last_checked_at: Option<u64>,
 }
@@ -169,6 +180,7 @@ pub(crate) struct UpdateState {
     pub(crate) download_url: &'static str,
     pub(crate) partial_check: Option<String>,
     pub(crate) error: Option<String>,
+    pub(crate) failure: Option<UpdateFailure>,
     pub(crate) progress: Option<DownloadProgress>,
     // Consumed only once the host has actually been told, so a host that is
     // down or unreachable never permanently loses this version's signal - the
@@ -204,6 +216,7 @@ impl UpdateState {
             download_url,
             partial_check: None,
             error: None,
+            failure: None,
             progress: None,
             signalled_version: None,
             last_check_at: None,
@@ -267,6 +280,7 @@ impl UpdateState {
         self.published_at = published_at;
         self.partial_check = partial_check;
         self.error = None;
+        self.failure = None;
         // A completed or failed download from a previous check must not leak
         // its progress into this one - a fresh Available must never carry a
         // stale 100%.
@@ -281,12 +295,14 @@ impl UpdateState {
         self.published_at = None;
         self.partial_check = partial_check;
         self.error = None;
+        self.failure = None;
     }
 
     pub(crate) fn record_check_failed(&mut self, now: u64, error: String) {
         self.last_check_at = Some(now);
         self.phase = UpdatePhase::Failed;
         self.error = Some(error);
+        self.failure = Some(UpdateFailure::Check);
     }
 
     // The single replacement for the old `UPDATE_IN_PROGRESS` static: both the
@@ -302,6 +318,7 @@ impl UpdateState {
         self.phase = UpdatePhase::Downloading;
         self.progress = None;
         self.error = None;
+        self.failure = None;
         true
     }
 
@@ -341,6 +358,7 @@ impl UpdateState {
     pub(crate) fn record_install_failed(&mut self, error: String) {
         self.phase = UpdatePhase::Failed;
         self.error = Some(error);
+        self.failure = Some(UpdateFailure::Install);
     }
 
     pub(crate) fn record_cancelled(&mut self) {
@@ -375,6 +393,7 @@ impl UpdateState {
             download_url: self.download_url,
             partial_check: self.partial_check.clone(),
             error: self.error.clone(),
+            failure: self.failure,
             progress: self.progress.clone(),
             last_checked_at: self.last_check_at,
         }
@@ -706,6 +725,40 @@ mod tests {
             let serialized = serde_json::to_value(phase).unwrap();
             assert_eq!(serialized.as_str(), Some(phase.as_str()));
         }
+    }
+
+    #[test]
+    fn a_failed_check_and_a_failed_download_are_distinguishable() {
+        let mut state = idle_state();
+        state.record_check_failed(1, "feed unreachable".to_string());
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.phase, UpdatePhase::Failed);
+        assert_eq!(snapshot.failure, Some(UpdateFailure::Check));
+        assert!(
+            snapshot.version.is_none(),
+            "a check that never resolved a release must not offer one"
+        );
+
+        let mut state = idle_state();
+        state.record_available(1, "3.1.0".to_string(), None, None, None);
+        assert!(state.try_begin_download());
+        state.record_install_failed("connection reset".to_string());
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.phase, UpdatePhase::Failed);
+        assert_eq!(snapshot.failure, Some(UpdateFailure::Install));
+        assert_eq!(snapshot.version.as_deref(), Some("3.1.0"));
+    }
+
+    #[test]
+    fn a_later_successful_check_clears_the_previous_failure() {
+        let mut state = idle_state();
+        state.record_check_failed(1, "feed unreachable".to_string());
+        state.record_up_to_date(2, None);
+        assert!(state.snapshot().failure.is_none());
+
+        state.record_check_failed(3, "feed unreachable".to_string());
+        state.record_available(4, "3.1.0".to_string(), None, None, None);
+        assert!(state.snapshot().failure.is_none());
     }
 
     #[test]

--- a/ui/bootstrapper/src/updater.rs
+++ b/ui/bootstrapper/src/updater.rs
@@ -1124,6 +1124,7 @@ mod tests {
             download_url: DOWNLOAD_PAGE_URL,
             partial_check: None,
             error: None,
+            failure: None,
             progress: None,
             last_checked_at: None,
         }
@@ -1336,38 +1337,38 @@ mod tests {
 
     #[test]
     fn feed_urls_derive_beta_from_latest() {
-        let feeds =
-            feed_urls_for("https://dev.macro-deck.app/releases/latest-{{target}}.json").unwrap();
+        let feeds = feed_urls_for("https://updater.macro-deck.app/releases/latest-{{target}}.json")
+            .unwrap();
         assert_eq!(
             feeds.stable,
-            "https://dev.macro-deck.app/releases/latest-{{target}}.json"
+            "https://updater.macro-deck.app/releases/latest-{{target}}.json"
         );
         assert_eq!(
             feeds.beta,
-            "https://dev.macro-deck.app/releases/beta-{{target}}.json"
+            "https://updater.macro-deck.app/releases/beta-{{target}}.json"
         );
     }
 
     #[test]
     fn feed_urls_derive_latest_from_beta() {
         let feeds =
-            feed_urls_for("https://dev.macro-deck.app/releases/beta-{{target}}.json").unwrap();
+            feed_urls_for("https://updater.macro-deck.app/releases/beta-{{target}}.json").unwrap();
         assert_eq!(
             feeds.stable,
-            "https://dev.macro-deck.app/releases/latest-{{target}}.json"
+            "https://updater.macro-deck.app/releases/latest-{{target}}.json"
         );
         assert_eq!(
             feeds.beta,
-            "https://dev.macro-deck.app/releases/beta-{{target}}.json"
+            "https://updater.macro-deck.app/releases/beta-{{target}}.json"
         );
     }
 
     #[test]
     fn feed_urls_are_none_for_the_dev_endpoint() {
-        assert!(
-            feed_urls_for("https://dev.macro-deck.app/releases/development-{{target}}.json")
-                .is_none()
-        );
+        assert!(feed_urls_for(
+            "https://updater.macro-deck.app/releases/development-{{target}}.json"
+        )
+        .is_none());
     }
 
     #[test]

--- a/ui/bootstrapper/tauri.conf.json
+++ b/ui/bootstrapper/tauri.conf.json
@@ -38,7 +38,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://dev.macro-deck.app/releases/development-{{target}}.json"
+        "https://updater.macro-deck.app/releases/development-{{target}}.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY1MUI3NjU5QTFBMzkyNzQKUldSMGtxT2hXWFliWlRjK2pUbkI2Q2IrZWlHK0Y4SG5BMUloS0tQb0R3cDBwdVYxTGhFUG5Ub1oK"
     }

--- a/ui/bootstrapper/tests/installer_config.rs
+++ b/ui/bootstrapper/tests/installer_config.rs
@@ -184,7 +184,7 @@ fn development_tauri_config_has_an_isolated_identity() {
     );
     assert_eq!(
         cfg["plugins"]["updater"]["endpoints"][0].as_str(),
-        Some("https://dev.macro-deck.app/releases/development-{{target}}.json")
+        Some("https://updater.macro-deck.app/releases/development-{{target}}.json")
     );
 }
 

--- a/ui/runtime/src/localization/generated/app-strings.ts
+++ b/ui/runtime/src/localization/generated/app-strings.ts
@@ -5820,6 +5820,7 @@ export const AppStrings = {
 		Details: {
 			CancelDownloadAction: 'macrodeck.app:Update.Details.CancelDownloadAction',
 			ChangelogHeading: 'macrodeck.app:Update.Details.ChangelogHeading',
+			CheckFailed: 'macrodeck.app:Update.Details.CheckFailed',
 			CurrentVersion: 'macrodeck.app:Update.Details.CurrentVersion',
 			DownloadFailed: 'macrodeck.app:Update.Details.DownloadFailed',
 			DownloadingStatus: 'macrodeck.app:Update.Details.DownloadingStatus',
@@ -11289,6 +11290,7 @@ export const AppStringsDefaults: Readonly<Record<string, string>> = {
 	'macrodeck.app:UiRender.UnsupportedField': 'This field isn\'t supported by this version of Macro Deck',
 	'macrodeck.app:Update.Details.CancelDownloadAction': 'Cancel download',
 	'macrodeck.app:Update.Details.ChangelogHeading': 'What\'s new',
+	'macrodeck.app:Update.Details.CheckFailed': 'Couldn\'t check for updates. {error}',
 	'macrodeck.app:Update.Details.CurrentVersion': 'You currently have {version}',
 	'macrodeck.app:Update.Details.DownloadFailed': 'The download failed. {error}',
 	'macrodeck.app:Update.Details.DownloadingStatus': 'Downloading… {percent}%',


### PR DESCRIPTION
## Summary

Every built client polls the update feed at dev.macro-deck.app, but the release workflow publishes the
channel manifests to an R2 bucket that is served at updater.macro-deck.app. dev.macro-deck.app now
301-redirects every path to the marketing site, so both feeds a Beta install resolves (latest- and beta-)
return an HTML page, neither manifest parses, and resolve_update reports "could not check for updates on
any feed (stable, beta)". This moves the baked endpoint, the four version-override lines in build.yml and
FEED_BASE_URL to updater.macro-deck.app.

The same report exposed a second defect. record_check_failed and record_install_failed both land on the
Failed phase, and the update modal rendered any Failed phase with the download-failed wording, so a feed
outage read as "The download failed." On top of that versionHeading fell back to currentVersion when no
release had been resolved, so the modal offered the version the user already had. The snapshot now carries
an UpdateFailure discriminator (Check or Install) that every successful transition clears, the modal picks
its message from it, and the version heading and changelog section only render when a release was actually
resolved.

## Testing

- ui/bootstrapper: cargo test (376 pass), cargo fmt --check, cargo clippy --all-targets -- -D warnings.
  Two new cases in update_state.rs cover the discriminator and its clearing on a later successful check.
- ui/angular: ng test --watch=false, 3792 pass. Three new cases in update-modal.component.spec.ts cover the
  check wording, the absent version heading and changelog, and the unchanged download wording.
- ci/scripts: node --test make-update-manifest.test.mjs point-manifests-at-release.test.mjs (27 pass).
- Localization: MACRODECK_UPDATE_GENERATED=1 dotnet test sdk/tests/MacroDeck.Localization.Tests.UnitTests
  (48 pass), which regenerated the checked-in TypeScript catalog.
- Confirmed against the live hosts: updater.macro-deck.app/releases/beta-darwin.json returns 200 with the
  manifest the last release published, while dev.macro-deck.app/releases/beta-darwin.json 301-redirects to
  https://macro-deck.app/. The installed 3.0.0-beta.2 binary carries the dev.macro-deck.app endpoint.

## Notes

This does not rescue clients that are already installed. Every 3.0.0-beta.2 build has dev.macro-deck.app
baked into it and will keep failing exactly as reported until either that host serves the bucket again with
the path preserved, or the user reinstalls. The current redirect drops the path, so it cannot be relied on
as a bridge.

The splash screen still infers the failure kind from whether an install was ever attempted
(UpdateService.installFailed) rather than from the new discriminator. It is left alone here; the reported
symptom is in the modal.

New localization key Update.Details.CheckFailed ships with a translation in all seven languages.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
