### PR TITLE
Tolerate timer resolution in elapsed assertions

### DIFF
--- a/sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests/A16_GracefulShutdownTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests/A16_GracefulShutdownTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using MacroDeck.Plugin.Protocol.Envelope;
 using MacroDeck.Plugin.Protocol.Errors;
 using MacroDeck.Plugin.Testing.Tests.UnitTests.Support;
@@ -95,15 +94,15 @@ public class A16_GracefulShutdownTests
 		await host.WaitForSessionAsync(TimeSpan.FromSeconds(30));
 
 		var grace = TimeSpan.FromSeconds(2);
-		var stopwatch = Stopwatch.StartNew();
 		var report = await plugin.StopGracefullyAsync(grace);
-		stopwatch.Stop();
 
 		Assert.Multiple(() =>
 		{
 			Assert.That(report.ExitedWithinGrace, Is.False);
 			Assert.That(report.Killed, Is.True);
-			Assert.That(report.Elapsed, Is.GreaterThanOrEqualTo(grace));
+			// A grace period may fire marginally before the stopwatch agrees it is due, so this asserts
+			// only that the kill waited out the grace period instead of happening early.
+			Assert.That(report.Elapsed, Is.GreaterThanOrEqualTo(grace - TimeSpan.FromMilliseconds(50)));
 			Assert.That(plugin.HasExited, Is.True);
 		});
 	}

--- a/sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests/A3_TimeoutTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Testing.Tests.UnitTests/A3_TimeoutTests.cs
@@ -50,7 +50,9 @@ public class A3_TimeoutTests
 		{
 			Assert.That(outcome.Succeeded, Is.False);
 			Assert.That(outcome.Error!.Code, Is.EqualTo(ProtocolErrorCodes.Timeout));
-			Assert.That(outcome.Elapsed, Is.GreaterThanOrEqualTo(timeout));
+			// A deadline may fire marginally before the stopwatch agrees it is due, so this asserts only
+			// that the call waited out the deadline instead of failing early on its own.
+			Assert.That(outcome.Elapsed, Is.GreaterThanOrEqualTo(timeout - TimeSpan.FromMilliseconds(50)));
 		});
 
 		// Proves the handler itself observed the cancellation - not that the test host merely gave up


### PR DESCRIPTION
## Summary

A3_TimeoutTests failed once on CI with an elapsed time 0.24 ms short of the requested 200 ms timeout,
and passed on a re-run of the same commit. The deadline is enforced by a CancelAfter timer while
Elapsed is read from a Stopwatch: two clocks that need not agree to the tick, with platform timer
granularity of roughly 15 ms on top. An exact greater-than-or-equal comparison was never derivable
from what the timeout contract promises.

What the contract does promise is that the call waits out the deadline instead of failing early on
its own, so the assertion stays with 50 ms of tolerance rather than being dropped. It is still worth
keeping: the sibling assertions prove that the call timed out, but only this one would catch a
miscomputed remaining budget that cancels immediately and reports TIMEOUT in roughly zero
milliseconds.

A16_GracefulShutdownTests carries the same pattern for its grace period and got the same tolerance.
The other elapsed assertion there compares a fast exit against a 10 second budget and is left alone.
A Stopwatch in the same file that was started and stopped but never asserted is removed.

## Testing

dotnet test on MacroDeck.Plugin.Testing.Tests.UnitTests in Release, filtered to A3_TimeoutTests and
A16_GracefulShutdownTests: 4 passed.

## Plugin SDK / API compatibility

No public contract changed. The change is test-only; no production timeout behaviour was touched.

- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
