### PR TITLE
Keep page overlays below the shell side panels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,10 @@ jobs:
         working-directory: ui/angular
         run: npm run test:boundaries
 
+      - name: Page stacking layering
+        working-directory: ui/angular
+        run: npm run test:stacking
+
       - name: Release feed script tests
         run: node --test ci/scripts/*.test.mjs
 

--- a/ui/angular/package.json
+++ b/ui/angular/package.json
@@ -15,6 +15,7 @@
     "test:proxy": "node --test proxy.conf.test.mjs",
     "test:dialog-box": "node --test dialog-box.test.mjs",
     "test:boundaries": "node --test projects/desktop-ui/boundaries.test.mjs",
+    "test:stacking": "node --test projects/desktop-ui/stacking.test.mjs",
     "build:runtime": "npm run build --prefix ../runtime"
   },
   "private": true,

--- a/ui/angular/projects/desktop-ui/src/app/components/pages/deck-page/deck-page.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/pages/deck-page/deck-page.component.scss
@@ -70,7 +70,8 @@
   top: var(--space-4);
   left: 50%;
   transform: translateX(-50%);
-  z-index: 1000;
+  // Below the shell side panels at 30, and above the marquee overlay at 25 the banner has to clear.
+  z-index: 28;
   width: min(90%, 480px);
 }
 

--- a/ui/angular/projects/desktop-ui/src/app/components/pages/store-page/store-page.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/pages/store-page/store-page.component.scss
@@ -134,7 +134,8 @@
 .store-coming-soon {
   position: absolute;
   inset: 0;
-  z-index: var(--z-overlay);
+  // Below the shell side panels at 30, and above .card-install at 1 so the cover still hides the catalog.
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/ui/angular/projects/desktop-ui/src/app/components/widgets/profile-selector/profile-selector.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/widgets/profile-selector/profile-selector.component.scss
@@ -150,7 +150,8 @@
   top: var(--spacing-md, 0.8125rem);
   left: 50%;
   transform: translateX(-50%);
-  z-index: 1000;
+  // Below the shell side panels at 30: a wrapped message reaches the panel header on a narrow window.
+  z-index: 28;
   width: min(90%, 480px);
 }
 

--- a/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/common/widget-editor-shell/widget-editor-shell.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/common/widget-editor-shell/widget-editor-shell.component.scss
@@ -133,9 +133,9 @@ $sidebar-width: 300px;
 // positioned - every `.icon` mask creates a stacking context, as does every action card - and they
 // come after the drawer in the DOM. `--z-dropdown` is the right rung: above page content, below
 // `--z-modal`, so a confirmation modal still covers the drawer. It caps the icon picker the sidebar
-// renders inline at that level too, which is harmless here only because no app chrome sets a
-// z-index at all - checked before choosing this over a DOM reorder, which would have put the
-// appearance pane after the action editor in the tab order.
+// renders inline at that level too - checked before choosing this over a DOM reorder, which would
+// have put the appearance pane after the action editor in the tab order. It does outrank the shell
+// side panels at 30, so an open drawer covers one: a click on the scrim dismisses it either way.
 .editor-shell-scrim {
   position: absolute;
   inset: 0;

--- a/ui/angular/projects/desktop-ui/stacking.test.mjs
+++ b/ui/angular/projects/desktop-ui/stacking.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * Guards the layering the routed pages depend on.
+ *
+ * The shell side panels sit at z-index 30 and the notification panel's close button is its only way
+ * out, so a page element that outranks them can cover that button and leave the app stuck (issue 694).
+ *
+ * Only components/pages is walked. Chrome elsewhere is not covered: the layers that legitimately sit
+ * above the panels are spread across a dozen files, and exempting them by name would be a list that
+ * has to be edited to stay true.
+ *
+ * A Node test rather than a karma spec because this is a question about the source tree. Run by
+ * npm run test:stacking.
+ */
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(HERE, 'src', 'app');
+const PAGES = path.join(SRC, 'components', 'pages');
+const PANELS = ['notification-panel/notification-panel', 'connection-panel/connection-panel']
+  .map(name => path.join(SRC, 'components', 'shell', `${name}.component.scss`));
+
+function walk(dir, predicate) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full, predicate));
+    else if (predicate(full)) out.push(full);
+  }
+  return out;
+}
+
+const isStyleOrTemplate = file => file.endsWith('.scss') || file.endsWith('.html');
+const rel = file => path.relative(HERE, file);
+
+// Trailing `//` needs the leading boundary so a `https://` inside a url() survives.
+function uncommented(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/(^|\s)\/\/.*$/gm, '$1');
+}
+
+function declarationsOf(file) {
+  const source = uncommented(readFileSync(file, 'utf8'));
+  const css = [...source.matchAll(/z-index\s*:\s*([^;}]+)/g)];
+  const bound = [...source.matchAll(/\[style\.z-index[^\]]*\]\s*=\s*"([^"]*)"/g)];
+  return [...css, ...bound].map(match => match[1].trim());
+}
+
+// Read from the panels rather than copied, so moving their rung cannot leave this enforcing an
+// old number in silence.
+function shellPanelZIndex() {
+  const values = PANELS.map(file => {
+    const match = /:host\s*\{[^}]*?z-index\s*:\s*(\d+)/s.exec(uncommented(readFileSync(file, 'utf8')));
+    assert.ok(match, `no :host z-index found in ${rel(file)}`);
+    return Number(match[1]);
+  });
+  assert.equal(values[0], values[1], 'the two shell side panels should share one rung');
+  return values[0];
+}
+
+// auto, unset, initial and revert all resolve to the auto layer, which cannot outrank the panels.
+// inherit can, so it is not on this list.
+const SAFE_KEYWORDS = new Set(['auto', 'unset', 'initial', 'revert']);
+
+function offends(value, limit) {
+  if (SAFE_KEYWORDS.has(value)) return false;
+  return !/^-?\d+$/.test(value) || Number(value) >= limit;
+}
+
+test('no page layers itself into the shell', () => {
+  const limit = shellPanelZIndex();
+  const offenders = [];
+  for (const file of walk(PAGES, isStyleOrTemplate)) {
+    for (const value of declarationsOf(file)) {
+      if (offends(value, limit)) offenders.push(`${rel(file)} -> z-index: ${value}`);
+    }
+  }
+  assert.deepEqual(offenders, [],
+    `a page needs a plain z-index below ${limit}, or it can cover an open panel and trap it`);
+});
+
+test('there are pages to check', () => {
+  // A sanity check on the check: if the directory moved, the test above would pass by walking nothing.
+  assert.ok(walk(PAGES, isStyleOrTemplate).length > 10, 'components/pages should hold the page sources');
+});


### PR DESCRIPTION
Closes #694

## Summary

The store page's coming soon overlay sat at the modal z-index rung, above the shell side panels, so it
painted over the notification flyout and swallowed the clicks on its only close control. Page level
overlays now sit below the panels. Two error banners had the same defect and are fixed with it.

## Testing

Full solution build with warnaserror, the desktop-ui suite (3792) and the node suites pass, including
a new test:stacking guard that fails on the old values. Reproduced in a browser against a running host
at the reporter's window size: the flyout now opens fully, closes and no longer blocks navigation. Not
verified on Windows or in the Tauri window.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] I reviewed and understand every submitted change
