### PR TITLE
Send number inputs to the host as numbers

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/components/action-builder/action-card/param-list/param-row.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/action-builder/action-card/param-list/param-row.component.html
@@ -118,7 +118,7 @@
               [max]="param.max"
               [step]="param.step"
               [ngModel]="primitive"
-              (ngModelChange)="onChange($event)" />
+              (ngModelChange)="onNumberChange($event)" />
           } @else {
             <shared-input
               type="number"
@@ -127,7 +127,7 @@
               [max]="param.max"
               [step]="param.step"
               [ngModel]="primitive"
-              (ngModelChange)="onChange($event)" />
+              (ngModelChange)="onNumberChange($event)" />
           }
         }
         @case ('boolean') {

--- a/ui/angular/projects/desktop-ui/src/app/components/action-builder/action-card/param-list/param-row.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/action-builder/action-card/param-list/param-row.component.spec.ts
@@ -175,6 +175,40 @@ describe('ParamRowComponent host-backed option labels', () => {
     ]);
   });
 
+  it('stores what a number box was given as a number', async () => {
+    const fixture = TestBed.createComponent(ParamRowComponent);
+    fixture.componentRef.setInput('blockId', 'block-1');
+    fixture.componentRef.setInput('param', {
+      name: 'delay', type: 'number', label: 'Delay', value: 10,
+    } satisfies ActionBlockParameter);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const box = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    box.value = '25';
+    box.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    expect(store.updateParam.calls.mostRecent().args[2] as unknown).toBe(25);
+  });
+
+  it('lets an optional number parameter be emptied', async () => {
+    const fixture = TestBed.createComponent(ParamRowComponent);
+    fixture.componentRef.setInput('blockId', 'block-1');
+    fixture.componentRef.setInput('param', {
+      name: 'delay', type: 'number', label: 'Delay', value: 10,
+    } satisfies ActionBlockParameter);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const box = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    box.value = '';
+    box.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    expect(store.updateParam.calls.mostRecent().args[2] as unknown).toBe('');
+  });
+
   it('renders what an empty pick list means, as the provider named it', () => {
     const fixture = TestBed.createComponent(ParamRowComponent);
     fixture.componentRef.setInput('blockId', 'block-1');

--- a/ui/angular/projects/desktop-ui/src/app/components/action-builder/action-card/param-list/param-row.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/action-builder/action-card/param-list/param-row.component.ts
@@ -390,6 +390,15 @@ export class ParamRowComponent implements OnInit, OnChanges {
     this.onChange(value as unknown as ParameterValue);
   }
 
+  onNumberChange(value: string | number): void {
+    if (value === '' || value == null) {
+      this.onChange('');
+      return;
+    }
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) this.onChange(parsed);
+  }
+
   onChange(value: ParameterValue): void {
     if (this.nested) {
       this.nestedChange.emit(value);

--- a/ui/angular/projects/desktop-ui/src/app/components/condition-builder/condition-operand-input/condition-operand-input.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/condition-builder/condition-operand-input/condition-operand-input.component.html
@@ -44,7 +44,7 @@
     [max]="parameter?.max"
     [step]="parameter?.step"
     [ngModel]="numberValue"
-    (ngModelChange)="emit($event)">
+    (ngModelChange)="emitNumber($event)">
   </shared-input>
 } @else if (controlType === 'datetime') {
   <shared-datetime-picker

--- a/ui/angular/projects/desktop-ui/src/app/components/condition-builder/condition-operand-input/condition-operand-input.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/condition-builder/condition-operand-input/condition-operand-input.component.spec.ts
@@ -48,6 +48,36 @@ describe('ConditionOperandInputComponent', () => {
     fixture.detectChanges();
   }
 
+  describe('a numeric literal', () => {
+    const param: Param = { name: 'threshold', type: 'number', label: 'Threshold' };
+
+    it('is emitted as a number', async () => {
+      await render(param, 10);
+      const emitted: unknown[] = [];
+      fixture.componentInstance.valueChange.subscribe(value => emitted.push(value));
+
+      const box = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+      box.value = '25';
+      box.dispatchEvent(new Event('input'));
+      await fixture.whenStable();
+
+      expect(emitted).toEqual([25]);
+    });
+
+    it('can still be cleared', async () => {
+      await render(param, 10);
+      const emitted: unknown[] = [];
+      fixture.componentInstance.valueChange.subscribe(value => emitted.push(value));
+
+      const box = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+      box.value = '';
+      box.dispatchEvent(new Event('input'));
+      await fixture.whenStable();
+
+      expect(emitted).toEqual(['']);
+    });
+  });
+
   describe('a dynamic list that cannot resolve the stored value (issue #768)', () => {
     const sceneParam: Param = { name: 'sceneName', type: 'dynamic-choice', label: 'Scene', dynamicOptions: true };
 

--- a/ui/angular/projects/desktop-ui/src/app/components/condition-builder/condition-operand-input/condition-operand-input.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/condition-builder/condition-operand-input/condition-operand-input.component.ts
@@ -127,6 +127,15 @@ export class ConditionOperandInputComponent implements OnInit, OnChanges, OnDest
     this.valueChange.emit(value);
   }
 
+  emitNumber(value: string | number): void {
+    if (value === '' || value == null) {
+      this.emit('');
+      return;
+    }
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) this.emit(parsed);
+  }
+
   loadDynamicOptions(filter?: string): void {
     const parameter = this.parameter;
     if (!parameter) return;

--- a/ui/angular/projects/desktop-ui/src/app/components/ui-render/config-node-primitives.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/ui-render/config-node-primitives.spec.ts
@@ -182,6 +182,95 @@ describe('shared-ui-node every configuration primitive', () => {
     expect(rendered.events).toEqual([{ nodeId: 'n', name: 'change', data: 1 }]);
   });
 
+  it('emits a number from the plain number box and keeps showing what was typed', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'number',
+      properties: { value: 14, min: 1, max: 100, events: ['change'] },
+    });
+    const box = el(rendered).querySelector<HTMLInputElement>('input[type="number"]')!;
+
+    box.value = '20';
+    box.dispatchEvent(new Event('input'));
+    await tick(rendered);
+
+    expect(rendered.events).toEqual([{ nodeId: 'n', name: 'change', data: 20 }]);
+    expect(box.value).toBe('20');
+  });
+
+  it('emits a number from the number box paired with a slider', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'number',
+      properties: { value: 5, min: 0, max: 10, showSlider: true, events: ['change'] },
+    });
+    const box = el(rendered).querySelector<HTMLInputElement>('input[type="number"]')!;
+
+    box.value = '7';
+    box.dispatchEvent(new Event('input'));
+    await tick(rendered);
+
+    expect(rendered.events).toEqual([{ nodeId: 'n', name: 'change', data: 7 }]);
+  });
+
+  it('steps the number box from the value it shows (issue #698)', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'number',
+      properties: { value: 14, min: 1, max: 100, events: ['change'] },
+    });
+    const box = el(rendered).querySelector<HTMLInputElement>('input[type="number"]')!;
+
+    box.stepUp();
+    box.dispatchEvent(new Event('input'));
+    await tick(rendered);
+    expect(box.value).toBe('15');
+
+    box.stepUp();
+    box.dispatchEvent(new Event('input'));
+    await tick(rendered);
+    expect(box.value).toBe('16');
+
+    expect(rendered.events).toEqual([
+      { nodeId: 'n', name: 'change', data: 15 },
+      { nodeId: 'n', name: 'change', data: 16 },
+    ]);
+  });
+
+  it('leaves a half-typed decimal alone while the model renormalises it', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'number',
+      properties: { value: 1, events: ['change'] },
+    });
+    const box = el(rendered).querySelector<HTMLInputElement>('input[type="number"]')!;
+
+    box.value = '1.10';
+    box.dispatchEvent(new Event('input'));
+    await tick(rendered);
+
+    expect(rendered.events).toEqual([{ nodeId: 'n', name: 'change', data: 1.1 }]);
+    expect(box.value).toBe('1.10');
+  });
+
+  it('sends nothing for an emptied number box and shows the kept value again on blur', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'number',
+      properties: { value: 14, min: 1, max: 100, events: ['change'] },
+    });
+    const box = el(rendered).querySelector<HTMLInputElement>('input[type="number"]')!;
+
+    box.value = '';
+    box.dispatchEvent(new Event('input'));
+    await tick(rendered);
+    expect(rendered.events).toEqual([]);
+
+    box.dispatchEvent(new Event('blur'));
+    await tick(rendered);
+    expect(box.value).toBe('14');
+  });
+
   // The Action Button's state list is the case: a user opening it wants to see which state the button
   // is on right now, which is a fact about the option, not part of its name.
   it('marks a choice option carrying a badge, and leaves the others unmarked', async () => {

--- a/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.html
@@ -98,7 +98,7 @@
               [ariaDescribedby]="ariaDescribedby()"
               [ariaInvalid]="ariaInvalid()"
               [ngModel]="numberValue()"
-              (ngModelChange)="onChange($event)" />
+              (ngModelChange)="onNumberChange($event)" />
           </div>
         } @else {
           <shared-input
@@ -114,7 +114,7 @@
             [ariaDescribedby]="ariaDescribedby()"
             [ariaInvalid]="ariaInvalid()"
             [ngModel]="numberValue()"
-            (ngModelChange)="onChange($event)" />
+            (ngModelChange)="onNumberChange($event)" />
         }
       }
       @case (types.Boolean) {

--- a/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.ts
@@ -342,6 +342,12 @@ export class UiInputComponent {
     this.context.setValue(this.node(), value);
   }
 
+  protected onNumberChange(value: string | number): void {
+    if (value === '' || value == null) return;
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) this.onChange(parsed);
+  }
+
   protected onBooleanSegmentedChange(value: string): void {
     this.onChange(value === 'true');
   }

--- a/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/widget-configuration-editor/widget-configuration-editor.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/widget-configuration-editor/widget-configuration-editor.component.spec.ts
@@ -403,6 +403,36 @@ describe('WidgetConfigurationEditorComponent', () => {
     expect((fixture.componentInstance.widget.data as { label?: string }).label).toBe('After');
   });
 
+  it('folds a typed font size into widget.data as a number, and sends a number to the session (issue #698)', async () => {
+    const w = widget({ data: { fontSize: 14 } as unknown as WidgetData });
+    const fixture = await createFixture(w);
+
+    const sizeNode: UiNode = {
+      id: 'fontSize',
+      type: UiConfigPrimitives.Number,
+      properties: {
+        [UiConfigProperties.Events]: [UiConfigEvents.Change],
+        [UiConfigProperties.Value]: 14,
+        [UiConfigProperties.Label]: 'Size (%)',
+        [UiConfigProperties.Min]: 1,
+        [UiConfigProperties.Max]: 100,
+      },
+    };
+    configHandle().root.set(configRoot([propertiesRegion([sizeNode])]));
+    await settle(fixture);
+
+    const box = fixture.nativeElement.querySelector('input[type="number"]') as HTMLInputElement;
+    box.value = '20';
+    box.dispatchEvent(new Event('input'));
+    await settle(fixture);
+    await Promise.resolve();
+    await settle(fixture);
+
+    expect(configHandle().sent).toEqual([{ nodeId: 'fontSize', name: UiConfigEvents.Change, data: 20 }]);
+    expect((fixture.componentInstance.widget.data as { fontSize?: unknown }).fontSize).toBe(20);
+    expect(box.value).toBe('20');
+  });
+
   it('forwards a change event to the session and folds it into widget.data, with a nested edit landing as nested JSON', async () => {
     const w = widget({ data: { label: 'Before', border: { style: 'solid', color: '#fff' } } as unknown as WidgetData });
     const fixture = await createFixture(w);

--- a/ui/angular/projects/desktop-ui/src/app/shared/components/forms/input/input.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/shared/components/forms/input/input.component.spec.ts
@@ -28,6 +28,57 @@ describe('InputComponent', () => {
     expect((el as HTMLInputElement).type).toBe('number');
   });
 
+  it('keeps what is being typed into a number box when the model only renormalises it', () => {
+    component.type = 'number';
+    component.onInput('1.10');
+
+    component.writeValue(1.1);
+
+    expect(component.value).toBe('1.10');
+  });
+
+  it('takes a number box to the value the model changed to', () => {
+    component.type = 'number';
+    component.onInput('14');
+
+    component.writeValue(20);
+
+    expect(component.value).toBe(20);
+  });
+
+  it('brings a number box back to the model value once typing is over', () => {
+    component.type = 'number';
+    component.onInput('1e3');
+    component.writeValue(1000);
+
+    expect(component.value).toBe('1e3');
+
+    component.onBlur();
+
+    expect(component.value).toBe(1000);
+  });
+
+  it('brings an emptied number box back to a model value the caller kept', () => {
+    component.type = 'number';
+    component.writeValue(14);
+    component.onInput('');
+
+    component.onBlur();
+
+    expect(component.value).toBe(14);
+  });
+
+  it('leaves an emptied number box empty for a model that accepted the empty value', () => {
+    component.type = 'number';
+    component.writeValue(14);
+    component.onInput('');
+    component.writeValue('');
+
+    component.onBlur();
+
+    expect(component.value).toBe('');
+  });
+
   it('renders a textarea when multiline is set', () => {
     component.multiline = true;
     fixture.detectChanges();

--- a/ui/angular/projects/desktop-ui/src/app/shared/components/forms/input/input.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/shared/components/forms/input/input.component.ts
@@ -95,6 +95,8 @@ export class InputComponent implements ControlValueAccessor, AfterViewInit {
 
   value: string | number = '';
 
+  private modelValue: string | number = '';
+
   onChange: (value: string | number) => void = () => {};
   onTouched: () => void = () => {};
 
@@ -109,7 +111,12 @@ export class InputComponent implements ControlValueAccessor, AfterViewInit {
   }
 
   writeValue(value: string | number | null): void {
-    this.value = value ?? '';
+    const next = value ?? '';
+    this.modelValue = next;
+    // A model that only renormalises what is being typed must not rewrite the box: it would drop a
+    // trailing zero and move the caret mid-entry.
+    if (this.type === 'number' && next !== '' && this.value !== '' && Number(this.value) === Number(next)) return;
+    this.value = next;
   }
 
   registerOnChange(fn: (value: string | number) => void): void {
@@ -130,6 +137,7 @@ export class InputComponent implements ControlValueAccessor, AfterViewInit {
   }
 
   onBlur(): void {
+    if (this.type === 'number' && this.value !== this.modelValue) this.value = this.modelValue;
     this.onTouched();
     this.blurred.emit();
   }


### PR DESCRIPTION
Closes #698

## Summary

The number boxes in the generic configuration renderer sent the typed text to the host as a string, so
the host rejected it, the field blanked itself and the save failed. They now send a number, and a box
that is being typed into is no longer rewritten under the caret.

The condition builder and the action parameter row had the same defect on the same control and are
fixed with it. Both keep letting an optional numeric field be cleared.

## Testing

The desktop-ui suite passes with 3807 specs, 15 of them new. Each new spec was checked to fail with
the fix reverted; the spinner one fails with the reported symptom, 1 instead of 16.

Verified in a browser against a running host: typing a font size keeps the value, the save persists it
as a number with no error toast, and one click on the up arrow from 14 gives 15.

The .NET suites were not run because no .NET file changed.

## Notes

Numeric action parameters and condition literals are now stored as JSON numbers instead of strings.
ActionArgumentBinder and ActionConditionEvaluator accept both, so old and new flows keep working.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
