### PR TITLE
Fade a button background when a state change recolours it

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/shared/components/ui-render/ui-widget-node.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/shared/components/ui-render/ui-widget-node.component.spec.ts
@@ -1183,6 +1183,10 @@ describe('ui.button appearance', () => {
     return el(rendered).querySelector('.widget-button') as HTMLElement;
   }
 
+  function reducedMotion(): boolean {
+    return matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
   it('is its own stacking context, so its always-present background cannot paint over the negative-z artwork', async () => {
     // .widget-button-artwork uses z-index: -1 to sit behind the flex children while staying above the
     // button's own background - but a negative z-index only paints behind whatever stacking context it
@@ -1193,6 +1197,65 @@ describe('ui.button appearance', () => {
     const rendered = await renderTree(node, withBasis(200));
 
     expect(getComputedStyle(buttonEl(rendered)).isolation).toBe('isolate');
+  });
+
+  it('eases a background colour change over the third of a second a viewer can follow', async () => {
+    if (reducedMotion()) pending('the viewer asked for less motion, so nothing is meant to move');
+
+    const node: UiNode = { id: 'btn', type: Types.Button, properties: { [Props.Background]: '#2b6cee' } };
+    const rendered = await renderTree(node, withBasis(200));
+    const style = getComputedStyle(buttonEl(rendered));
+    const seconds = parseFloat(style.transitionDuration);
+
+    expect(style.transitionProperty).toContain('background-color');
+    expect(seconds).toBeGreaterThanOrEqual(0.3);
+    expect(seconds).toBeLessThanOrEqual(0.5);
+  });
+
+  it('leaves a button that eases its artwork on its own longer curve', async () => {
+    if (reducedMotion()) pending('the viewer asked for less motion, so nothing is meant to move');
+
+    const plain = await renderTree(
+      { id: 'btn', type: Types.Button, properties: { [Props.Background]: '#2b6cee' } }, withBasis(200));
+    const plainSeconds = parseFloat(getComputedStyle(buttonEl(plain)).transitionDuration);
+
+    const crossfading = await renderTree(
+      {
+        id: 'btn', type: Types.Button,
+        properties: { [Props.Background]: '#2b6cee', [Props.Transition]: 'crossfade' },
+      }, withBasis(200));
+
+    expect(parseFloat(getComputedStyle(buttonEl(crossfading)).transitionDuration))
+      .toBeGreaterThan(plainSeconds);
+  });
+
+  it('starts fading when the colour changes and not when the button first appears', async () => {
+    if (reducedMotion()) pending('the viewer asked for less motion, so nothing is meant to move');
+
+    const button = (properties: Record<string, unknown>): UiNode =>
+      ({ id: 'btn', type: Types.Button, properties });
+    const rendered = await renderTree(button({ [Props.Background]: '#2b6cee' }), withBasis(200));
+
+    expect(buttonEl(rendered).getAnimations().length).toBe(0);
+
+    await updateTree(rendered, { root: button({ [Props.Background]: '#ef4444' }) });
+
+    expect(buttonEl(rendered).getAnimations()
+      .some(animation => (animation as CSSTransition).transitionProperty === 'background-color'))
+      .toBeTrue();
+  });
+
+  it('does not fade a button in from transparent when it is nested inside a stack', async () => {
+    if (reducedMotion()) pending('the viewer asked for less motion, so nothing is meant to move');
+
+    const node: UiNode = {
+      id: 'root', type: Types.Stack, properties: {},
+      children: [{ id: 'btn', type: Types.Button, properties: { [Props.Background]: '#2b6cee' } }],
+    };
+    const rendered = await renderTree(node, withBasis(200));
+
+    expect(buttonEl(rendered).getAnimations().length).toBe(0);
+    expect(getComputedStyle(buttonEl(rendered)).backgroundColor).toBe('rgb(43, 108, 238)');
   });
 
   it('draws a ring in the configured color when borderStyle/borderColor are set', async () => {

--- a/ui/runtime/src/ui-components/stack-paint.ts
+++ b/ui/runtime/src/ui-components/stack-paint.ts
@@ -54,6 +54,9 @@ export function paintStackLayout<TState>(node: UiNode, ctx: UiComponentContext<T
   const tileCorner = isButton && !ctx.isTreeRoot && buttonTakesTileCorner(node);
   ctx.setClass(element, 'widget-node-root', isButton && ctx.isTreeRoot);
   ctx.setClass(element, 'widget-tile-corner', tileCorner);
+  // Before the corner: a nested button measures its own height, and that read flushes style. With the
+  // colour still unset the flush settles on transparent and the button eases in from it on every mount.
+  ctx.setStyle(element, 'background', isButton ? buttonBackground(node) : stackBackground(node) ?? null);
   ctx.setStyle(element, 'border-radius',
     isButton && !ctx.isTreeRoot && !tileCorner ? px(buttonCornerPx(element, ctx.box.height)) : null);
   ctx.setStyle(element, 'flex-direction', horizontal ? 'row' : 'column');
@@ -61,7 +64,6 @@ export function paintStackLayout<TState>(node: UiNode, ctx: UiComponentContext<T
   ctx.setStyle(element, 'align-items', nodeAlign(node));
   ctx.setStyle(element, 'gap', px(gap));
   ctx.setStyle(element, 'padding', px(padding));
-  ctx.setStyle(element, 'background', isButton ? buttonBackground(node) : stackBackground(node) ?? null);
   ctx.sizeTo(element, ctx.box);
 
   const entries = layoutStackChildren(node, ctx.box, ctx.basis, padding, gap, horizontal, ctx.registry);

--- a/ui/runtime/styles.test.mjs
+++ b/ui/runtime/styles.test.mjs
@@ -385,3 +385,24 @@ test('no sheet that styles a widget border ring conditions it on reduced motion'
       `${sheet} styles the ring and must be among the scanned sheets, saw ${styling.join(', ')}`);
   }
 });
+
+test('a button that fades its background stops fading when the viewer asks for less motion', () => {
+  const source = readFileSync(path.join(HERE, 'styles', 'renderer.css'), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  const opened = source.search(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{/);
+  assert.notEqual(opened, -1, 'renderer.css declares no prefers-reduced-motion block');
+
+  let depth = 0;
+  let end = source.indexOf('{', opened);
+  for (let at = end; at < source.length; at++) {
+    if (source[at] === '{') depth++;
+    else if (source[at] === '}' && --depth === 0) { end = at; break; }
+  }
+
+  const stilled = [...source.slice(source.indexOf('{', opened) + 1, end).matchAll(/([^{}]+)\{([^}]*)\}/g)]
+    .filter(rule => /transition:\s*none/.test(rule[2]))
+    .flatMap(rule => rule[1].split(',').map(one => one.trim()));
+
+  assert.ok(stilled.includes('.widget-button'),
+    'a button eases its background colour, so the reduce query has to still it like every other transition');
+});

--- a/ui/runtime/styles/renderer.css
+++ b/ui/runtime/styles/renderer.css
@@ -51,6 +51,7 @@
   min-width: 0;
   min-height: 0;
   touch-action: none;
+  transition: background-color var(--transition-slow);
   /*
    * A nested button's corner is painted inline by the renderer, as a fraction of its own height - see
    * BUTTON_CORNER_RATIO. Not stated here, because it is not a constant: a button half the height of
@@ -445,6 +446,7 @@
     animation: none;
   }
 
+  .widget-button,
   .widget-artwork-eased,
   .widget-artwork-eased > img,
   .widget-progress-fill,


### PR DESCRIPTION
Closes #684

## Summary

A button's background colour was painted on the next frame, so a state change or an action cut
straight to the new colour. It now eases over 0.3s, the low end of the range the issue asks for,
through one declaration on the shared widget button rule in renderer.css. That sheet is the only
widget renderer stylesheet and both the web client and the desktop UI use it, so one rule covers
both. Reduced motion stills it, and a button that opted into a crossfade keeps its own longer curve.

Adding the transition exposed an existing ordering bug: a nested button measures its own height
during paint, and that read flushed style before the colour was written, so every nested button
faded in from transparent on each mount. The background is now written before that read.

Deliberately out of scope: a widget whose root is a stack rather than a button still cuts, and a
per-state ring colour still snaps while the face fades.

## Testing

Release build with warnings as errors and the full Release suite pass, including the plugin
contract, conformance, protocol, packaging and analyzer suites. ui/runtime 943 specs plus 25
boundary tests, ui/web-client 411 specs plus 88 legacy compatibility tests, desktop-ui 3812 specs.

New tests: three in real Chrome asserting the computed duration falls in the range the issue names,
that a crossfading button keeps its longer curve, and that the fade starts on a colour change and
not on mount; one for the nested button that caught the ordering bug; and one that the reduced
motion query stills the button.

Verified by hand against a running host serving the built web client, on a real deck Action Button
with two state colours and a press that toggles its state. Before the change the colour jumped in
one step and no transition ran. After it, 26 distinct intermediate colours were sampled between the
two state colours, and driving the transition's own timeline gives the expected midpoints. No button
animated on deck load, the artwork crossfade still measured 0.8s, and with reduced motion emulated
the button measured none and 0s.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
