### PR TITLE
Stop text scrolling under the Liquid trigger

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/components/forms/param-input/param-input.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/param-input/param-input.component.scss
@@ -21,11 +21,8 @@
   min-width: 0;
 }
 
-/*
- * The shell owns the geometry of the overlaid action: it sizes the trigger and, through the
- * gutter properties the field components read, reserves exactly the matching padding. Keeping
- * both sides of that in one place is what stops typed text from ever reaching the trigger.
- */
+// The shell owns the geometry of the overlaid action. It publishes the band and the gutter
+// together: a publisher that sets one without the other under-reserves the field that reads it.
 .pi-has-liquid {
   // Wide enough for the five-character {{ }} glyph with room to spare for a fallback mono font -
   // the trigger must never wrap, and the gutter below is derived from this width.
@@ -36,6 +33,26 @@
 
 .pi-has-liquid:not(.pi-multiline) {
   --input-action-inline-gutter: calc(var(--tb-trigger-width) + var(--space-2));
+  --input-action-inline-band: calc(var(--input-action-inline-gutter) + var(--space-3));
+}
+
+// The field's scrollport is its padding box, so it paints content through the band it reserved.
+// Depends on the field staying at z-index auto: a z-index there lifts the text back over this.
+.pi-has-liquid:not(.pi-multiline) .pi-field::after {
+  content: '';
+  position: absolute;
+  inset-block: 1px;
+  inset-inline-end: 1px;
+  width: var(--input-action-inline-band);
+  border-start-end-radius: calc(var(--radius-md) - 1px);
+  border-end-end-radius: calc(var(--radius-md) - 1px);
+  background-color: var(--color-bg-primary);
+  pointer-events: none;
+}
+
+// The field dims itself from inside, so the band has to dim with it or it reads as a solid block.
+.pi-shell.pi-disabled .pi-field::after {
+  opacity: 0.55;
 }
 
 /*

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/param-input/param-input.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/param-input/param-input.component.spec.ts
@@ -201,4 +201,74 @@ describe('ParamInputComponent', () => {
     expect(chipEditor()?.querySelectorAll('.vti-chip').length).toBe(1);
   });
 
+  describe('the space reserved for the Liquid trigger', () => {
+    function editor(): HTMLElement {
+      return fixture.nativeElement.querySelector('.vti-editor');
+    }
+
+    function backdrop(): CSSStyleDeclaration {
+      return getComputedStyle(chipEditor()!, '::after');
+    }
+
+    async function overflowingSingleLineField(): Promise<void> {
+      enableChipEditor();
+      enableLiquid();
+      await setValue('Now playing: {{ vars.title }} on repeat for the rest of the afternoon');
+    }
+
+    it('is covered across the whole width the field reserved', async () => {
+      await overflowingSingleLineField();
+
+      expect(parseFloat(backdrop().width))
+        .toBe(parseFloat(getComputedStyle(editor()).paddingInlineEnd));
+    });
+
+    it('is covered from the top border of the field to its bottom border', async () => {
+      await overflowingSingleLineField();
+
+      const field = getComputedStyle(editor());
+      expect(parseFloat(backdrop().insetBlockStart)).toBe(parseFloat(field.borderTopWidth));
+      expect(parseFloat(backdrop().insetBlockEnd)).toBe(parseFloat(field.borderBottomWidth));
+    });
+
+    it('hides what scrolls into it rather than letting it reach the trigger', async () => {
+      await overflowingSingleLineField();
+
+      expect(backdrop().backgroundColor).toBe(getComputedStyle(editor()).backgroundColor);
+    });
+
+    it('still lets a click there put the caret in the field', async () => {
+      await overflowingSingleLineField();
+
+      // Karma's banner can push the fixture out of the viewport, where nothing hit-tests at all.
+      editor().scrollIntoView({ block: 'center' });
+      const field = editor().getBoundingClientRect();
+      // Other fixtures share the document, so only this one's elements can be hit-tested.
+      const hits = document
+        .elementsFromPoint(field.right - 3, field.top + field.height / 2)
+        .filter(element => fixture.nativeElement.contains(element));
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits[0]).toBe(editor());
+    });
+
+    it('dims with the field rather than staying a solid block on it', async () => {
+      await overflowingSingleLineField();
+      paramInput().setDisabledState(true);
+      fixture.detectChanges();
+
+      expect(parseFloat(backdrop().opacity)).toBeLessThan(1);
+    });
+
+    it('is not reserved on a multiline field, which puts the trigger below the text', async () => {
+      await overflowingSingleLineField();
+      const singleLine = getComputedStyle(editor()).scrollPaddingInlineEnd;
+
+      fixture.componentInstance.multiline.set(true);
+      fixture.detectChanges();
+
+      expect(parseFloat(singleLine)).toBeGreaterThan(0);
+      expect(getComputedStyle(editor()).scrollPaddingInlineEnd).toBe('auto');
+    });
+  });
+
 });

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/param-input/param-input.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/param-input/param-input.component.ts
@@ -31,7 +31,11 @@ import { VariableTextInputComponent } from '../variable-text-input/variable-text
     },
   ],
   template: `
-    <div class="pi-shell" [class.pi-multiline]="multiline" [class.pi-has-liquid]="showLiquid">
+    <div
+      class="pi-shell"
+      [class.pi-multiline]="multiline"
+      [class.pi-has-liquid]="showLiquid"
+      [class.pi-disabled]="disabledState()">
       @if (usesVariableEditor) {
         <shared-variable-text-input
           class="pi-field"

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/variable-text-input/variable-text-input.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/variable-text-input/variable-text-input.component.scss
@@ -41,6 +41,9 @@
  * `min-height` stays the binding constraint (see control-size).
  */
 .vti-editor:not(.vti-multiline) {
+  // The caret is revealed into the padding box, which is where an overlaid action is painted.
+  // isUnderOverlaidAction reads this back as the band's width, so it has to stay in step with it.
+  scroll-padding-inline-end: var(--input-action-inline-band, auto);
   scrollbar-width: none;
   line-height: calc(var(--vti-height) - 2 * var(--vti-pad-y) - 3px);
 }

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/variable-text-input/variable-text-input.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/variable-text-input/variable-text-input.component.spec.ts
@@ -249,6 +249,86 @@ describe('VariableTextInputComponent', () => {
     });
   });
 
+  describe('a field with an action overlaid on it', () => {
+    const GUTTER = 46;
+    const BAND = GUTTER + 10;
+
+    function overlayAction(): void {
+      editor().style.width = '200px';
+      editor().style.setProperty('--input-action-inline-gutter', `${GUTTER}px`);
+      editor().style.setProperty('--input-action-inline-band', `${BAND}px`);
+      fixture.detectChanges();
+    }
+
+    function overflowingValue(): void {
+      setValue('a {{ vars.title }} and enough trailing text to overflow the box several times over');
+    }
+
+    it('reveals the end of an overflowing value clear of the space the action reserved', () => {
+      overlayAction();
+      setValue('enough leading text to overflow the box several times over {{ vars.title }}');
+
+      const end = chips()[chips().length - 1];
+      editor().scrollLeft = 0;
+      end.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+
+      const revealed = editor().getBoundingClientRect().right
+        - end.getBoundingClientRect().right;
+      expect(revealed).toBeGreaterThanOrEqual(BAND);
+    });
+
+    it('does not remove a reference the action is painted over', () => {
+      overlayAction();
+      overflowingValue();
+      const emitted: string[] = [];
+      component.valueChange.subscribe(v => emitted.push(v));
+
+      const chip = chips()[0];
+      editor().scrollLeft = chip.offsetLeft - 10;
+      const remove = chip.querySelector<HTMLElement>('.vti-chip-remove')!;
+      remove.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: editor().getBoundingClientRect().right - 3,
+      }));
+      fixture.detectChanges();
+
+      expect(emitted).toEqual([]);
+      expect(chips().length).toBe(1);
+    });
+
+    it('still removes a reference the user can see', () => {
+      overlayAction();
+      overflowingValue();
+      const emitted: string[] = [];
+      component.valueChange.subscribe(v => emitted.push(v));
+
+      const chip = chips()[0];
+      const remove = chip.querySelector<HTMLElement>('.vti-chip-remove')!;
+      remove.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: chip.getBoundingClientRect().right,
+      }));
+      fixture.detectChanges();
+
+      expect(chips().length).toBe(0);
+    });
+
+    it('removes a reference anywhere in a field that has no action overlaid on it', () => {
+      editor().style.width = '200px';
+      overflowingValue();
+
+      const chip = chips()[0];
+      const remove = chip.querySelector<HTMLElement>('.vti-chip-remove')!;
+      remove.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        clientX: editor().getBoundingClientRect().right - 3,
+      }));
+      fixture.detectChanges();
+
+      expect(chips().length).toBe(0);
+    });
+  });
+
   describe('reading the edited tree back', () => {
     it('turns a token typed as loose text into a chip and emits the value', () => {
       setValue('Hello ');

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/variable-text-input/variable-text-input.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/variable-text-input/variable-text-input.component.ts
@@ -274,12 +274,28 @@ export class VariableTextInputComponent implements AfterViewInit {
     const chip = remove?.parentElement;
     const token = chip?.dataset['token'];
     if (!chip || token === undefined || this.disabled) return;
+    if (this.isUnderOverlaidAction(event)) return;
 
     const start = this.offsetBefore(chip);
     if (start === null) return;
     event.preventDefault();
     const value = this.valueState();
     this.commit(value.slice(0, start) + value.slice(start + token.length), start);
+  }
+
+  // An action overlaid on the field hides whatever scrolled under the band it reserved, and the
+  // backdrop passes clicks through so the field stays focusable there.
+  private isUnderOverlaidAction(event: MouseEvent): boolean {
+    const editor = this.editorRef?.nativeElement;
+    if (!editor) return false;
+
+    const style = getComputedStyle(editor);
+    const band = parseFloat(style.scrollPaddingInlineEnd);
+    if (!Number.isFinite(band)) return false;
+
+    const contentEdge = editor.getBoundingClientRect().right
+      - band - parseFloat(style.borderInlineEndWidth);
+    return event.clientX > contentEdge;
   }
 
   onBlur(): void {

--- a/ui/angular/projects/desktop-ui/src/app/components/template-builder/template-builder.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/template-builder/template-builder.component.scss
@@ -10,11 +10,10 @@
 /*
  * The trigger sits inside the text field it belongs to (issue #665), so it carries no border or
  * control padding of its own - a bordered box inside a bordered box. The host sizes it through
- * --tb-trigger-width / --tb-trigger-height and reserves matching padding on the field, so typed
- * text cannot reach it.
+ * --tb-trigger-width / --tb-trigger-height and reserves matching padding on the field.
  *
- * The opaque background is not decoration: a multi-line field scrolls its content underneath the
- * trigger, which would otherwise show through it.
+ * The opaque background is not decoration: a field scrolls its content underneath the trigger,
+ * which would otherwise show through it.
  */
 .tb-trigger {
   display: inline-flex;


### PR DESCRIPTION
Closes #706

## Summary

A single-line variable field reserves inline-end padding for the Liquid trigger, but a scroll box
paints through its own padding, so overflowing text and chips collided with the glyph. The shell now
paints that band opaque, keeps the caret out of it, and ignores a chip remove click inside it.

## Testing

ng test desktop-ui 3818/3818, npm run build:prod, dotnet build -c Release -warnaserror and dotnet
test MacroDeck.slnx -c Release all green. Seven of the new specs fail when the fix is reverted.
Checked in the running desktop UI on the History Graph subtitle: nothing painted in the band at any
scroll offset, caret stays visible while typing, focus border intact, template builder still opens.
Not verified: a real keystroke in the Tauri webview, and WebKitGTK.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] I reviewed and understand every submitted change
