### PR TITLE
Report an oversized UI message, do not abort

### DIFF
--- a/host/src/MacroDeckHost/Ui/UiWebSocketEndpoint.cs
+++ b/host/src/MacroDeckHost/Ui/UiWebSocketEndpoint.cs
@@ -3,6 +3,8 @@ using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading.Channels;
 using MacroDeckHost.WebSockets;
+using Serilog;
+using ILogger = Serilog.ILogger;
 
 namespace MacroDeckHost.Ui;
 
@@ -23,7 +25,12 @@ public sealed class UiWebSocketEndpoint(
 	TimeProvider timeProvider)
 {
 	private const int QueueLimit = 256;
+
+	// Reported to the client when an outbound envelope will not fit the protocol's size limit.
+	internal const string OversizedCode = "message_too_large";
+
 	private static readonly TimeSpan SendDeadline = TimeSpan.FromSeconds(30);
+	private static readonly ILogger _logger = Log.ForContext<UiWebSocketEndpoint>();
 
 	public async Task HandleAsync(HttpContext context)
 	{
@@ -310,7 +317,7 @@ public sealed class UiWebSocketEndpoint(
 
 	private static bool ValidId(string? value) => value is null or { Length: <= 128 };
 
-	private static async Task WriteAsync(WebSocket socket,
+	internal static async Task WriteAsync(WebSocket socket,
 		ChannelReader<UiWebSocketEnvelope> reader,
 		CancellationTokenSource cancellation,
 		TimeProvider timeProvider)
@@ -322,7 +329,13 @@ public sealed class UiWebSocketEndpoint(
 				var bytes = JsonSerializer.SerializeToUtf8Bytes(envelope, UiWebSocketProtocol.Json);
 				if (bytes.Length > UiWebSocketProtocol.MaxMessageBytes)
 				{
-					throw new JsonException("The outbound UI WebSocket message exceeded the size limit.");
+					if (await ReportOversized(socket, envelope, bytes.Length, timeProvider, cancellation))
+					{
+						continue;
+					}
+
+					cancellation.Cancel();
+					return;
 				}
 
 				await WebSocketMessageIO.SendTextAsync(socket, bytes, SendDeadline, timeProvider, cancellation.Token);
@@ -336,6 +349,47 @@ public sealed class UiWebSocketEndpoint(
 			cancellation.Cancel();
 			socket.Abort();
 		}
+	}
+
+	// Reports an envelope too large to send and says whether the session may continue. This used to abort
+	// the socket silently, leaving a client waiting forever for a message it was never told was dropped.
+	private static async Task<bool> ReportOversized(WebSocket socket,
+		UiWebSocketEnvelope envelope,
+		int size,
+		TimeProvider timeProvider,
+		CancellationTokenSource cancellation)
+	{
+		_logger.Error(
+			"Outbound UI message {Kind}/{Type} is {Size} bytes, over the {Limit} byte limit, and was not sent",
+			envelope.Kind,
+			envelope.Type ?? "-",
+			size,
+			UiWebSocketProtocol.MaxMessageBytes);
+
+		// Only a correlated envelope can be reported without ending the session: a client matches an error
+		// to its pending request by correlationId and ignores one carrying none (websocket-transport.ts).
+		if (envelope.CorrelationId is not null)
+		{
+			// Built here rather than through Error, which reads the id of an inbound request: what
+			// correlates an outbound envelope to that request is its own CorrelationId.
+			var error = new UiWebSocketEnvelope(UiWebSocketProtocol.Version,
+				"error",
+				envelope.Type,
+				null,
+				envelope.CorrelationId,
+				null,
+				new UiWebSocketError(OversizedCode));
+
+			var bytes = JsonSerializer.SerializeToUtf8Bytes(error, UiWebSocketProtocol.Json);
+			if (bytes.Length <= UiWebSocketProtocol.MaxMessageBytes)
+			{
+				await WebSocketMessageIO.SendTextAsync(socket, bytes, SendDeadline, timeProvider, cancellation.Token);
+				return true;
+			}
+		}
+
+		await CloseAsync(socket, WebSocketCloseStatus.MessageTooBig, "Message too large", CancellationToken.None);
+		return false;
 	}
 
 	private async Task HeartbeatAsync(WebSocket socket,

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Ui/UiWebSocketOversizedMessageTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Ui/UiWebSocketOversizedMessageTests.cs
@@ -1,0 +1,186 @@
+using System.Net.WebSockets;
+using System.Text.Json;
+using System.Threading.Channels;
+using MacroDeckHost.Ui;
+
+namespace MacroDeckHost.Tests.UnitTests.Ui;
+
+/// <summary>
+/// An outbound envelope over the protocol's size limit used to abort the socket with no error frame and
+/// no close reason, so a client waited forever for a message nobody told it had been dropped. Whatever
+/// the cause of the oversize, the failure has to reach the client and the log.
+/// </summary>
+[TestFixture]
+public sealed class UiWebSocketOversizedMessageTests
+{
+	[Test]
+	public async Task An_oversized_response_is_reported_to_the_request_that_asked_for_it()
+	{
+		var socket = new RecordingWebSocket();
+		var channel = Channel.CreateUnbounded<UiWebSocketEnvelope>();
+		using var cancellation = new CancellationTokenSource();
+		channel.Writer.TryWrite(Oversized("response", correlationId: "request-1"));
+		channel.Writer.TryComplete();
+
+		await UiWebSocketEndpoint.WriteAsync(socket, channel.Reader, cancellation, TimeProvider.System);
+
+		var sent = socket.Sent.Select(Read).ToList();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(sent, Has.Count.EqualTo(1), "the oversized envelope must not be sent, its failure must");
+			Assert.That(sent[0].Kind, Is.EqualTo("error"));
+			Assert.That(sent[0].CorrelationId,
+				Is.EqualTo("request-1"),
+				"a client matches an error to its pending request by correlation id, so an uncorrelated one is lost");
+			Assert.That(sent[0].Error!.Code, Is.EqualTo(UiWebSocketEndpoint.OversizedCode));
+			Assert.That(socket.Aborted, Is.False, "the session must not die over one message it could report");
+		});
+	}
+
+	[Test]
+	public async Task A_session_survives_an_oversized_response_and_keeps_sending()
+	{
+		var socket = new RecordingWebSocket();
+		var channel = Channel.CreateUnbounded<UiWebSocketEnvelope>();
+		using var cancellation = new CancellationTokenSource();
+		channel.Writer.TryWrite(Oversized("response", correlationId: "request-1"));
+		channel.Writer.TryWrite(new UiWebSocketEnvelope(UiWebSocketProtocol.Version,
+			"message",
+			"AfterTheFailure",
+			null,
+			null,
+			"small",
+			null));
+		channel.Writer.TryComplete();
+
+		await UiWebSocketEndpoint.WriteAsync(socket, channel.Reader, cancellation, TimeProvider.System);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(socket.Sent.Select(Read).Select(envelope => envelope.Kind),
+				Is.EqualTo(new[] { "error", "message" }),
+				"the failure is reported, then the connection carries on with the next message");
+			Assert.That(cancellation.IsCancellationRequested, Is.False);
+		});
+	}
+
+	// A pushed message carries no correlation id, so an error frame would be dropped by the client and the
+	// drop would be as silent as the abort was. Closing with a reason is what a client can actually see.
+	[Test]
+	public async Task An_oversized_pushed_message_closes_the_session_with_a_reason()
+	{
+		var socket = new RecordingWebSocket();
+		var channel = Channel.CreateUnbounded<UiWebSocketEnvelope>();
+		using var cancellation = new CancellationTokenSource();
+		channel.Writer.TryWrite(Oversized("message", correlationId: null));
+		channel.Writer.TryComplete();
+
+		await UiWebSocketEndpoint.WriteAsync(socket, channel.Reader, cancellation, TimeProvider.System);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(socket.Sent, Is.Empty);
+			Assert.That(socket.ClosedWith, Is.EqualTo(WebSocketCloseStatus.MessageTooBig));
+			Assert.That(socket.CloseDescription, Is.Not.Null.And.Not.Empty, "a close with no reason explains nothing");
+			Assert.That(socket.Aborted, Is.False, "an abort gives the client no close frame to read a reason from");
+			Assert.That(cancellation.IsCancellationRequested, Is.True, "the rest of the connection has to wind down");
+		});
+	}
+
+	[Test]
+	public async Task A_message_within_the_limit_is_still_sent_untouched()
+	{
+		var socket = new RecordingWebSocket();
+		var channel = Channel.CreateUnbounded<UiWebSocketEnvelope>();
+		using var cancellation = new CancellationTokenSource();
+		channel.Writer.TryWrite(new UiWebSocketEnvelope(UiWebSocketProtocol.Version,
+			"message",
+			"Notice",
+			null,
+			null,
+			"payload",
+			null));
+		channel.Writer.TryComplete();
+
+		await UiWebSocketEndpoint.WriteAsync(socket, channel.Reader, cancellation, TimeProvider.System);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(socket.Sent.Select(Read).Select(envelope => envelope.Type), Is.EqualTo(new[] { "Notice" }));
+			Assert.That(socket.ClosedWith, Is.Null);
+			Assert.That(socket.Aborted, Is.False);
+		});
+	}
+
+	private static UiWebSocketEnvelope Oversized(string kind, string? correlationId)
+		=> new(UiWebSocketProtocol.Version,
+			kind,
+			"Big",
+			null,
+			correlationId,
+			new string('x', UiWebSocketProtocol.MaxMessageBytes + 1),
+			null);
+
+	private static UiWebSocketEnvelope Read(byte[] bytes)
+		=> JsonSerializer.Deserialize<UiWebSocketEnvelope>(bytes, UiWebSocketProtocol.Json)!;
+
+	private sealed class RecordingWebSocket : WebSocket
+	{
+		private WebSocketState _state = WebSocketState.Open;
+
+		public List<byte[]> Sent { get; } = [];
+
+		public WebSocketCloseStatus? ClosedWith { get; private set; }
+
+		public string? CloseDescription { get; private set; }
+
+		public bool Aborted { get; private set; }
+
+		public override WebSocketCloseStatus? CloseStatus => ClosedWith;
+
+		public override string? CloseStatusDescription => CloseDescription;
+
+		public override WebSocketState State => _state;
+
+		public override string? SubProtocol => UiWebSocketProtocol.SubProtocol;
+
+		public override void Abort()
+		{
+			Aborted = true;
+			_state = WebSocketState.Aborted;
+		}
+
+		public override Task CloseAsync(WebSocketCloseStatus closeStatus,
+			string? statusDescription,
+			CancellationToken cancellationToken)
+			=> CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
+
+		public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus,
+			string? statusDescription,
+			CancellationToken cancellationToken)
+		{
+			ClosedWith = closeStatus;
+			CloseDescription = statusDescription;
+			_state = WebSocketState.CloseSent;
+			return Task.CompletedTask;
+		}
+
+		public override void Dispose()
+		{
+		}
+
+		public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer,
+			CancellationToken cancellationToken)
+			=> throw new NotSupportedException();
+
+		public override Task SendAsync(ArraySegment<byte> buffer,
+			WebSocketMessageType messageType,
+			bool endOfMessage,
+			CancellationToken cancellationToken)
+		{
+			Sent.Add(buffer.ToArray());
+			return Task.CompletedTask;
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #673 and #685. There is no separate issue for this one.

## Summary

When an outbound UI WebSocket envelope exceeded the 256 KB protocol limit, the write loop threw and
the surrounding catch called socket.Abort(). The session died with no error frame, no close reason and
no log line, so a client waited forever for a message nobody told it had been dropped, and the host
recorded nothing about it either. That is how an Action Button with 400 states left the desktop editor
sitting on "Loading editor..." indefinitely: the host was idle, every REST call answered, and the tree
simply never arrived.

The size check now reports the failure instead of aborting. What it can do depends on the envelope,
because the client matches an error to a pending request by correlation id and ignores an error that
carries none, see ui/runtime/src/protocol/websocket-transport.ts.

A correlated envelope, meaning a response to a request, gets an error envelope with the code
message_too_large. The client's pending request rejects with a real reason and the connection stays up:
one request fails rather than the whole UI session.

An uncorrelated envelope, meaning any pushed message, cannot be reported that way, since an error frame
without a correlation id is dropped by the client and the drop would be as silent as the abort was. That
closes the socket with status 1009 MessageTooBig and a reason, which is a failure the client can
actually see and act on.

Both paths log the kind, type, size and limit at error level. The class had no logger at all, which is
why this was invisible on the host as well as in the client.

The error envelope is built directly rather than through the existing Error helper. That helper reads
the id of an inbound request, but what correlates an outbound envelope to its request is its own
CorrelationId, so the helper would have produced an error frame with a null correlation id, which the
client discards. There is also a guard for the case where the error envelope would itself exceed the
limit, since an inbound type string is not length capped the way ids are, so the rule that the host
never sends a frame over the limit still holds without exception.

Issue #673 caps Button states at 25 and so removes the common way of reaching this, but the transport
behaviour was untouched by that change: any oversized envelope from any provider still killed the
session silently.

## Testing

dotnet build MacroDeck.slnx -c Release -warnaserror: clean.

dotnet test: MacroDeckHost.Tests.UnitTests 7717 passed and 1 skipped, PluginContractTests 198 passed.

Four new tests drive the real write loop against a recording WebSocket: an oversized response produces
an error envelope correlated to the request that asked for it and does not abort, the session carries on
sending after one, an oversized pushed message closes with MessageTooBig and a non empty reason rather
than aborting, and a message within the limit is still sent untouched. Restoring the old throw fails
exactly the first three and leaves the fourth green, so none of them passes vacuously.

Not verified end to end in a browser. Another host was running on this machine throughout, and
SingleInstanceGuard reads a machine wide loopback port file and probes whoever answers it, so a second
host exits on startup regardless of the port or data directory it is given. The tests exercise the real
write loop, but I have not watched the desktop UI react to the close frame.

## Notes

This changes what first party clients can observe on the UI WebSocket, additively: a new error code
message_too_large, and a close status that was previously an abrupt drop. Nothing in sdk/, protocol/,
the plugin endpoints, the manifest or package format is involved, and the UI WebSocket is not part of
the published plugin surface, so the compatibility section of the template does not apply.

The bare catch that follows the write loop still swallows every other send failure without logging. It
was left alone deliberately: it also runs on ordinary disconnects, so logging there would be noise
rather than signal, and doing it properly means separating an abnormal failure from a normal teardown,
which is a wider change than this one.

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
