### PR TITLE
Publish a widget state transition before the onStateChange flow it triggers

### DIFF
--- a/host/src/MacroDeckHost.Application/Rendering/WidgetStatePublisher.cs
+++ b/host/src/MacroDeckHost.Application/Rendering/WidgetStatePublisher.cs
@@ -5,10 +5,10 @@ using MacroDeckHost.Application.Ui.Transport.Messages.Widgets;
 namespace MacroDeckHost.Application.Rendering;
 
 /// <summary>
-/// The single place a reconciliation result turns into a client push, shared by the background
-/// eval loop and the explicit "Set"/"Cycle Button State" actions - the actions reconcile inline
-/// (so <c>vars.state</c> is committed before they return) but still need the same one push a
-/// background-driven transition gets, not a duplicate and not none.
+/// The single place a reconciliation result turns into a client push. <see cref="WidgetStateReconciler" />
+/// calls this on every reconcile, right after committing the state and before any <c>onStateChange</c>
+/// flow runs, so a client can see what that flow paints while it runs rather than only its end result
+/// (issue #678). Whether a call actually pushes is decided here, not by the caller.
 /// </summary>
 public interface IWidgetStatePublisher
 {

--- a/host/src/MacroDeckHost.Application/Rendering/WidgetStateReconciler.cs
+++ b/host/src/MacroDeckHost.Application/Rendering/WidgetStateReconciler.cs
@@ -52,6 +52,7 @@ public sealed class WidgetStateReconciler : IWidgetStateReconciler
 	private readonly WidgetDerivedStateStore _store;
 	private readonly IVariableService _variableService;
 	private readonly IFlowExecutor _flowExecutor;
+	private readonly IWidgetStatePublisher _publisher;
 	private readonly IFolderCache _folderCache;
 	private readonly IWidgetService _widgetService;
 	private readonly IWidgetDataWriteLock _writeLock;
@@ -65,6 +66,7 @@ public sealed class WidgetStateReconciler : IWidgetStateReconciler
 		WidgetDerivedStateStore store,
 		IVariableService variableService,
 		IFlowExecutor flowExecutor,
+		IWidgetStatePublisher publisher,
 		IFolderCache folderCache,
 		IWidgetService widgetService,
 		IWidgetDataWriteLock writeLock,
@@ -77,6 +79,7 @@ public sealed class WidgetStateReconciler : IWidgetStateReconciler
 		_store = store;
 		_variableService = variableService;
 		_flowExecutor = flowExecutor;
+		_publisher = publisher;
 		_folderCache = folderCache;
 		_widgetService = widgetService;
 		_writeLock = writeLock;
@@ -137,6 +140,20 @@ public sealed class WidgetStateReconciler : IWidgetStateReconciler
 		var transitioned = previous is not null && previous != resolution.StateId;
 		var changed = previous != resolution.StateId;
 
+		var reconciliation = new WidgetStateReconciliation(resolution.StateId,
+			resolution.StateLabel,
+			resolution.States,
+			changed,
+			transitioned,
+			resolution.ProviderSetChanged)
+		{
+			OptimisticState = resolution.OptimisticState
+		};
+
+		// Announced before the flow it triggers, never after: a client that learns the transition only
+		// once the flow finished cannot see anything the flow paints in between (issue #678).
+		await PublishTransition(widgetId, reconciliation, cancellationToken);
+
 		if (transitioned)
 		{
 			var depth = _reconcileDepth.AddOrUpdate(widgetId, 1, static (_, d) => d + 1);
@@ -160,15 +177,29 @@ public sealed class WidgetStateReconciler : IWidgetStateReconciler
 			}
 		}
 
-		return new WidgetStateReconciliation(resolution.StateId,
-			resolution.StateLabel,
-			resolution.States,
-			changed,
-			transitioned,
-			resolution.ProviderSetChanged)
+		return reconciliation;
+	}
+
+	// Called on every reconcile, gated inside PublishIfChanged. An unreachable client must not cancel
+	// the flow, so a failing push only logs; a cancelled reconcile still stops before firing one.
+	private async Task PublishTransition(Guid widgetId,
+		WidgetStateReconciliation reconciliation,
+		CancellationToken cancellationToken)
+	{
+		try
 		{
-			OptimisticState = resolution.OptimisticState
-		};
+			await _publisher.PublishIfChanged(widgetId, reconciliation, cancellationToken);
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+			throw;
+		}
+		catch (Exception exception) when (exception is not OutOfMemoryException)
+		{
+			_logger.Warning(exception,
+				"Failed to publish the state transition for widget {WidgetId}; continuing with its onStateChange flow",
+				widgetId);
+		}
 	}
 
 	private bool IsCurrent(WidgetStateResolution resolution)

--- a/host/src/MacroDeckHost.Application/Widgets/ActionButtonStateService.cs
+++ b/host/src/MacroDeckHost.Application/Widgets/ActionButtonStateService.cs
@@ -27,20 +27,17 @@ public sealed class ActionButtonStateService : IActionButtonStateService
 	private readonly IWidgetDataWriteLock _writeLock;
 	private readonly IWidgetService _widgetService;
 	private readonly IWidgetStateReconciler _reconciler;
-	private readonly IWidgetStatePublisher _publisher;
 
 	public ActionButtonStateService(
 		IFolderCache folderCache,
 		IWidgetDataWriteLock writeLock,
 		IWidgetService widgetService,
-		IWidgetStateReconciler reconciler,
-		IWidgetStatePublisher publisher)
+		IWidgetStateReconciler reconciler)
 	{
 		_folderCache = folderCache;
 		_writeLock = writeLock;
 		_widgetService = widgetService;
 		_reconciler = reconciler;
-		_publisher = publisher;
 	}
 
 	public Task<WidgetStateWriteResult> SetAsync(Guid widgetId,
@@ -132,8 +129,7 @@ public sealed class ActionButtonStateService : IActionButtonStateService
 		// lock, and reconciling while still holding it would deadlock that action against this call.
 		// Reconciling inline (not just enqueuing) is what guarantees vars.state is committed, and the
 		// flow has already run, before this call returns.
-		var reconciliation = await _reconciler.Reconcile(widgetId, cancellationToken);
-		await _publisher.PublishIfChanged(widgetId, reconciliation, cancellationToken);
+		await _reconciler.Reconcile(widgetId, cancellationToken);
 		return WidgetStateWriteResult.Succeeded(newStateId);
 	}
 

--- a/host/src/MacroDeckHost.Infrastructure/BackgroundServices/WidgetStateEvalBackgroundService.cs
+++ b/host/src/MacroDeckHost.Infrastructure/BackgroundServices/WidgetStateEvalBackgroundService.cs
@@ -23,7 +23,6 @@ public sealed class WidgetStateEvalBackgroundService : HostReadyBackgroundServic
 
 	private readonly WidgetStateEvalChannel _queue;
 	private readonly IServiceScopeFactory _scopeFactory;
-	private readonly IWidgetStatePublisher _publisher;
 	private readonly WidgetStateSubscriptionTracker _subscriptions;
 	private readonly IFolderCache _folderCache;
 	private readonly IWidgetVariableIndex _variableIndex;
@@ -37,7 +36,6 @@ public sealed class WidgetStateEvalBackgroundService : HostReadyBackgroundServic
 		IHostApplicationLifetime lifetime,
 		WidgetStateEvalChannel queue,
 		IServiceScopeFactory scopeFactory,
-		IWidgetStatePublisher publisher,
 		WidgetStateSubscriptionTracker subscriptions,
 		IFolderCache folderCache,
 		IWidgetVariableIndex variableIndex,
@@ -48,7 +46,6 @@ public sealed class WidgetStateEvalBackgroundService : HostReadyBackgroundServic
 	{
 		_queue = queue;
 		_scopeFactory = scopeFactory;
-		_publisher = publisher;
 		_subscriptions = subscriptions;
 		_folderCache = folderCache;
 		_variableIndex = variableIndex;
@@ -199,7 +196,6 @@ public sealed class WidgetStateEvalBackgroundService : HostReadyBackgroundServic
 		using var scope = _scopeFactory.CreateScope();
 		var reconciler = scope.ServiceProvider.GetRequiredService<IWidgetStateReconciler>();
 
-		var result = await reconciler.Reconcile(widgetId, cancellationToken);
-		await _publisher.PublishIfChanged(widgetId, result, cancellationToken);
+		await reconciler.Reconcile(widgetId, cancellationToken);
 	}
 }

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Events/WidgetBatchNotificationFanOutTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Events/WidgetBatchNotificationFanOutTests.cs
@@ -95,6 +95,7 @@ public class WidgetBatchNotificationFanOutTests
 			_derivedState,
 			_variableScope.ServiceProvider.GetRequiredService<IVariableService>(),
 			new NoOpFlowExecutor(),
+			new NoOpWidgetStatePublisher(),
 			_folderCache,
 			new NotSupportedWidgetService(),
 			new WidgetDataWriteLock(),

--- a/host/tests/MacroDeckHost.Tests.UnitTests/ExecuteActionButtonTriggerRequestMessageHandlerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/ExecuteActionButtonTriggerRequestMessageHandlerTests.cs
@@ -881,5 +881,4 @@ public class ExecuteActionButtonTriggerRequestMessageHandlerTests
 				MatchedFlows = 0
 			});
 	}
-
 }

--- a/host/tests/MacroDeckHost.Tests.UnitTests/ExecuteActionButtonTriggerRequestMessageHandlerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/ExecuteActionButtonTriggerRequestMessageHandlerTests.cs
@@ -283,6 +283,7 @@ public class ExecuteActionButtonTriggerRequestMessageHandlerTests
 			derivedStateStore,
 			vars,
 			new NoOpFlowExecutor(),
+			new NoOpWidgetStatePublisher(),
 			folders,
 			widgets,
 			writeLock,
@@ -290,7 +291,7 @@ public class ExecuteActionButtonTriggerRequestMessageHandlerTests
 			TestLocalization.Resolver,
 			Serilog.Log.Logger);
 
-		return new ActionButtonStateService(folders, writeLock, widgets, reconciler, new NoOpPublisher());
+		return new ActionButtonStateService(folders, writeLock, widgets, reconciler);
 	}
 
 	[TearDown]
@@ -881,11 +882,4 @@ public class ExecuteActionButtonTriggerRequestMessageHandlerTests
 			});
 	}
 
-	private sealed class NoOpPublisher : IWidgetStatePublisher
-	{
-		public Task PublishIfChanged(Guid widgetId,
-			WidgetStateReconciliation result,
-			CancellationToken cancellationToken = default)
-			=> Task.CompletedTask;
-	}
 }

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Rendering/WidgetStateReconcilerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Rendering/WidgetStateReconcilerTests.cs
@@ -29,29 +29,32 @@ public class WidgetStateReconcilerTests
 	};
 
 	private static (WidgetStateReconciler Reconciler, RecordingFlowExecutor Flow, RecordingVariableService Vars,
-		WidgetDerivedStateStore Store) Build(WidgetEntity widget, params string?[] resolvedStateIds)
+		WidgetDerivedStateStore Store, RecordingStatePublisher Publisher) Build(WidgetEntity widget,
+		params string?[] resolvedStateIds)
 	{
 		var store = new WidgetDerivedStateStore();
 		var flow = new RecordingFlowExecutor();
 		var vars = new RecordingVariableService();
+		var publisher = new RecordingStatePublisher();
 		var reconciler = new WidgetStateReconciler(new QueuedStateService(resolvedStateIds),
 			store,
 			vars,
 			flow,
+			publisher,
 			new FakeFolderCache(widget),
 			new NotSupportedWidgetService(),
 			new WidgetDataWriteLock(),
 			TestLocalization.Preferences,
 			TestLocalization.Resolver,
 			Serilog.Log.Logger);
-		return (reconciler, flow, vars, store);
+		return (reconciler, flow, vars, store, publisher);
 	}
 
 	[Test]
 	public async Task FirstEvaluation_seeds_var_without_firing_flow()
 	{
 		var widget = BoundButton(Guid.NewGuid());
-		var (reconciler, flow, vars, _) = Build(widget, "on");
+		var (reconciler, flow, vars, _, _) = Build(widget, "on");
 
 		var result = await reconciler.Reconcile(widget.Id);
 
@@ -73,7 +76,7 @@ public class WidgetStateReconcilerTests
 	public async Task Transition_fires_onStateChange_and_updates_var()
 	{
 		var widget = BoundButton(Guid.NewGuid());
-		var (reconciler, flow, vars, _) = Build(widget, "off", "on");
+		var (reconciler, flow, vars, _, _) = Build(widget, "off", "on");
 
 		await reconciler.Reconcile(widget.Id); // seed = off
 		var result = await reconciler.Reconcile(widget.Id); // flip to on
@@ -93,7 +96,7 @@ public class WidgetStateReconcilerTests
 	public async Task Transition_marks_its_flow_host_originated_so_it_is_not_gated_while_locked()
 	{
 		var widget = BoundButton(Guid.NewGuid());
-		var (reconciler, flow, _, _) = Build(widget, "off", "on");
+		var (reconciler, flow, _, _, _) = Build(widget, "off", "on");
 
 		await reconciler.Reconcile(widget.Id); // seed = off
 		await reconciler.Reconcile(widget.Id); // flip to on
@@ -105,7 +108,7 @@ public class WidgetStateReconcilerTests
 	public async Task UnchangedValue_does_not_fire_flow_or_report_changed()
 	{
 		var widget = BoundButton(Guid.NewGuid());
-		var (reconciler, flow, _, _) = Build(widget, "on", "on");
+		var (reconciler, flow, _, _, _) = Build(widget, "on", "on");
 
 		await reconciler.Reconcile(widget.Id); // seed = on
 		var result = await reconciler.Reconcile(widget.Id); // still on
@@ -122,7 +125,7 @@ public class WidgetStateReconcilerTests
 	public async Task Unresolvable_widget_returns_none_and_forgets_state()
 	{
 		var widget = BoundButton(Guid.NewGuid());
-		var (reconciler, flow, _, store) = Build(widget, "on", null);
+		var (reconciler, flow, _, store, _) = Build(widget, "on", null);
 
 		await reconciler.Reconcile(widget.Id); // seed = on
 		var result = await reconciler.Reconcile(widget.Id); // now unbound / unresolvable
@@ -164,6 +167,7 @@ public class WidgetStateReconcilerTests
 			derivedStates,
 			vars,
 			flow,
+			new NoOpWidgetStatePublisher(),
 			new FakeFolderCache(widget),
 			new NotSupportedWidgetService(),
 			new WidgetDataWriteLock(),
@@ -189,7 +193,7 @@ public class WidgetStateReconcilerTests
 	public async Task StateTransition_FiresOnStateChangeOncePerActualTransition()
 	{
 		var widget = BoundButton(Guid.NewGuid());
-		var (reconciler, flow, _, _) = Build(widget, "off", "on", "on", "off"); // cpu: 50, 95, 96, 40
+		var (reconciler, flow, _, _, _) = Build(widget, "off", "on", "on", "off"); // cpu: 50, 95, 96, 40
 
 		foreach (var _ in Enumerable.Range(0, 4))
 		{
@@ -245,6 +249,7 @@ public class WidgetStateReconcilerTests
 			new WidgetDerivedStateStore(),
 			variableService,
 			flow,
+			new NoOpWidgetStatePublisher(),
 			folderCache,
 			new NotSupportedWidgetService(),
 			new WidgetDataWriteLock(),
@@ -263,6 +268,114 @@ public class WidgetStateReconcilerTests
 
 		Assert.That(finished, Is.SameAs(ticks), "the reconciler hung instead of settling");
 		Assert.That(flow.Triggers.Count, Is.LessThanOrEqualTo(1), "at most one onStateChange across 5 ticks");
+	}
+
+	// Issue #678: a client that is told about the transition only once the flow has finished cannot see
+	// anything the flow paints while it runs - a Set Border it also turns off again is invisible.
+	[Test]
+	public async Task Transition_IsPublishedBeforeItsOnStateChangeFlowRuns()
+	{
+		var widget = BoundButton(Guid.NewGuid());
+		var (reconciler, flow, _, _, publisher) = Build(widget, "off", "on");
+		var publishedWhenFlowStarted = -1;
+		flow.OnExecuting = () =>
+		{
+			publishedWhenFlowStarted = publisher.Published.Count;
+			return Task.CompletedTask;
+		};
+
+		await reconciler.Reconcile(widget.Id); // seed = off
+		await reconciler.Reconcile(widget.Id); // flip to on
+
+		Assert.That(publishedWhenFlowStarted, Is.EqualTo(2), "the transition was still unpublished when its flow ran");
+		Assert.That(publisher.Published[^1].StateId, Is.EqualTo("on"));
+	}
+
+	[Test]
+	public async Task Reconcile_DoesNotReturnUntilItsOnStateChangeFlowHasFinished()
+	{
+		var widget = BoundButton(Guid.NewGuid());
+		var (reconciler, flow, _, _, _) = Build(widget, "off", "on");
+		var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		flow.OnExecuting = () => release.Task;
+
+		await reconciler.Reconcile(widget.Id); // seed = off
+		var reconcile = reconciler.Reconcile(widget.Id);
+
+		Assert.That(await Task.WhenAny(reconcile, Task.Delay(200)), Is.Not.SameAs(reconcile),
+			"Set/Cycle Button State rely on the flow having run before the call returns");
+		release.SetResult();
+		Assert.That((await reconcile).Transitioned, Is.True);
+	}
+
+	// The seed is a change without a transition, and it is the one the Changed gate exists for: it must
+	// still be published even though it fires no flow.
+	[Test]
+	public async Task Seed_IsPublishedAndFiresNoFlow()
+	{
+		var widget = BoundButton(Guid.NewGuid());
+		var (reconciler, flow, _, _, publisher) = Build(widget, "on");
+
+		await reconciler.Reconcile(widget.Id);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(publisher.Published.Single().Changed, Is.True);
+			Assert.That(publisher.Published.Single().Transitioned, Is.False);
+			Assert.That(flow.Triggers, Is.Empty);
+		});
+	}
+
+	// The push travels an unisolated signal multicast and a real socket write. Neither is allowed to
+	// stop the flow: an unreachable client must not cancel host business logic.
+	[Test]
+	public async Task PublishFailure_StillLeavesTheOnStateChangeFlowFired()
+	{
+		var widget = BoundButton(Guid.NewGuid());
+		var (reconciler, flow, _, _, publisher) = Build(widget, "off", "on");
+		publisher.OnPublishing = () => throw new InvalidOperationException("a session handler threw");
+
+		await reconciler.Reconcile(widget.Id); // seed = off
+		var result = await reconciler.Reconcile(widget.Id); // flip to on
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(flow.Triggers, Is.EqualTo(new[] { "onStateChange" }));
+			Assert.That(result.StateId, Is.EqualTo("on"));
+		});
+	}
+
+	private sealed class RecordingStatePublisher : IWidgetStatePublisher
+	{
+		private readonly List<WidgetStateReconciliation> _published = [];
+
+		public List<WidgetStateReconciliation> Published
+		{
+			get
+			{
+				lock (_published)
+				{
+					return _published.ToList();
+				}
+			}
+		}
+
+		public Func<Task>? OnPublishing { get; set; }
+
+		public async Task PublishIfChanged(Guid widgetId,
+			WidgetStateReconciliation result,
+			CancellationToken cancellationToken = default)
+		{
+			lock (_published)
+			{
+				_published.Add(result);
+			}
+
+			if (OnPublishing is { } callback)
+			{
+				await callback();
+			}
+		}
 	}
 
 	private sealed class QueuedStateService : IWidgetStateService
@@ -363,16 +476,25 @@ public class WidgetStateReconcilerTests
 
 		public List<FlowExecutionRequest> Requests { get; } = [];
 
-		public Task<FlowExecutionResult> ExecuteAsync(FlowExecutionRequest request, CancellationToken cancellationToken)
+		public Func<Task>? OnExecuting { get; set; }
+
+		public async Task<FlowExecutionResult> ExecuteAsync(FlowExecutionRequest request,
+			CancellationToken cancellationToken)
 		{
 			Triggers.Add(request.Trigger.Value);
 			Requests.Add(request);
-			return Task.FromResult(new FlowExecutionResult
+
+			if (OnExecuting is { } callback)
+			{
+				await callback();
+			}
+
+			return new FlowExecutionResult
 			{
 				ExecutionId = Guid.NewGuid(),
 				Status = FlowExecutionStatus.Succeeded,
 				MatchedFlows = 1
-			});
+			};
 		}
 	}
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Rendering/WidgetStateReconcilerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Rendering/WidgetStateReconcilerTests.cs
@@ -30,7 +30,7 @@ public class WidgetStateReconcilerTests
 
 	private static (WidgetStateReconciler Reconciler, RecordingFlowExecutor Flow, RecordingVariableService Vars,
 		WidgetDerivedStateStore Store, RecordingStatePublisher Publisher) Build(WidgetEntity widget,
-		params string?[] resolvedStateIds)
+			params string?[] resolvedStateIds)
 	{
 		var store = new WidgetDerivedStateStore();
 		var flow = new RecordingFlowExecutor();
@@ -302,7 +302,8 @@ public class WidgetStateReconcilerTests
 		await reconciler.Reconcile(widget.Id); // seed = off
 		var reconcile = reconciler.Reconcile(widget.Id);
 
-		Assert.That(await Task.WhenAny(reconcile, Task.Delay(200)), Is.Not.SameAs(reconcile),
+		Assert.That(await Task.WhenAny(reconcile, Task.Delay(200)),
+			Is.Not.SameAs(reconcile),
 			"Set/Cycle Button State rely on the flow having run before the call returns");
 		release.SetResult();
 		Assert.That((await reconcile).Transitioned, Is.True);

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Rendering/WidgetStateVariablesAndPushTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Rendering/WidgetStateVariablesAndPushTests.cs
@@ -97,6 +97,7 @@ public class WidgetStateVariablesAndPushTests
 			new WidgetDerivedStateStore(),
 			harness.Service,
 			new NoOpFlowExecutor(),
+			new NoOpWidgetStatePublisher(),
 			folderCache,
 			new NotSupportedWidgetService(),
 			new WidgetDataWriteLock(),

--- a/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/NoOpWidgetStatePublisher.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/NoOpWidgetStatePublisher.cs
@@ -1,0 +1,11 @@
+using MacroDeckHost.Application.Rendering;
+
+namespace MacroDeckHost.Tests.UnitTests.TestSupport;
+
+public sealed class NoOpWidgetStatePublisher : IWidgetStatePublisher
+{
+	public Task PublishIfChanged(Guid widgetId,
+		WidgetStateReconciliation result,
+		CancellationToken cancellationToken = default)
+		=> Task.CompletedTask;
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/ActionButtonStateServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/ActionButtonStateServiceTests.cs
@@ -190,7 +190,8 @@ public class ActionButtonStateServiceTests
 		var write = fixture.Service.SetAsync(fixture.WidgetId, "on");
 		await flowEntered.Task;
 
-		Assert.That(callsSeenInsideTheFlow, Is.EqualTo(publishedBeforeTheFlow + 1),
+		Assert.That(callsSeenInsideTheFlow,
+			Is.EqualTo(publishedBeforeTheFlow + 1),
 			"the transition was still unpublished while its own flow was running");
 
 		release.SetResult();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/ActionButtonStateServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/ActionButtonStateServiceTests.cs
@@ -165,6 +165,38 @@ public class ActionButtonStateServiceTests
 		});
 	}
 
+	// Issue #678: the transition has to reach clients while its onStateChange flow is still running.
+	// Published only after the flow returned, anything that flow paints and then clears again - a
+	// Set Border with a Wait and a Set Border off - is never visible on any client.
+	[Test]
+	public async Task StateWrite_IsPublishedWhileItsOnStateChangeFlowIsStillRunning()
+	{
+		var fixture = new Fixture(TwoStates);
+
+		// Seed the derived-state store so the next write is a real transition, not the initial seed.
+		Assert.That((await fixture.Service.SetAsync(fixture.WidgetId, "off")).Success, Is.True);
+		var publishedBeforeTheFlow = fixture.Publisher.Calls;
+
+		var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var flowEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var callsSeenInsideTheFlow = -1;
+		fixture.Flow.OnFlowExecuting = () =>
+		{
+			callsSeenInsideTheFlow = fixture.Publisher.Calls;
+			flowEntered.SetResult();
+			return release.Task;
+		};
+
+		var write = fixture.Service.SetAsync(fixture.WidgetId, "on");
+		await flowEntered.Task;
+
+		Assert.That(callsSeenInsideTheFlow, Is.EqualTo(publishedBeforeTheFlow + 1),
+			"the transition was still unpublished while its own flow was running");
+
+		release.SetResult();
+		Assert.That((await write).Success, Is.True);
+	}
+
 	// Carried over from UpdateWidgetDataRuntimeGuardTests.AFlowThatWritesTheSameWidget_DoesNotDeadlockThePress:
 	// the reconciler used to run while ActionButtonStateService still held the per-widget write lock, so
 	// an onStateChange flow containing a widget action targeting this same button deadlocked against
@@ -228,6 +260,7 @@ public class ActionButtonStateServiceTests
 				new WidgetDerivedStateStore(),
 				Vars,
 				Flow,
+				Publisher,
 				folderCache,
 				Widgets,
 				writeLock,
@@ -235,7 +268,7 @@ public class ActionButtonStateServiceTests
 				TestLocalization.Resolver,
 				Serilog.Log.Logger);
 
-			Service = new ActionButtonStateService(folderCache, writeLock, Widgets, reconciler, Publisher);
+			Service = new ActionButtonStateService(folderCache, writeLock, Widgets, reconciler);
 		}
 
 		public Guid WidgetId { get; }


### PR DESCRIPTION
Closes #678

## Summary

A widget's state transition was announced to clients only after the onStateChange flow it triggers had
finished. WidgetStateReconciler.Reconcile committed the new state and then awaited the whole flow
before returning, and both callers published only afterwards, so every session except the one that
received the press stayed on the old state for the flow's entire duration.

An Action Button renders its border from the state it is currently showing. A flow of Set Border,
Wait 2000, Set Border off therefore wrote a border onto a state no client was rendering yet, and by
the time the transition was announced the border had already been set back to off. The ring was never
visible, and the tile appeared to update only once the actions had finished, which is exactly what the
issue reports.

The transition is now published inside WidgetStateReconciler at the moment it is committed, before
FireStateChange runs. IWidgetStatePublisher loses its two coordinated call sites and keeps one, which
is what its own summary already claimed it was. Exactly one push per transition, same payload, same
group, only earlier.

The push travels an unisolated signal multicast and a real socket write, neither of which was
previously on the path to the flow, so it is wrapped in a try/catch: an unreachable client logs a
warning and the flow still runs. A cancelled reconcile still stops before firing a flow.

Two smaller consequences, both intended. A flow that immediately moves the state back now produces two
pushes instead of one coalesced one, which is the point: the intermediate state is what was invisible.
And a publish failure no longer fails Set Button State, since the state write itself did succeed.

## Testing

Automated: dotnet build MacroDeck.slnx -c Release -warnaserror is clean, and dotnet test
MacroDeck.slnx -c Release passes in full, including the host suite, the conformance suite and the
plugin contract tests. Five tests were added covering publish-before-flow at the reconciler and at the
ActionButtonStateService caller, that Reconcile still does not return until the flow has finished, that
the seed is still published and fires no flow, and that a throwing state-signal subscriber still leaves
the flow fired. Both ordering tests were confirmed red by temporarily moving the publish back after the
flow.

Runtime, against a running host with the real web client, measured on the host's UI WebSocket and in a
visible browser. The issue's scenario is acting in one client and watching another, so the trigger was
fired from outside the observing session; it was measured both before and after by temporarily
restoring the defect in the host.

Before: one change at +2098ms, and the comet ring never appeared at all.
After: state change at +19ms, comet ring at +37ms, ring removed at +2036ms.

For a state-mapping-bound button the host emitted a single patch at +2226ms carrying no borderStyle;
it now emits three, at +233ms with the state change, +258ms with borderStyle comet, and +2272ms
removing it. A press issued by the observing session itself, which already worked, is unchanged.

## Notes

Issue #682, no border animation in the web client, is deliberately not addressed here. While
reproducing this one I confirmed that widget-border.css is shipped to the web client, that a
statically configured comet border renders and animates there, and that all eight border styles render
correctly in Firefox. #682 needs its own reproduction rather than a guess folded into this fix.

WidgetStateEvalBackgroundService.ConsumeQueue processes widgets serially, so a long onStateChange flow
still delays other widgets' state evaluation. That is pre-existing and out of scope here.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
