### PR TITLE
Keep CPU Load graphs in sync across many widgets

### DIFF
--- a/host/src/MacroDeckHost.Application/Variables/TemplateVariableAccess.cs
+++ b/host/src/MacroDeckHost.Application/Variables/TemplateVariableAccess.cs
@@ -1,0 +1,111 @@
+using Scriban;
+using Scriban.Functions;
+using Scriban.Syntax;
+
+namespace MacroDeckHost.Application.Variables;
+
+internal static class TemplateVariableAccess
+{
+	private const string VarsName = "vars";
+
+	private static readonly string[] _pureFilters =
+	[
+		"append", "capitalize", "downcase", "lstrip", "prepend", "remove", "remove_first", "replace",
+		"replace_first", "rstrip", "strip", "strip_newlines", "truncate", "truncatewords", "upcase", "abs", "ceil",
+		"divided_by", "floor", "minus", "modulo", "plus", "round", "times", "escape", "escape_once",
+		"newline_to_br", "strip_html", "default", "size",
+	];
+
+	private static readonly HashSet<string> _bareCallees =
+		new(_pureFilters.Append(TemplateFilters.PlainTextName), StringComparer.Ordinal);
+
+	private static readonly HashSet<(string Target, string Member)> _memberCallees = BuildMemberCallees();
+
+	public static IReadOnlyCollection<string>? ReadNames(Template template)
+	{
+		if (template.HasErrors || template.Page is null)
+		{
+			return null;
+		}
+
+		var names = new HashSet<string>(StringComparer.Ordinal);
+		return Visit(template.Page, names) ? names : null;
+	}
+
+	// Only listed shapes may use a reduced context: anything else, however harmless it looks, could read a
+	// variable the walk cannot name (object.eval_template renders a runtime string against the whole context).
+	private static bool Visit(ScriptNode? node, HashSet<string> names)
+	{
+		switch (node)
+		{
+			case null:
+				return true;
+			case ScriptMemberExpression or ScriptIndexerExpression when TryReadVariable(node, out var name):
+				names.Add(name);
+				return true;
+			case ScriptFunctionCall call:
+				return IsPureCallee(call.Target) && call.Arguments.All(argument => Visit(argument, names));
+			case ScriptPage or ScriptBlockStatement or ScriptRawStatement or ScriptEscapeStatement
+				or ScriptExpressionStatement or ScriptIfStatement or ScriptElseStatement or ScriptEndStatement
+				or ScriptNopStatement or ScriptKeyword or ScriptToken or ScriptList or ScriptPipeCall
+				or ScriptNestedExpression or ScriptLiteral or ScriptBinaryExpression or ScriptUnaryExpression:
+				return node.Children.All(child => Visit(child, names));
+			default:
+				return false;
+		}
+	}
+
+	private static bool TryReadVariable(ScriptNode node, out string name)
+	{
+		var current = node;
+
+		while (current is ScriptMemberExpression { Target: var target, Member: ScriptVariable } member &&
+			!IsVars(target))
+		{
+			current = member.Target;
+		}
+
+		switch (current)
+		{
+			case ScriptMemberExpression { Target: var root, Member: ScriptVariable variable } when IsVars(root):
+				name = variable.Name;
+				return true;
+			case ScriptIndexerExpression { Target: var root, Index: ScriptLiteral { Value: string literal } }
+				when IsVars(root):
+				name = literal;
+				return true;
+			default:
+				name = string.Empty;
+				return false;
+		}
+	}
+
+	private static bool IsVars(ScriptExpression? expression)
+		=> expression is ScriptVariableGlobal { Name: VarsName };
+
+	private static bool IsPureCallee(ScriptExpression? callee)
+		=> callee switch
+		{
+			ScriptVariableGlobal global => _bareCallees.Contains(global.Name),
+			ScriptMemberExpression { Target: ScriptVariableGlobal target, Member: ScriptVariable member }
+				=> _memberCallees.Contains((target.Name, member.Name)),
+			_ => false,
+		};
+
+	private static HashSet<(string Target, string Member)> BuildMemberCallees()
+	{
+		var callees = new HashSet<(string Target, string Member)>();
+
+		foreach (var filter in _pureFilters)
+		{
+			if (LiquidBuiltinsFunctions.TryLiquidToScriban(filter, out var target, out var member) &&
+				target is not null &&
+				member is not null)
+			{
+				callees.Add((target, member));
+			}
+		}
+
+		return callees;
+	}
+}

--- a/host/src/MacroDeckHost.Application/Variables/TemplateVariableAccess.cs
+++ b/host/src/MacroDeckHost.Application/Variables/TemplateVariableAccess.cs
@@ -45,10 +45,23 @@ internal static class TemplateVariableAccess
 				return true;
 			case ScriptFunctionCall call:
 				return IsPureCallee(call.Target) && call.Arguments.All(argument => Visit(argument, names));
-			case ScriptPage or ScriptBlockStatement or ScriptRawStatement or ScriptEscapeStatement
-				or ScriptExpressionStatement or ScriptIfStatement or ScriptElseStatement or ScriptEndStatement
-				or ScriptNopStatement or ScriptKeyword or ScriptToken or ScriptList or ScriptPipeCall
-				or ScriptNestedExpression or ScriptLiteral or ScriptBinaryExpression or ScriptUnaryExpression:
+			case ScriptPage
+				or ScriptBlockStatement
+				or ScriptRawStatement
+				or ScriptEscapeStatement
+				or ScriptExpressionStatement
+				or ScriptIfStatement
+				or ScriptElseStatement
+				or ScriptEndStatement
+				or ScriptNopStatement
+				or ScriptKeyword
+				or ScriptToken
+				or ScriptList
+				or ScriptPipeCall
+				or ScriptNestedExpression
+				or ScriptLiteral
+				or ScriptBinaryExpression
+				or ScriptUnaryExpression:
 				return node.Children.All(child => Visit(child, names));
 			default:
 				return false;

--- a/host/src/MacroDeckHost.Application/Variables/VariableTemplateRenderer.cs
+++ b/host/src/MacroDeckHost.Application/Variables/VariableTemplateRenderer.cs
@@ -108,7 +108,8 @@ public class VariableTemplateRenderer : IVariableTemplateRenderer
 	private static readonly ParserOptions _liquidParserOptions = new() { LiquidFunctionsToScriban = true };
 
 	private readonly VariableRegistry _registry;
-	private readonly ConcurrentDictionary<string, Template> _templateCache = new();
+	private readonly ConcurrentDictionary<string, ParsedTemplate> _templateCache = new();
+	private readonly ConcurrentDictionary<(VariableScope Scope, string? ScopeRefId), RenderMemo> _memo = new();
 
 	public VariableTemplateRenderer(VariableRegistry registry)
 	{
@@ -119,9 +120,108 @@ public class VariableTemplateRenderer : IVariableTemplateRenderer
 		=> Task.FromResult(Render(templateText, contextScope, contextScopeRefId));
 
 	public string Render(string templateText, VariableScope contextScope, string? contextScopeRefId)
-		=> ContainsLiquid(templateText)
-			? Render(templateText, BuildContext(contextScope, contextScopeRefId))
-			: templateText;
+	{
+		if (!ContainsLiquid(templateText))
+		{
+			return templateText;
+		}
+
+		var parsed = Parse(templateText);
+		if (parsed.Names is null)
+		{
+			return Render(parsed.Template, BuildContext(contextScope, contextScopeRefId));
+		}
+
+		var snapshot = CaptureSnapshot(parsed.Names, contextScope, contextScopeRefId);
+		var key = (contextScope, contextScopeRefId);
+
+		if (_memo.TryGetValue(key, out var memo) &&
+			string.Equals(memo.TemplateText, templateText, StringComparison.Ordinal) &&
+			memo.Snapshot.SequenceEqual(snapshot))
+		{
+			return memo.Output;
+		}
+
+		var output = RenderSnapshot(parsed.Template, snapshot);
+		_memo[key] = new RenderMemo(templateText, snapshot, output);
+		return output;
+	}
+
+	internal IReadOnlyList<VariableSnapshot> CaptureSnapshot(
+		IReadOnlyCollection<string> names,
+		VariableScope contextScope,
+		string? contextScopeRefId)
+	{
+		var readsLocals = contextScope != VariableScope.Global && !string.IsNullOrEmpty(contextScopeRefId);
+		var snapshot = new List<VariableSnapshot>(names.Count);
+
+		foreach (var name in names)
+		{
+			var entity = (readsLocals ? _registry.FindByName(contextScope, contextScopeRefId, name) : null) ??
+				_registry.FindByName(VariableScope.Global, null, name);
+
+			snapshot.Add(entity is null
+				? new VariableSnapshot(name, null, false)
+				: new VariableSnapshot(name, Detach(entity), _registry.IsAvailable(entity.Id)));
+		}
+
+		return snapshot;
+	}
+
+	internal string RenderSnapshot(string templateText, IReadOnlyList<VariableSnapshot> snapshot)
+		=> RenderSnapshot(Parse(templateText).Template, snapshot);
+
+	private static string RenderSnapshot(Template template, IReadOnlyList<VariableSnapshot> snapshot)
+	{
+		var vars = new VariablesScriptObject();
+		var resolvable = new Dictionary<string, VariableEntity>(StringComparer.Ordinal);
+
+		// Rendered from the detached copies only, never the live entities writers mutate in place: the memo
+		// then stores text and snapshot that describe the same data, so an equal snapshot means equal text.
+		foreach (var entry in snapshot)
+		{
+			if (entry.Variable is not { } variable)
+			{
+				continue;
+			}
+
+			vars[entry.Name] = EntryOf(variable, entry.IsAvailable);
+			if (entry.IsAvailable)
+			{
+				resolvable[entry.Name] = variable;
+			}
+		}
+
+		var root = new ScriptObject { ["vars"] = vars, ["event"] = new ScriptObject() };
+		return Render(template, new VariableContext(resolvable, root));
+	}
+
+	private ParsedTemplate Parse(string templateText)
+		=> _templateCache.GetOrAdd(templateText, text =>
+		{
+			var template = Template.ParseLiquid(text, null, _liquidParserOptions);
+			return new ParsedTemplate(template, TemplateVariableAccess.ReadNames(template));
+		});
+
+	private static VariableEntity Detach(VariableEntity live) => new()
+	{
+		Id = live.Id,
+		Name = live.Name,
+		Scope = live.Scope,
+		ScopeRefId = live.ScopeRefId,
+		Type = live.Type,
+		Classification = live.Classification,
+		Value = live.Value,
+		DecimalPlaces = live.DecimalPlaces,
+		Unit = live.Unit,
+		SemanticKind = live.SemanticKind,
+		Attributes = live.Attributes is { } attributes
+			? new Dictionary<string, string>(attributes, StringComparer.Ordinal)
+			: null,
+		Min = live.Min,
+		Max = live.Max,
+		Step = live.Step,
+	};
 
 	public Task<VariableContext> CreateContextAsync(VariableScope contextScope, string? contextScopeRefId)
 		=> Task.FromResult(BuildContext(contextScope, contextScopeRefId));
@@ -154,16 +254,11 @@ public class VariableTemplateRenderer : IVariableTemplateRenderer
 		var resolvable = new Dictionary<string, VariableEntity>(StringComparer.Ordinal);
 		foreach (var kv in byName)
 		{
-			if (_registry.IsAvailable(kv.Value.Id))
+			var isAvailable = _registry.IsAvailable(kv.Value.Id);
+			vars[kv.Key] = EntryOf(kv.Value, isAvailable);
+			if (isAvailable)
 			{
-				vars[kv.Key] = Wrap(kv.Value, FormatForTemplate(kv.Value), isAvailable: true);
 				resolvable[kv.Key] = kv.Value;
-			}
-			else
-			{
-				// Wrapped on this branch too: a variable's unit does not stop existing because its
-				// provider is momentarily quiet, so vars.x.unit still resolves while vars.x reads "n/v".
-				vars[kv.Key] = Wrap(kv.Value, UnavailablePlaceholder, isAvailable: false);
 			}
 		}
 
@@ -178,12 +273,61 @@ public class VariableTemplateRenderer : IVariableTemplateRenderer
 			return templateText;
 		}
 
-		var parsed = _templateCache.GetOrAdd(templateText, t => Template.ParseLiquid(t, null, _liquidParserOptions));
+		return Render(Parse(templateText).Template, context);
+	}
+
+	private static string Render(Template template, VariableContext context)
+	{
 		var templateContext = new VariableTemplateContext();
 
 		templateContext.PushGlobal(TemplateFilters.CreateScope());
 		templateContext.PushGlobal(context.ScribanObject);
-		return parsed.Render(templateContext);
+		return template.Render(templateContext);
+	}
+
+	// Wrapped on the unavailable branch too: a variable's unit does not stop existing because its provider is
+	// momentarily quiet, so vars.x.unit still resolves while vars.x reads "n/v".
+	private static VariableTemplateValue EntryOf(VariableEntity variable, bool isAvailable)
+		=> isAvailable
+			? Wrap(variable, FormatForTemplate(variable), isAvailable: true)
+			: Wrap(variable, UnavailablePlaceholder, isAvailable: false);
+
+	private sealed record ParsedTemplate(Template Template, IReadOnlyCollection<string>? Names);
+
+	private sealed record RenderMemo(string TemplateText, IReadOnlyList<VariableSnapshot> Snapshot, string Output);
+
+	internal sealed record VariableSnapshot(string Name, VariableEntity? Variable, bool IsAvailable)
+	{
+		public bool Equals(VariableSnapshot? other)
+			=> other is not null &&
+				string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+				IsAvailable == other.IsAvailable &&
+				RendersAlike(Variable, other.Variable);
+
+		public override int GetHashCode() => HashCode.Combine(Name, IsAvailable, Variable?.Value);
+
+		private static bool RendersAlike(VariableEntity? left, VariableEntity? right)
+			=> left is null || right is null
+				? left is null && right is null
+				: left.Id == right.Id &&
+				left.Type == right.Type &&
+				string.Equals(left.Value, right.Value, StringComparison.Ordinal) &&
+				left.DecimalPlaces == right.DecimalPlaces &&
+				string.Equals(left.Unit, right.Unit, StringComparison.Ordinal) &&
+				string.Equals(left.SemanticKind, right.SemanticKind, StringComparison.Ordinal) &&
+				Nullable.Equals(left.Min, right.Min) &&
+				Nullable.Equals(left.Max, right.Max) &&
+				Nullable.Equals(left.Step, right.Step) &&
+				SameAttributes(left.Attributes, right.Attributes);
+
+		private static bool SameAttributes(
+			IReadOnlyDictionary<string, string>? left,
+			IReadOnlyDictionary<string, string>? right)
+			=> left is null || right is null
+				? left is null && right is null
+				: left.Count == right.Count &&
+				left.All(pair => right.TryGetValue(pair.Key, out var value) &&
+					string.Equals(value, pair.Value, StringComparison.Ordinal));
 	}
 
 	public static bool ContainsLiquid(string? template)

--- a/host/src/MacroDeckHost.Application/Variables/VariableTemplateRenderer.cs
+++ b/host/src/MacroDeckHost.Application/Variables/VariableTemplateRenderer.cs
@@ -197,11 +197,12 @@ public class VariableTemplateRenderer : IVariableTemplateRenderer
 	}
 
 	private ParsedTemplate Parse(string templateText)
-		=> _templateCache.GetOrAdd(templateText, text =>
-		{
-			var template = Template.ParseLiquid(text, null, _liquidParserOptions);
-			return new ParsedTemplate(template, TemplateVariableAccess.ReadNames(template));
-		});
+		=> _templateCache.GetOrAdd(templateText,
+			text =>
+			{
+				var template = Template.ParseLiquid(text, null, _liquidParserOptions);
+				return new ParsedTemplate(template, TemplateVariableAccess.ReadNames(template));
+			});
 
 	private static VariableEntity Detach(VariableEntity live) => new()
 	{

--- a/host/src/MacroDeckHost.Widgets/HistoryGraph/HistoryGraphWidgetSession.cs
+++ b/host/src/MacroDeckHost.Widgets/HistoryGraph/HistoryGraphWidgetSession.cs
@@ -15,6 +15,7 @@ internal sealed class HistoryGraphWidgetSession : IUiSession
 	private readonly IVariableHistoryWindow _window;
 	private readonly IVariableChangeNotifier _variables;
 	private readonly HashSet<string> _watched;
+	private readonly Lock _refreshSync = new();
 
 	public HistoryGraphWidgetSession(UiView view,
 		UiState<HistoryGraphViewState> state,
@@ -82,5 +83,12 @@ internal sealed class HistoryGraphWidgetSession : IUiSession
 
 	// One resolve feeds every property the tree reads, and an unchanged resolve compares equal - so a flat
 	// metric between two samples costs a comparison and emits no patch at all.
-	private void Refresh() => _state.Set(_resolver.Resolve(_window.Values));
+	private void Refresh()
+	{
+		// The sampling timer and the variable notifier both land here, and the resolver keeps state of its own.
+		lock (_refreshSync)
+		{
+			_state.Set(_resolver.Resolve(_window.Values));
+		}
+	}
 }

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableTemplateRendererCostTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableTemplateRendererCostTests.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using System.Globalization;
+using MacroDeckHost.Application.Variables;
+using MacroDeckHost.Domain.Entities;
+using MacroDeckHost.Domain.Enums;
+
+namespace MacroDeckHost.Tests.UnitTests.Variables;
+
+[TestFixture]
+public class VariableTemplateRendererCostTests
+{
+	private const int Cards = 84;
+	private const string Subtitle = "{{ vars.system_cpu_name }}";
+
+	[Test]
+	[CancelAfter(120_000)]
+	public void A_grid_of_cards_repaints_its_subtitles_as_fast_with_many_unrelated_variables_as_with_none()
+	{
+		var withNone = MedianPassMilliseconds(unrelatedVariables: 0);
+		var withMany = MedianPassMilliseconds(unrelatedVariables: 2000);
+
+		// A ratio with a floor, not a time budget: the requirement is that the cost does not grow with the
+		// registry, and a fixed number of milliseconds would fail on a slow or busy machine instead.
+		Assert.That(withMany,
+			Is.LessThan(Math.Max(withNone * 4, 5)),
+			$"one pass over {Cards} cards took {withNone:F2} ms with no other variables and {withMany:F2} ms with 2000");
+	}
+
+	private static double MedianPassMilliseconds(int unrelatedVariables)
+	{
+		var registry = new VariableRegistry();
+		registry.Upsert(Variable("system_cpu_name", "AMD Ryzen 5 7535H"));
+
+		for (var index = 0; index < unrelatedVariables; index++)
+		{
+			registry.Upsert(Variable($"unrelated_{index}", index.ToString(CultureInfo.InvariantCulture)));
+		}
+
+		var cards = Enumerable.Range(0, Cards)
+			.Select(_ => (Renderer: new VariableTemplateRenderer(registry), WidgetId: Guid.NewGuid().ToString()))
+			.ToList();
+
+		var passes = new List<double>();
+		var stopwatch = new Stopwatch();
+
+		for (var pass = 0; pass < 9; pass++)
+		{
+			stopwatch.Restart();
+
+			foreach (var (renderer, widgetId) in cards)
+			{
+				renderer.Render(Subtitle, VariableScope.Widget, widgetId);
+			}
+
+			stopwatch.Stop();
+			passes.Add(stopwatch.Elapsed.TotalMilliseconds);
+		}
+
+		var measured = passes.Skip(2).Order().ToList();
+		return measured[measured.Count / 2];
+	}
+
+	private static VariableEntity Variable(string name, string value) => new()
+	{
+		Id = Guid.NewGuid(),
+		Name = name,
+		Scope = VariableScope.Global,
+		Type = VariableType.Text,
+		Classification = VariableClassification.User,
+		Value = value,
+		UpdatedAt = DateTime.UtcNow,
+	};
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableTemplateRendererReducedContextTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableTemplateRendererReducedContextTests.cs
@@ -82,8 +82,7 @@ public class VariableTemplateRendererReducedContextTests
 		attributed.Attributes = new Dictionary<string, string> { ["room"] = "kitchen" };
 		var gone = Var("gone", "stale");
 
-		var registry = Registry(
-			Var("a", "Alpha"),
+		var registry = Registry(Var("a", "Alpha"),
 			Var("b", "Beta"),
 			Var("empty_text", string.Empty),
 			Var("flag", "true", VariableType.Boolean),
@@ -136,7 +135,9 @@ public class VariableTemplateRendererReducedContextTests
 		var live = Var("a", "one");
 		var registry = Registry(live);
 		var renderer = new VariableTemplateRenderer(registry);
-		string Render() => renderer.Render("{{ vars.a }}|{{ vars.a.unit }}|{{ vars.a.room }}", VariableScope.Global, null);
+
+		string Render() =>
+			renderer.Render("{{ vars.a }}|{{ vars.a.unit }}|{{ vars.a.room }}", VariableScope.Global, null);
 
 		Assert.That(Render(), Is.EqualTo("one||"));
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableTemplateRendererReducedContextTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableTemplateRendererReducedContextTests.cs
@@ -1,0 +1,246 @@
+using MacroDeckHost.Application.Variables;
+using MacroDeckHost.Domain.Entities;
+using MacroDeckHost.Domain.Enums;
+using Scriban;
+using Scriban.Parsing;
+
+namespace MacroDeckHost.Tests.UnitTests.Variables;
+
+[TestFixture]
+public class VariableTemplateRendererReducedContextTests
+{
+	private static readonly string _widgetId = Guid.NewGuid().ToString();
+
+	private static readonly string[] _templates =
+	[
+		"{{ vars.a }}",
+		"{{ vars.a }} and {{ vars.b }}",
+		"{{ vars.u }}{{ vars.u.unit }}",
+		"{{ vars.a.state.is_available }}/{{ vars.gone.state.is_available }}",
+		"{{ vars[\"a\"] }}",
+		"{{ vars.a | upcase }}",
+		"{{ vars.n | round: 1 }}",
+		"{{ vars.empty_text | default: vars.b }}",
+		"{{ vars.a | plain_text }}",
+		"{% if vars.n > 3 %}{{ vars.b }}{% elsif vars.flag %}f{% else %}-{% endif %}",
+		"{% if vars.flag %}yes{% endif %}",
+		"{{ vars.typo }}|{{ vars.typo.state.is_not_available }}",
+		"{{ vars.gone }}",
+		"{{ vars.shared }}",
+		"{{ vars.n }}",
+		"{{ vars.attr.room }}",
+		"{{ vars }}",
+		"{% for v in vars %}[{{ v }}]{% endfor %}",
+		"{{ vars == empty }}",
+		"{{ object.keys vars }}",
+		"{{ vars.a }}|{{ \"{{ vars.unrelated }}\" | object.eval_template }}",
+		"{{ object[\"eval_template\"] }}",
+		"{% assign k = \"unrelated\" %}{{ vars[k] }}",
+		"{{ vars.tags | split: \",\" | array.size }}",
+		"{% assign x = vars.a %}{{ x }}",
+		"{% capture c %}{{ vars.a }}{% endcapture %}{{ c }}",
+		"{% for t in vars.tags | split: \",\" %}{{ t }}{% endfor %}",
+		"{{ event.x }}",
+		"{{ vars.a ",
+	];
+
+	private static VariableEntity Var(
+		string name,
+		string value,
+		VariableType type = VariableType.Text,
+		VariableScope scope = VariableScope.Global,
+		string? scopeRefId = null) => new()
+	{
+		Id = Guid.NewGuid(),
+		Name = name,
+		Scope = scope,
+		ScopeRefId = scopeRefId,
+		Type = type,
+		Classification = VariableClassification.User,
+		Value = value,
+		UpdatedAt = DateTime.UtcNow,
+	};
+
+	private static VariableRegistry Registry(params VariableEntity[] variables)
+	{
+		var registry = new VariableRegistry();
+		foreach (var variable in variables)
+		{
+			registry.Upsert(variable);
+		}
+
+		return registry;
+	}
+
+	private static VariableRegistry Catalog()
+	{
+		var number = Var("n", "12.3456", VariableType.Numeric);
+		number.DecimalPlaces = 2;
+		var unit = Var("u", "40", VariableType.Numeric);
+		unit.Unit = "%";
+		var attributed = Var("attr", "on");
+		attributed.Attributes = new Dictionary<string, string> { ["room"] = "kitchen" };
+		var gone = Var("gone", "stale");
+
+		var registry = Registry(
+			Var("a", "Alpha"),
+			Var("b", "Beta"),
+			Var("empty_text", string.Empty),
+			Var("flag", "true", VariableType.Boolean),
+			Var("tags", "x,y"),
+			Var("unrelated", "LEAKED"),
+			Var("shared", "global shared"),
+			Var("shared", "widget shared", scope: VariableScope.Widget, scopeRefId: _widgetId),
+			Var("a", "widget alpha", scope: VariableScope.Widget, scopeRefId: _widgetId),
+			number,
+			unit,
+			attributed,
+			gone);
+
+		registry.SetAvailable(gone.Id, false);
+		return registry;
+	}
+
+	private static string Outcome(Func<string> render)
+	{
+		try
+		{
+			return render();
+		}
+		catch (Exception exception)
+		{
+			return "throws " + exception.GetType().Name;
+		}
+	}
+
+	[TestCaseSource(nameof(_templates))]
+	public async Task A_template_renders_the_same_text_as_it_does_against_the_full_context(string template)
+	{
+		foreach (var (scope, scopeRefId) in new[]
+			{ (VariableScope.Global, (string?)null), (VariableScope.Widget, _widgetId) })
+		{
+			var registry = Catalog();
+			var full = new VariableTemplateRenderer(registry);
+			var context = await full.CreateContextAsync(scope, scopeRefId);
+
+			var expected = Outcome(() => full.Render(template, context));
+			var actual = Outcome(() => new VariableTemplateRenderer(registry).Render(template, scope, scopeRefId));
+
+			Assert.That(actual, Is.EqualTo(expected), $"scope {scope}");
+		}
+	}
+
+	[Test]
+	public void A_template_follows_every_change_to_the_variable_it_names()
+	{
+		var live = Var("a", "one");
+		var registry = Registry(live);
+		var renderer = new VariableTemplateRenderer(registry);
+		string Render() => renderer.Render("{{ vars.a }}|{{ vars.a.unit }}|{{ vars.a.room }}", VariableScope.Global, null);
+
+		Assert.That(Render(), Is.EqualTo("one||"));
+
+		live.Value = "two";
+		Assert.That(Render(), Is.EqualTo("two||"), "a value written in place");
+
+		live.Value = "one";
+		Assert.That(Render(), Is.EqualTo("one||"), "a value written back");
+
+		live.Unit = "%";
+		Assert.That(Render(), Is.EqualTo("one|%|"), "a unit");
+
+		live.Attributes = new Dictionary<string, string> { ["room"] = "hall" };
+		Assert.That(Render(), Is.EqualTo("one|%|hall"), "an attribute");
+
+		live.Attributes = new Dictionary<string, string> { ["room"] = "kitchen" };
+		Assert.That(Render(), Is.EqualTo("one|%|kitchen"), "an attribute changed by content");
+
+		registry.SetAvailable(live.Id, false);
+		Assert.That(Render(), Does.StartWith(VariableTemplateRenderer.UnavailablePlaceholder), "availability");
+
+		registry.Remove(live.Id);
+		Assert.That(Render(), Is.EqualTo("||"), "deletion");
+	}
+
+	[Test]
+	public void An_unchanged_variable_renders_the_same_text_every_time()
+	{
+		var renderer = new VariableTemplateRenderer(Registry(Var("a", "same")));
+
+		var first = renderer.Render("{{ vars.a }}", VariableScope.Global, null);
+		var second = renderer.Render("{{ vars.a }}", VariableScope.Global, null);
+
+		Assert.That(second, Is.EqualTo(first).And.EqualTo("same"));
+	}
+
+	[Test]
+	public void A_polled_variable_that_stops_reporting_reads_as_unavailable_without_any_write()
+	{
+		var live = Var("cpu", "42");
+		live.Classification = VariableClassification.Integration;
+		live.OwnerIntegrationId = "system";
+		var renderer = new VariableTemplateRenderer(Registry(live));
+
+		Assert.That(renderer.Render("{{ vars.cpu }}", VariableScope.Global, null), Is.EqualTo("42"));
+
+		live.UpdatedAt = DateTime.UtcNow - VariableRegistry.IntegrationFreshness - TimeSpan.FromMinutes(1);
+
+		Assert.That(renderer.Render("{{ vars.cpu }}", VariableScope.Global, null),
+			Is.EqualTo(VariableTemplateRenderer.UnavailablePlaceholder));
+	}
+
+	[Test]
+	public void Two_templates_rendered_alternately_for_one_widget_each_show_their_own_text()
+	{
+		var renderer = new VariableTemplateRenderer(Registry(Var("a", "x")));
+
+		for (var round = 0; round < 3; round++)
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(renderer.Render("A {{ vars.a }}", VariableScope.Widget, _widgetId), Is.EqualTo("A x"));
+				Assert.That(renderer.Render("B {{ vars.a }}", VariableScope.Widget, _widgetId), Is.EqualTo("B x"));
+			});
+		}
+	}
+
+	[Test]
+	public void A_render_shows_the_variable_as_it_was_read_even_if_it_changes_while_rendering()
+	{
+		var live = Var("a", "v1");
+		var renderer = new VariableTemplateRenderer(Registry(live));
+		var snapshot = renderer.CaptureSnapshot(["a"], VariableScope.Global, null);
+
+		live.Value = "v2";
+
+		Assert.That(renderer.RenderSnapshot("{{ vars.a }}", snapshot), Is.EqualTo("v1"));
+
+		live.Value = "v1";
+		Assert.That(renderer.Render("{{ vars.a }}", VariableScope.Global, null), Is.EqualTo("v1"));
+
+		live.Value = "v3";
+		Assert.That(renderer.Render("{{ vars.a }}", VariableScope.Global, null), Is.EqualTo("v3"));
+	}
+
+	[TestCase("{{ vars.system_cpu_name }}", "system_cpu_name")]
+	[TestCase("{{ vars.n | round: 1 }}", "n")]
+	[TestCase("{{ vars.a | default: vars.b }}", "a,b")]
+	[TestCase("{% if vars.a %}{{ vars.b }}{% elsif vars.c %}c{% else %}-{% endif %}", "a,b,c")]
+	public void A_template_that_only_names_variables_reads_exactly_those(string template, string expected)
+	{
+		var names = TemplateVariableAccess.ReadNames(Parse(template));
+
+		Assert.That(names, Is.EquivalentTo(expected.Split(',')));
+	}
+
+	[TestCase("{{ vars }}")]
+	[TestCase("{{ \"{{ vars.b }}\" | object.eval_template }}")]
+	[TestCase("{{ vars.a | date: \"%Y\" }}")]
+	public void A_template_that_can_read_unnamed_variables_needs_the_full_context(string template)
+	{
+		Assert.That(TemplateVariableAccess.ReadNames(Parse(template)), Is.Null);
+	}
+
+	private static Template Parse(string template)
+		=> Template.ParseLiquid(template, null, new ParserOptions { LiquidFunctionsToScriban = true });
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/HistoryGraphWidgetSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/HistoryGraphWidgetSessionTests.cs
@@ -84,8 +84,8 @@ public class HistoryGraphWidgetSessionTests
 	public async Task A_subtitle_naming_the_value_variable_shows_the_new_value_after_one_publish()
 	{
 		var registry = Registry();
-		await using var fixture = new Fixture(
-			new { valueVariable = Metric, subtitle = "now {{ vars.system_cpu_usage_percent }}", maxValue = 100 },
+		await using var fixture = new Fixture(new
+				{ valueVariable = Metric, subtitle = "now {{ vars.system_cpu_usage_percent }}", maxValue = 100 },
 			registry: registry);
 
 		SetMetric(registry, 88);

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/HistoryGraphWidgetSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/HistoryGraphWidgetSessionTests.cs
@@ -81,6 +81,25 @@ public class HistoryGraphWidgetSessionTests
 	}
 
 	[Test]
+	public async Task A_subtitle_naming_the_value_variable_shows_the_new_value_after_one_publish()
+	{
+		var registry = Registry();
+		await using var fixture = new Fixture(
+			new { valueVariable = Metric, subtitle = "now {{ vars.system_cpu_usage_percent }}", maxValue = 100 },
+			registry: registry);
+
+		SetMetric(registry, 88);
+		fixture.Variables.Publish(Metric);
+
+		var written = fixture.Session.DrainPatches()
+			.SelectMany(patch => patch.Operations)
+			.SelectMany(operation => operation.Properties?.Values ?? [])
+			.Select(value => value.GetRawText());
+
+		Assert.That(written, Has.Some.Contains("now 88"));
+	}
+
+	[Test]
 	public async Task A_change_to_a_variable_the_card_does_not_name_leaves_it_alone()
 	{
 		await using var fixture = new Fixture(_config);


### PR DESCRIPTION
Reported on Discord (no issue): many identical CPU Load graphs update out of step.

## Summary

Every History Graph card rebuilt a template context over all variables to render its subtitle on each refresh, so a grid of cards changed value one after another. Templates that only name plain variables now render from just those variables and are skipped when nothing they read changed.

## Testing

Full solution build and test suites pass, with new tests for output parity against the full context, freshness and rendering cost. Measured 84 CPU Load cards on a running host: the spread between the first and last card changing dropped from about 55 ms to about 3 ms. Not verified on Windows.

## Notes

Each card still reads the live value at its own moment, so a few milliseconds of difference can remain.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
