### PR TITLE
Run a button press against the stored widget

### DIFF
--- a/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetSession.cs
+++ b/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetSession.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using MacroDeck.Sdk.Ui;
 using MacroDeck.Ui.Dsl;
 using MacroDeckHost.Application.Actions;
+using MacroDeckHost.Application.Caching;
 using MacroDeck.Ui.Model.Events;
 using MacroDeck.Ui.Model.Nodes;
 using MacroDeck.Ui.Model.Patches;
@@ -46,6 +47,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 	private readonly UiState<IReadOnlyDictionary<WidgetIconReference, UiResource>> _iconResourcesState;
 	private readonly UiState<WidgetIconResolution> _iconProviderState;
 	private readonly WidgetEntity _widget;
+	private readonly IFolderCache _folderCache;
 	private readonly IWidgetTriggerService _triggerService;
 	private readonly IHostLockState _lockState;
 	private readonly IWidgetIconResources _iconResources;
@@ -134,6 +136,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		UiState<IReadOnlyDictionary<WidgetIconReference, UiResource>> iconResourcesState,
 		UiState<WidgetIconResolution> iconProviderState,
 		WidgetEntity widget,
+		IFolderCache folderCache,
 		IWidgetTriggerService triggerService,
 		IHostLockState lockState,
 		IWidgetIconResources iconResources,
@@ -151,6 +154,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		ArgumentNullException.ThrowIfNull(iconResourcesState);
 		ArgumentNullException.ThrowIfNull(iconProviderState);
 		ArgumentNullException.ThrowIfNull(widget);
+		ArgumentNullException.ThrowIfNull(folderCache);
 		ArgumentNullException.ThrowIfNull(triggerService);
 		ArgumentNullException.ThrowIfNull(lockState);
 		ArgumentNullException.ThrowIfNull(iconResources);
@@ -166,6 +170,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		_iconResourcesState = iconResourcesState;
 		_iconProviderState = iconProviderState;
 		_widget = widget;
+		_folderCache = folderCache;
 		_triggerService = triggerService;
 		_lockState = lockState;
 		_iconResources = iconResources;
@@ -434,10 +439,21 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		string? originClientId,
 		CancellationToken cancellationToken)
 	{
+		// The profile cache replaces the widget instance on every edit, so the entity this session opened
+		// with is a pre-edit snapshot whose flows a press must not run (issue #683).
+		var widget = _folderCache.GetAllFolders()
+			.SelectMany(folder => folder.Widgets)
+			.FirstOrDefault(candidate => candidate.Id == _widget.Id);
+
+		if (widget is null)
+		{
+			return;
+		}
+
 		// No origin device: a press dispatched through a UI session comes from a deck client, which is
 		// identified by its client id. A device origin belongs to a plugin-provided device (ADR 0068).
 		var dispatch = await _triggerService
-			.ExecuteAsync(_widget, triggerType, originClientId, originDeviceId: (Guid?)null, cancellationToken)
+			.ExecuteAsync(widget, triggerType, originClientId, originDeviceId: (Guid?)null, cancellationToken)
 			.ConfigureAwait(false);
 
 		// dispatch.Result is null when the flow outran WidgetTriggerService's own bound and was detached -

--- a/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetUiProvider.cs
+++ b/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetUiProvider.cs
@@ -184,6 +184,7 @@ public sealed class ActionButtonWidgetUiProvider : IBuiltInWidgetUiProvider
 			iconResourcesState,
 			iconProviderState,
 			widget,
+			_folderCache,
 			_triggerService,
 			_lockState,
 			_iconResources,

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetSessionTests.cs
@@ -17,6 +17,7 @@ using MacroDeckHost.Application.Widgets;
 using MacroDeckHost.Domain.Entities;
 using MacroDeckHost.Domain.Widgets;
 using MacroDeckHost.Tests.UnitTests.TestSupport;
+using MacroDeckHost.Tests.UnitTests.Triggers;
 using MacroDeckHost.Widgets.ActionButton;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -620,6 +621,53 @@ public class ActionButtonWidgetSessionTests
 		await fixture.Session.DisposeAsync();
 	}
 
+	[Test]
+	public async Task A_press_runs_the_flows_the_widget_has_now_not_the_ones_its_session_opened_with()
+	{
+		var fixture = Build(FlowData("original"), interactive: true);
+
+		var edited = FlowData("edited");
+		fixture.Folder.Widgets[0] = new WidgetEntity
+		{
+			Id = _widgetId,
+			FolderId = fixture.Folder.Id,
+			Type = WidgetTypeIds.ActionButton,
+			Data = edited
+		};
+
+		fixture.Host.ById("actionButton").Raise(UiComponentEvents.Press);
+		await fixture.Host.SettleAsync();
+
+		Assert.That(fixture.Trigger.Calls.Single().WidgetData, Is.EqualTo(edited));
+
+		await fixture.Session.DisposeAsync();
+	}
+
+	[Test]
+	public async Task A_press_on_a_widget_that_is_no_longer_stored_runs_nothing()
+	{
+		var fixture = Build(FlowData("original"), interactive: true);
+
+		fixture.Folder.Widgets.Clear();
+
+		fixture.Host.ById("actionButton").Raise(UiComponentEvents.Press);
+		await fixture.Host.SettleAsync();
+
+		Assert.That(fixture.Trigger.Calls, Is.Empty);
+
+		await fixture.Session.DisposeAsync();
+	}
+
+	private static string FlowData(string blockId)
+	{
+		var flows = JsonSerializer.Serialize(new[]
+		{
+			new { triggerId = "t", triggerType = "onShortPress", children = new[] { new { id = blockId } } }
+		});
+
+		return JsonSerializer.Serialize(new { stateMode = false, label = "Button", flows });
+	}
+
 	private static SessionFixture Build(
 		string data,
 		bool interactive,
@@ -638,6 +686,9 @@ public class ActionButtonWidgetSessionTests
 			= new UiState<IReadOnlyDictionary<WidgetIconReference, UiResource>>(
 				new Dictionary<WidgetIconReference, UiResource>());
 		var widget = new WidgetEntity { Id = _widgetId, Type = WidgetTypeIds.ActionButton, Data = data };
+		var folderCache = new StubFolderCache();
+		var folder = folderCache.AddFolder(widget);
+		widget.FolderId = folder.Id;
 		var trigger = new RecordingTriggerService();
 		var lockState = new FakeHostLockState { IsLocked = locked };
 		var icons = iconResources ?? new FakeWidgetIconResources();
@@ -658,6 +709,7 @@ public class ActionButtonWidgetSessionTests
 			iconResourcesState,
 			iconProviderState,
 			widget,
+			folderCache,
 			trigger,
 			lockState,
 			icons,
@@ -688,7 +740,8 @@ public class ActionButtonWidgetSessionTests
 			transport,
 			stateSubscriptions,
 			labelSubscriptions,
-			iconServiceFake);
+			iconServiceFake,
+			folder);
 	}
 
 	private sealed record SessionFixture(
@@ -699,7 +752,8 @@ public class ActionButtonWidgetSessionTests
 		RecordingTransport Transport,
 		WidgetStateSubscriptionTracker StateSubscriptions,
 		LabelSubscriptionTracker LabelSubscriptions,
-		FakeWidgetIconService IconService);
+		FakeWidgetIconService IconService,
+		FolderEntity Folder);
 
 	/// <summary>A configurable <see cref="IWidgetIconService" /> stand-in - defaults to
 	/// <see cref="WidgetIconResolution.Inactive" />, matching a button with no icon-provider assignment.</summary>
@@ -754,7 +808,7 @@ public class ActionButtonWidgetSessionTests
 
 	private sealed class RecordingTriggerService : IWidgetTriggerService
 	{
-		public List<(string TriggerType, string? OriginClientId)> Calls { get; } = [];
+		public List<(string TriggerType, string? OriginClientId, string? WidgetData)> Calls { get; } = [];
 
 		public FlowExecutionResult? Result { get; set; }
 
@@ -765,7 +819,7 @@ public class ActionButtonWidgetSessionTests
 			Guid? originDeviceId,
 			CancellationToken cancellationToken)
 		{
-			Calls.Add((triggerType, originClientId));
+			Calls.Add((triggerType, originClientId, widget.Data));
 
 			return Task.FromResult(new ActionExecutionDispatch(Guid.NewGuid(), Result));
 		}


### PR DESCRIPTION
Closes #683

## Summary

A button's UI session ran the widget entity it captured when the session opened, and the profile cache
replaces that instance on every edit, so a press executed the flows from before the edit. A press now
resolves the stored widget instead.

## Testing

Full solution build, the host unit suite and the plugin contract suite pass, with two new tests: the
edited flow runs, and a press on a widget that is no longer stored runs nothing. Verified in a browser
against a running host before the branch was rebased. The rebased build was not re-checked in a browser
because another host instance held the single instance lock.

## Notes

Not specific to copy and paste: any flow edit was affected while a client had the button open. A pasted
button keeps its session across the edit because its declared trigger set does not change, while a new
button gains its first trigger on the first save and so gets a fresh session.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] I reviewed and understand every submitted change
