### PR TITLE
Improve release notes rendering in the update dialog

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/release-notes.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/release-notes.spec.ts
@@ -1,0 +1,75 @@
+import { releaseNoteSections } from './release-notes';
+
+function shape(text: string): string[][] {
+  return releaseNoteSections(text).map(section => section.map(block => block.kind));
+}
+
+describe('releaseNoteSections', () => {
+  it('drops a leading "What\'s Changed" heading so the dialog heading stays the only title', () => {
+    expect(shape("## What's Changed\n### Bug Fixes\n* a")).toEqual([['heading', 'list']]);
+    expect(shape('## What’s changed\n* a')).toEqual([['list']]);
+  });
+
+  it('keeps a "What\'s Changed" heading that does not open the notes', () => {
+    expect(shape("Intro\n\n## What's Changed\n* a")).toEqual([['paragraph'], ['heading', 'list']]);
+  });
+
+  it('gives every heading its own section, whatever its level', () => {
+    expect(shape('### A\n* a\n### B\n* b\n## New Contributors\n* c')).toEqual([
+      ['heading', 'list'],
+      ['heading', 'list'],
+      ['heading', 'list'],
+    ]);
+  });
+
+  it('moves a paragraph that follows a category list out of that category', () => {
+    expect(shape('### Other\n* a\n\n**Full Changelog**: https://example.com/compare')).toEqual([['heading', 'list'], ['paragraph']]);
+    expect(shape('### Breaking\n* a\n\nMigrate by hand.')).toEqual([['heading', 'list'], ['paragraph']]);
+  });
+
+  it('keeps a paragraph between a category heading and its list inside the category', () => {
+    expect(shape('### A\nIntro\n* a')).toEqual([['heading', 'paragraph', 'list']]);
+  });
+
+  it('labels bare GitHub links the way the release page does and links @mentions to profiles', () => {
+    const [[list]] = releaseNoteSections([
+      '* Fix by @manuelmayer-dev in https://github.com/Macro-Deck-App/Macro-Deck/pull/697',
+      '* Port of https://github.com/Other/Repo/issues/12, mail a@b.example',
+      '* Range https://github.com/Macro-Deck-App/Macro-Deck/compare/v3.0.0-beta.2...v3.0.0-beta.3',
+      '* See [the docs](https://macro-deck.app/docs) and https://macro-deck.app',
+    ].join('\n'));
+
+    expect(list.kind === 'list' ? list.items : []).toEqual([
+      [
+        { kind: 'text', text: 'Fix by ' },
+        { kind: 'link', text: '@manuelmayer-dev', href: 'https://github.com/manuelmayer-dev' },
+        { kind: 'text', text: ' in ' },
+        { kind: 'link', text: '#697', href: 'https://github.com/Macro-Deck-App/Macro-Deck/pull/697', bare: true },
+      ],
+      [
+        { kind: 'text', text: 'Port of ' },
+        { kind: 'link', text: 'Other/Repo#12', href: 'https://github.com/Other/Repo/issues/12', bare: true },
+        { kind: 'text', text: ', mail a@b.example' },
+      ],
+      [
+        { kind: 'text', text: 'Range ' },
+        {
+          kind: 'link',
+          text: 'v3.0.0-beta.2...v3.0.0-beta.3',
+          href: 'https://github.com/Macro-Deck-App/Macro-Deck/compare/v3.0.0-beta.2...v3.0.0-beta.3',
+          bare: true,
+        },
+      ],
+      [
+        { kind: 'text', text: 'See ' },
+        { kind: 'link', text: 'the docs', href: 'https://macro-deck.app/docs' },
+        { kind: 'text', text: ' and ' },
+        { kind: 'link', text: 'https://macro-deck.app', href: 'https://macro-deck.app/', bare: true },
+      ],
+    ]);
+  });
+
+  it('returns no sections for notes that are only a comment', () => {
+    expect(shape('<!-- generated -->\n')).toEqual([]);
+  });
+});

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/release-notes.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/release-notes.ts
@@ -1,0 +1,81 @@
+import { MarkdownBlock, MarkdownInline, parseMarkdown } from '../../../util/markdown';
+
+const RELEASE_REPO = 'Macro-Deck-App/Macro-Deck';
+const WHATS_CHANGED = /^what['’]s changed$/i;
+const GITHUB_REFERENCE = /^https:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/(?:pull|issues)\/(\d+)\/?$/;
+const GITHUB_COMPARE = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/compare\/([^/?#]+)$/;
+const MENTION = /(^|[^\w@/.])@([A-Za-z0-9][A-Za-z0-9-]{0,38})/g;
+
+function plainText(inlines: MarkdownInline[]): string {
+  return inlines.map(run => run.text).join('').trim();
+}
+
+function shortLabel(text: string, href: string): string {
+  const reference = GITHUB_REFERENCE.exec(href);
+  if (reference) {
+    return reference[1] === RELEASE_REPO ? `#${reference[2]}` : `${reference[1]}#${reference[2]}`;
+  }
+  return GITHUB_COMPARE.exec(href)?.[1] ?? text;
+}
+
+function linkMentions(text: string): MarkdownInline[] {
+  const runs: MarkdownInline[] = [];
+  let last = 0;
+  for (const match of text.matchAll(MENTION)) {
+    const start = match.index + match[1].length;
+    if (start > last) {
+      runs.push({ kind: 'text', text: text.slice(last, start) });
+    }
+    runs.push({ kind: 'link', text: `@${match[2]}`, href: `https://github.com/${match[2]}` });
+    last = start + match[2].length + 1;
+  }
+  if (last < text.length) {
+    runs.push({ kind: 'text', text: text.slice(last) });
+  }
+  return runs;
+}
+
+function githubInlines(inlines: MarkdownInline[]): MarkdownInline[] {
+  return inlines.flatMap(run => {
+    if (run.kind === 'link' && run.bare) {
+      return [{ ...run, text: shortLabel(run.text, run.href) }];
+    }
+    return run.kind === 'text' ? linkMentions(run.text) : [run];
+  });
+}
+
+function githubBlock(block: MarkdownBlock): MarkdownBlock {
+  switch (block.kind) {
+    case 'heading':
+    case 'paragraph':
+    case 'quote':
+      return { ...block, inlines: githubInlines(block.inlines) };
+    case 'list':
+      return { ...block, items: block.items.map(githubInlines) };
+    default:
+      return block;
+  }
+}
+
+export function releaseNoteSections(text: string): MarkdownBlock[][] {
+  const blocks = parseMarkdown(text);
+  const first = blocks[0];
+  if (first?.kind === 'heading' && WHATS_CHANGED.test(plainText(first.inlines))) {
+    blocks.shift();
+  }
+
+  const sections: MarkdownBlock[][] = [];
+  let current: MarkdownBlock[] | null = null;
+  for (const block of blocks) {
+    const closesCategory = current !== null
+      && current[0].kind === 'heading'
+      && current[current.length - 1].kind === 'list'
+      && block.kind !== 'list';
+    if (current === null || block.kind === 'heading' || closesCategory) {
+      current = [];
+      sections.push(current);
+    }
+    current.push(githubBlock(block));
+  }
+  return sections;
+}

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.html
@@ -1,6 +1,7 @@
 <shared-modal
   [heading]="heading()"
-  [maxWidth]="'520px'"
+  [maxWidth]="'900px'"
+  [style.--modal-height]="'min(88vh, 60rem)'"
   (close)="onModalClose()">
   <div class="update-modal">
     @if (versionHeading(); as version) {
@@ -22,7 +23,12 @@
         <h4 class="update-modal__section-heading">{{ appStrings.Update.Details.ChangelogHeading | translate }}</h4>
         <div class="update-modal__changelog">
           @if (hasChangelog()) {
-            <shared-store-markdown [text]="changelogText()" />
+            @for (section of sections(); track $index) {
+              <shared-store-markdown
+                class="update-modal__notes-section"
+                [class.update-modal__notes-section--category]="section[0].kind === 'heading'"
+                [blocks]="section" />
+            }
           } @else {
             <p class="update-modal__no-changelog">{{ appStrings.Update.Details.NoChangelog | translate }}</p>
           }

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  height: 100%;
 }
 
 .update-modal__version {
@@ -25,6 +26,13 @@
   font-size: var(--text-sm);
 }
 
+.update-modal__changelog-section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 10rem;
+}
+
 .update-modal__section-heading {
   margin: 0 0 var(--space-2);
   color: var(--color-text-primary);
@@ -33,9 +41,24 @@
 }
 
 .update-modal__changelog {
-  max-height: 16rem;
+  --md-font-size: var(--text-base);
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  gap: var(--space-3);
+  min-height: 0;
   overflow-y: auto;
   padding-right: var(--space-2);
+}
+
+.update-modal__notes-section {
+  display: block;
+}
+
+.update-modal__notes-section--category {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
 }
 
 .update-modal__no-changelog {

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.spec.ts
@@ -155,6 +155,55 @@ describe('UpdateModalComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('<script>alert(1)</script>');
   });
 
+  it('renders GitHub release notes without the generator comment or a second heading, one bordered section per category', async () => {
+    const notes = [
+      '<!-- Release notes generated using configuration in .github/release.yml at fd59e92 -->',
+      '',
+      "## What's Changed",
+      '### 🛠 Breaking Changes',
+      '* Detect GPUs by @a in https://github.com/Macro-Deck-App/Macro-Deck/pull/697',
+      '### 🐞 Bug Fixes',
+      '* Run a button press by @a in https://github.com/Macro-Deck-App/Macro-Deck/pull/689',
+      '* Keep widget border animating by @a in https://github.com/Macro-Deck-App/Macro-Deck/pull/691',
+      '',
+      '## New Contributors',
+      '* @b made their first contribution in https://github.com/Macro-Deck-App/Macro-Deck/pull/700',
+      '',
+      '',
+      '**Full Changelog**: https://github.com/Macro-Deck-App/Macro-Deck/compare/v3.0.0-beta.2...v3.0.0-beta.3',
+    ].join('\n');
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ notes })),
+      onUpdateState: () => Promise.resolve(() => {}),
+    });
+
+    const fixture = await createFixture();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text.split("What's new").length - 1).toBe(1);
+    expect(text).not.toContain("What's Changed");
+    expect(text).not.toContain('<!--');
+    expect(text).not.toContain('release.yml');
+
+    const changelog = fixture.nativeElement.querySelector('.update-modal__changelog') as HTMLElement;
+    const categories = Array.from(changelog.querySelectorAll<HTMLElement>('.update-modal__notes-section--category'));
+    expect(categories.map(section => section.querySelector('.md-heading')?.textContent?.trim()))
+      .toEqual(['🛠 Breaking Changes', '🐞 Bug Fixes', 'New Contributors']);
+    expect(changelog.textContent).toContain('Full Changelog');
+    expect(categories.some(section => section.textContent!.includes('Full Changelog'))).toBeFalse();
+  });
+
+  it('shows the no-changelog fallback when the notes are only a generator comment', async () => {
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ notes: '<!-- Release notes generated using configuration in .github/release.yml -->\n' })),
+      onUpdateState: () => Promise.resolve(() => {}),
+    });
+
+    const fixture = await createFixture();
+
+    expect(fixture.nativeElement.querySelector('.update-modal__no-changelog')).not.toBeNull();
+  });
+
   it('shows the no-changelog fallback for null notes', async () => {
     setShell({
       getUpdateState: () => Promise.resolve(makeState({ notes: null })),

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/update-modal/update-modal.component.ts
@@ -4,6 +4,7 @@ import { ButtonComponent, LocalizationService, ModalComponent, TranslatePipe, di
 import { StoreMarkdownComponent } from '../../store/store-markdown.component';
 import { UpdateModalService } from '../../../services/update-modal.service';
 import { UpdateService } from '../../../services/update.service';
+import { releaseNoteSections } from './release-notes';
 
 @Component({
   selector: 'app-update-modal',
@@ -56,8 +57,8 @@ export class UpdateModalComponent {
       ? this.localization.translateKey(AppStrings.Settings.Update.ChannelBeta)
       : this.localization.translateKey(AppStrings.Settings.Update.ChannelStable));
 
-  protected readonly changelogText = computed(() => this.updates.notes() ?? '');
-  protected readonly hasChangelog = computed(() => this.changelogText().trim().length > 0);
+  protected readonly sections = computed(() => releaseNoteSections(this.updates.notes() ?? ''));
+  protected readonly hasChangelog = computed(() => this.sections().length > 0);
 
   protected readonly downloadStatus = computed(() => {
     const percent = this.updates.progressPercent();

--- a/ui/angular/projects/desktop-ui/src/app/components/store/store-markdown.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/store/store-markdown.component.html
@@ -21,7 +21,7 @@
 </ng-template>
 
 <div class="md">
-  @for (block of blocks(); track $index) {
+  @for (block of rendered(); track $index) {
     @switch (block.kind) {
       @case ('heading') {
         @switch (block.level) {

--- a/ui/angular/projects/desktop-ui/src/app/components/store/store-markdown.component.scss
+++ b/ui/angular/projects/desktop-ui/src/app/components/store/store-markdown.component.scss
@@ -6,7 +6,7 @@
   gap: var(--space-3);
   min-width: 0;
   color: var(--color-text-secondary);
-  font-size: var(--text-sm);
+  font-size: var(--md-font-size, var(--text-sm));
   line-height: var(--leading-normal);
 
   > :first-child {
@@ -21,8 +21,17 @@
 .md-heading {
   margin: 0;
   color: var(--color-text-primary);
+  font-size: 1em;
   font-weight: var(--font-semibold);
   line-height: var(--leading-tight);
+}
+
+h3.md-heading {
+  font-size: 1.3em;
+}
+
+h4.md-heading {
+  font-size: 1.15em;
 }
 
 .md-paragraph {
@@ -69,7 +78,7 @@
   margin: 0;
   padding: var(--space-3);
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
+  font-size: inherit;
   line-height: var(--leading-normal);
   white-space: pre;
   color: var(--color-text-primary);

--- a/ui/angular/projects/desktop-ui/src/app/components/store/store-markdown.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/store/store-markdown.component.ts
@@ -14,7 +14,8 @@ import { MarkdownBlock, parseMarkdown } from '../../util/markdown';
   styleUrls: ['./store-markdown.component.scss'],
 })
 export class StoreMarkdownComponent {
-  readonly text = input.required<string>();
+  readonly text = input('');
+  readonly blocks = input<MarkdownBlock[] | null>(null);
 
-  protected readonly blocks = computed<MarkdownBlock[]>(() => parseMarkdown(this.text()));
+  protected readonly rendered = computed<MarkdownBlock[]>(() => this.blocks() ?? parseMarkdown(this.text()));
 }

--- a/ui/angular/projects/desktop-ui/src/app/util/markdown.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/util/markdown.spec.ts
@@ -73,4 +73,50 @@ describe('parseMarkdown', () => {
     const inlines = blocks[0].kind === 'paragraph' ? blocks[0].inlines : [];
     expect(inlines).toEqual([{ kind: 'link', text: 'docs', href: 'https://example.com/path' }]);
   });
+
+  it('turns a bare http or https URL into an https link and leaves trailing punctuation outside it', () => {
+    expect(parseMarkdown('See https://example.com/a_b, or http://example.com/x.')).toEqual([{
+      kind: 'paragraph',
+      inlines: [
+        { kind: 'text', text: 'See ' },
+        { kind: 'link', text: 'https://example.com/a_b', href: 'https://example.com/a_b', bare: true },
+        { kind: 'text', text: ', or ' },
+        { kind: 'link', text: 'http://example.com/x', href: 'https://example.com/x', bare: true },
+        { kind: 'text', text: '.' },
+      ],
+    }]);
+  });
+
+  it('never autolinks a non-http scheme', () => {
+    expect(JSON.stringify(parseMarkdown('javascript:alert(1) and ftp://example.com'))).not.toContain('"link"');
+  });
+
+  it('drops a block-level HTML comment, on one line or several, and keeps what follows', () => {
+    const blocks = parseMarkdown('<!-- generated at abc -->\n\n## Title\n\n<!--\nhidden\n-->\nAfter.');
+
+    expect(blocks.map(block => block.kind)).toEqual(['heading', 'paragraph']);
+    expect(JSON.stringify(blocks)).not.toContain('hidden');
+    expect(JSON.stringify(blocks)).not.toContain('<!--');
+  });
+
+  it('keeps text written after the closing --> on the same line', () => {
+    expect(parseMarkdown('<!-- note --> visible')).toEqual([{ kind: 'paragraph', inlines: [{ kind: 'text', text: 'visible' }] }]);
+  });
+
+  it('ends a paragraph at a comment line', () => {
+    expect(parseMarkdown('Line\n<!-- x -->\nNext').map(block => block.kind)).toEqual(['paragraph', 'paragraph']);
+  });
+
+  it('leaves a comment indented four spaces or opened mid-line as literal text', () => {
+    expect(JSON.stringify(parseMarkdown('    <!-- x -->'))).toContain('<!-- x -->');
+    expect(JSON.stringify(parseMarkdown('a <!-- x --> b'))).toContain('<!-- x -->');
+  });
+
+  it('keeps a comment inside a fenced code block as code', () => {
+    expect(parseMarkdown('```\n<!-- x -->\n```')).toEqual([{ kind: 'code', text: '<!-- x -->', language: null }]);
+  });
+
+  it('hides everything after an unterminated comment, as GitHub does', () => {
+    expect(parseMarkdown('Before\n\n<!-- open\nstill hidden')).toEqual([{ kind: 'paragraph', inlines: [{ kind: 'text', text: 'Before' }] }]);
+  });
 });

--- a/ui/angular/projects/desktop-ui/src/app/util/markdown.ts
+++ b/ui/angular/projects/desktop-ui/src/app/util/markdown.ts
@@ -7,7 +7,7 @@ export type MarkdownInline =
   | { kind: 'strong'; text: string }
   | { kind: 'em'; text: string }
   | { kind: 'code'; text: string }
-  | { kind: 'link'; text: string; href: string };
+  | { kind: 'link'; text: string; href: string; bare?: true };
 
 export type MarkdownBlock =
   | { kind: 'heading'; level: 1 | 2 | 3; inlines: MarkdownInline[] }
@@ -23,6 +23,8 @@ const ORDERED_ITEM = /^\d+\.\s+(.*)$/;
 const QUOTE_LINE = /^>\s?(.*)$/;
 const FENCE = /^```\s*(\S*)\s*$/;
 const RULE = /^([-*_])(?:\s*\1){2,}$/;
+const COMMENT_OPEN = /^ {0,3}<!--/;
+const TRAILING_PUNCTUATION = /[.,:;!?'"*_~]+$/;
 
 function safeHref(rawHref: string): string | null {
   const href = rawHref.trim();
@@ -40,7 +42,7 @@ function safeHref(rawHref: string): string | null {
   }
 }
 
-const INLINE_TOKEN = /(\*\*([^*]+)\*\*)|(\*([^*]+)\*)|(`([^`]+)`)|(\[([^\]]*)\]\(([^)\s]*)\))/;
+const INLINE_TOKEN = /(\*\*([^*]+)\*\*)|(\*([^*]+)\*)|(`([^`]+)`)|(\[([^\]]*)\]\(([^)\s]*)\))|(https?:\/\/[^\s<>()[\]]+)/;
 
 function parseInline(source: string): MarkdownInline[] {
   const inlines: MarkdownInline[] = [];
@@ -57,22 +59,28 @@ function parseInline(source: string): MarkdownInline[] {
       inlines.push({ kind: 'text', text: remaining.slice(0, match.index) });
     }
 
+    let consumed = match[0].length;
     if (match[1] !== undefined) {
       inlines.push({ kind: 'strong', text: match[2] });
     } else if (match[3] !== undefined) {
       inlines.push({ kind: 'em', text: match[4] });
     } else if (match[5] !== undefined) {
       inlines.push({ kind: 'code', text: match[6] });
-    } else {
+    } else if (match[7] !== undefined) {
       const href = safeHref(match[9]);
       if (href) {
         inlines.push({ kind: 'link', text: match[8], href });
       } else {
         inlines.push({ kind: 'text', text: match[0] });
       }
+    } else {
+      const url = match[10].replace(TRAILING_PUNCTUATION, '');
+      const href = safeHref(url);
+      inlines.push(href ? { kind: 'link', text: url, href, bare: true } : { kind: 'text', text: url });
+      consumed = url.length;
     }
 
-    remaining = remaining.slice(match.index + match[0].length);
+    remaining = remaining.slice(match.index + consumed);
   }
 
   return inlines;
@@ -102,6 +110,23 @@ export function parseMarkdown(source: string): MarkdownBlock[] {
       }
       i++; // skip closing fence (or EOF)
       blocks.push({ kind: 'code', text: codeLines.join('\n'), language });
+      continue;
+    }
+
+    if (COMMENT_OPEN.test(line)) {
+      let end = line.indexOf('-->', line.indexOf('<!--') + 4);
+      while (end < 0 && ++i < lines.length) {
+        end = lines[i].indexOf('-->');
+      }
+      if (i >= lines.length) {
+        break;
+      }
+      const rest = lines[i].slice(end + 3).trimStart();
+      if (rest === '') {
+        i++;
+      } else {
+        lines[i] = rest;
+      }
       continue;
     }
 
@@ -163,6 +188,7 @@ export function parseMarkdown(source: string): MarkdownBlock[] {
       !UNORDERED_ITEM.test(lines[i]) &&
       !ORDERED_ITEM.test(lines[i]) &&
       !QUOTE_LINE.test(lines[i]) &&
+      !COMMENT_OPEN.test(lines[i]) &&
       !RULE.test(lines[i].trim())
     ) {
       paragraphLines.push(lines[i]);


### PR DESCRIPTION
## Summary

The software update dialog is larger, hides the release.yml generator comment and the duplicate What's Changed heading, and shows each release note category as its own section. Bare URLs become links with GitHub-style short labels (#697, the compare range, @mentions).

## Testing

Full desktop-ui suite and production build pass, with new specs for comment handling, autolinks and section grouping. Verified in a browser against a running host with the real v3.0.0-beta.3 notes. The store pages share the markdown renderer but could not be checked visually, since the store is disabled in this build.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
