### PR TITLE
Keep widget border animating under reduced motion

### DIFF
--- a/docs/src/content/docs/sdk/ui/components/button.md
+++ b/docs/src/content/docs/sdk/ui/components/button.md
@@ -59,7 +59,8 @@ ignore it. The ring is drawn at a fixed `2` device-independent units along the i
 element's corner radius - the one length in the framework that is not a fraction of the basis, deliberately:
 a ring that grew with the element would read wildly inconsistently across differently sized buttons. Every
 looping style is phase-locked to a clock shared with Macro Deck, so one button animates in step on every
-client showing it; a reader honouring a reduced-motion preference freezes each style to its static look.
+client showing it, and it keeps animating whatever the viewer's reduced-motion preference says - a border
+a deck owner configured to move is the same border on every client, so a reader must not freeze it.
 
 Paint order, which none of the properties imply and a reader owes: `background`, then the artwork, then
 the children, then the press feedback, then the ring. The ring is above everything so artwork covering the

--- a/ui-model/src/MacroDeck.Ui/Components/UiElements.cs
+++ b/ui-model/src/MacroDeck.Ui/Components/UiElements.cs
@@ -783,8 +783,9 @@ public sealed record UiSlider : UiComponentLeaf
 /// basis, deliberately: a ring that grew with the element would read wildly inconsistently across
 /// differently sized widgets. Every looping <see cref="UiComponentBorderStyles" /> is phase-locked to a
 /// clock shared with the host rather than to its own element, so one button shows the same phase on every
-/// client displaying it; a reader honouring a reduced-motion preference freezes each style to its static
-/// look.
+/// client displaying it, and it keeps animating whatever the viewer's reduced-motion preference says: a
+/// border a deck owner configured to move is the same border on every client, so a reader must not freeze
+/// it.
 /// </para>
 ///
 /// <para>

--- a/ui/runtime/styles.test.mjs
+++ b/ui/runtime/styles.test.mjs
@@ -329,3 +329,48 @@ test('every ring style the fallback tints is one that paints the colour on the r
   assert.deepEqual(fallbackList('TINTED_RING_STYLES').sort(), declared.sort(),
     'a style that paints --wb-color on the element needs the fallback, and no other does');
 });
+
+test('no sheet that styles a widget border ring conditions it on reduced motion', () => {
+  // The ring is the one decoration that keeps looping under the preference (issue 682): freezing it in
+  // the runtime sheet alone left it animating in the configuration UI and dead in the web client.
+  const roots = [
+    path.join(HERE, 'styles'),
+    path.resolve(HERE, '..', 'angular', 'projects'),
+    path.resolve(HERE, '..', 'web-client', 'src'),
+  ];
+  // Asserted rather than skipped: a root that moved would otherwise take a whole surface out of the
+  // walk and leave this green, which is the one failure a guard cannot afford.
+  for (const root of roots) assert.ok(existsSync(root), `${root} must exist to be scanned`);
+
+  const styling = [];
+  const offenders = [];
+  const stack = [...roots];
+  while (stack.length) {
+    const entry = stack.pop();
+    if (statSync(entry).isDirectory()) {
+      for (const child of readdirSync(entry)) {
+        if (child === 'node_modules' || child === 'dist') continue;
+        stack.push(path.join(entry, child));
+      }
+      continue;
+    }
+    if (!/\.(scss|css)$/.test(entry)) continue;
+    const sheet = readFileSync(entry, 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    if (!/(^|[\s,>+~(&])\.(ring(?![\w-])|wb-)/.test(sheet)) continue;
+    styling.push(path.relative(HERE, entry));
+    if (/prefers-reduced-motion/.test(sheet)) offenders.push(path.relative(HERE, entry));
+  }
+
+  // Whatever the query gates, and however it nests, a sheet holding the ring's own rules has no
+  // business naming the preference at all, so the check needs no parser.
+  assert.deepEqual(offenders, [],
+    'a widget border ring must keep animating whatever the viewer prefers, on every surface');
+  // By name, not by count: a third sheet matching .wb- for its own reasons would otherwise let one of
+  // these two go missing unnoticed.
+  for (const sheet of ['styles/widget-border.css', 'widget-border-overlay.component.scss']) {
+    assert.ok(styling.some(found => found.endsWith(sheet)),
+      `${sheet} styles the ring and must be among the scanned sheets, saw ${styling.join(', ')}`);
+  }
+});

--- a/ui/runtime/styles/widget-border.css
+++ b/ui/runtime/styles/widget-border.css
@@ -45,6 +45,9 @@
   }
 }
 
+/* Every looping style below keeps running under prefers-reduced-motion. Freezing the ring here alone
+   left one border animating in the configuration UI and dead in the web client (issue 682). */
+
 /* Colour-tinted styles paint the ring directly; the animated ones vary its opacity. */
 .wb-static,
 .wb-heartbeat,
@@ -154,13 +157,5 @@
 @keyframes wb-hue-shift {
   to {
     filter: hue-rotate(1turn);
-  }
-}
-
-/* Every style freezes to its static look for reduced-motion users. */
-@media (prefers-reduced-motion: reduce) {
-  .ring,
-  .ring::before {
-    animation: none;
   }
 }


### PR DESCRIPTION
Closes #682

## Summary

Widget border rings were frozen under prefers-reduced-motion by the shared runtime stylesheet, while
the desktop configuration UI kept animating because its encapsulated component styles outrank that
rule. The ring is now exempt from the preference, so a configured border animates on every surface.

## Testing

The runtime, web client and legacy suites, the Angular border specs and a full Release solution build
all pass, with a new test that fails if any stylesheet holding the ring's rules names the preference
again. Verified in a real browser against a running host with reduced motion emulated: all seven
looping styles animate, where before every ring rendered but sat static.

## Plugin SDK / API compatibility

No public contract changed. The UiButton XML doc and the button documentation page both promised the
old freeze, so both now state that a reader keeps the ring animating; prose only, in the same words.
What did change is a documented reader obligation, which is why the label is on the PR. The
conformance suite and the ui-model suites pass; I did not build a sample plugin against it.

- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed

## Notes

That the reporter had reduced motion enabled is a hypothesis, not something the issue states. It is
the only cause that reproduces the reported symptom and nothing else in the tree can freeze a ring, so
it is worth asking them to confirm their Windows animation setting.

Exempting the ring is a deliberate trade agreed beforehand: a viewer who asked their system for
reduced motion now sees a looping ring on every tile that has one configured.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
