### PR TITLE
Advertise the host over mDNS for LAN discovery

### DIFF
--- a/docs/src/content/docs/policies/security.md
+++ b/docs/src/content/docs/policies/security.md
@@ -14,7 +14,7 @@ The host runs more than one listener.
 
 | Listener | Reachable from | Notes |
 | --- | --- | --- |
-| Public listener | The LAN | Serves the API and the web client. HTTPS is optional and configurable - see [ADR 0040](https://github.com/Macro-Deck-App/Macro-Deck/blob/main/engineering/decisions/0040-public-listeners-and-tls.md). |
+| Public listener | The LAN | Serves the API and the web client. HTTPS is optional and configurable - see [ADR 0040](https://github.com/Macro-Deck-App/Macro-Deck/blob/main/engineering/decisions/0040-public-listeners-and-tls.md). While its plain-HTTP port is serving, the host announces its instance name, version and that port on the LAN over mDNS (`_macrodeck._tcp`), unless this is turned off in Settings > Network - see [ADR 0082](https://github.com/Macro-Deck-App/Macro-Deck/blob/main/engineering/decisions/0082-lan-discovery-uses-the-platform-responder.md). |
 | Private loopback listener | The local machine only | Never gets TLS: the desktop shell and the plugin SDK reach it over plain HTTP on `127.0.0.1`. |
 
 **Plugin endpoints are served on both listeners but only accept a loopback remote address.** A caller

--- a/engineering/architecture.md
+++ b/engineering/architecture.md
@@ -47,6 +47,8 @@ Transport shortcuts such as Android ADB reverse tunnels must terminate on the pu
 
 The public listener can use HTTP or HTTPS according to the resolved network configuration. See [ADR 0040](decisions/0040-public-listeners-and-tls.md).
 
+The host advertises its plain-HTTP public listener on the LAN as `_macrodeck._tcp` through the operating system's own mDNS responder, so the companion app finds it without scanning. See [ADR 0082](decisions/0082-lan-discovery-uses-the-platform-responder.md).
+
 Backup archives concentrate the same secrets this trust boundary protects - the Data Protection key ring, the TLS and token signing keys, and every stored secret - encrypted under a key stored only on this installation. Backup download, import, and restore are therefore loopback-only, the same restriction setup and plugin pairing already have. The key ring itself is wrapped by a key held in the platform keystore and escrowed under that same recovery key, so the recovery key is the one root both an archive and the live installation depend on. See [ADR 0047](decisions/0047-secrets-backups-and-restore.md).
 
 ## Persistence and state changes

--- a/engineering/decisions/0082-lan-discovery-uses-the-platform-responder.md
+++ b/engineering/decisions/0082-lan-discovery-uses-the-platform-responder.md
@@ -1,0 +1,75 @@
+# ADR 0082: LAN discovery uses the platform's own mDNS responder
+
+Status: Accepted
+
+## Context
+
+The host announced itself on the network in no way at all, so the companion app found a host by probing
+every address in the subnet: hundreds of HTTP requests, 10 to 15 seconds, and unreliable. The companion
+already browses DNS-SD for `_macrodeck._tcp.local.` and connects to what it finds over plain HTTP, reading
+the host's real name and version from the TXT record.
+
+Multicast DNS runs on UDP 5353, and every desktop platform the host supports already runs a responder that
+owns that port: mDNSResponder on macOS, Avahi on most Linux desktops, and the DNS client service on
+Windows 10 1809 and later. A second responder in the host would share the port with it, answer the same
+queries independently, and on macOS in particular contend with the system daemon that already publishes the
+machine's own host records.
+
+## Decision
+
+The host registers the service through the platform responder, one small implementation per OS behind
+`IServiceAdvertiser`, with no new package:
+
+- **macOS:** `DNSServiceRegister` from libSystem. Deallocating the reference withdraws the service with
+  goodbye packets, and mDNSResponder does the same when the host process dies.
+- **Windows:** `DnsServiceRegister` / `DnsServiceDeRegister` from dnsapi.dll, available from Windows 10
+  1809. The host names itself `<host name>.local` and gives each registration that interface's IPv4 address.
+- **Linux:** libavahi-client, Avahi's own binding of its D-Bus API, on a threaded poll. The daemon withdraws
+  the entry group when the client disconnects.
+
+What is advertised is decided by one pure planner, not by the platform code:
+
+- The service type is `_macrodeck._tcp`. The SRV port is the public **plain-HTTP** listener and never the
+  HTTPS one. No plain-HTTP listener (HTTPS replaces it, or it could not be bound) means nothing is
+  advertised.
+- The instance name is the machine name that connection-info reports, cut to 63 UTF-8 bytes for the wire.
+  The TXT record carries `name` (the full, undeduplicated name) and `version`.
+- The service is registered **once per eligible interface**, never on "all interfaces", so a virtual adapter
+  never answers for the host. Loopback, tunnel and PPP interfaces, link-local-only interfaces (169.254/16),
+  and adapters whose name or description marks them as virtual (Hyper-V, WSL, Docker, VPN tunnels, VM
+  bridges and similar) are excluded.
+
+A hosted service reconciles the advertisement after start-up, on every network address or availability
+change (debounced), when the setting changes, and every 60 seconds. It only touches the responder when the
+plan changed or the responder lost a registration, for example after mDNSResponder or avahi-daemon
+restarted. Failure is logged and never stops the host. Advertising can be switched off in Settings >
+Network; it applies immediately and needs no restart.
+
+## Consequences
+
+- The host announces its machine name, version and plain-HTTP port to anyone on the LAN without
+  authentication, while the plain-HTTP listener is serving and the setting is on. The same information was
+  already reachable by probing the port.
+- A Linux system without avahi-daemon or libavahi-client, or an older Windows, simply is not advertised; the
+  companion still has the QR code, manual entry and its subnet scan.
+- A name conflict seen on one link only can rename just that interface's registration on macOS; on Linux,
+  where every interface shares one entry group, the whole group is renamed. The TXT `name` keeps the real
+  name, which is why the companion reads it.
+- A registration the responder rejects is retried at the next periodic check, not at once, so a lasting
+  conflict costs one warning and a probe a minute rather than a loop.
+- Adapter filtering is a name heuristic. A real LAN bridge named `bridge0` is excluded along with the VM
+  bridges the rule targets.
+- Unverified on Windows, where no test machine was available: whether registrations survive a hard-killed
+  host until their TTL ends, whether same-named registrations on several interfaces conflict with each other,
+  and whether Windows' own responder answers `<host>.local` with virtual adapter addresses regardless.
+  Windows has no documented automatic rename, so a conflicting registration is logged rather than retried
+  under another name.
+
+## Alternatives considered
+
+- **A managed mDNS responder library.** A second responder on UDP 5353 beside the one the OS already runs,
+  and a dependency for something every supported platform provides.
+- **Talking to Avahi over raw D-Bus.** There is no D-Bus library in the host, and libavahi-client is the
+  supported binding of exactly that interface.
+- **Registering on all interfaces.** Simpler, but it advertises the host on Hyper-V, WSL, Docker and VPN
+  adapters, which the companion cannot reach and must not be offered.

--- a/host/src/MacroDeckHost.Application/Network/Discovery/IServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Application/Network/Discovery/IServiceAdvertiser.cs
@@ -1,0 +1,21 @@
+namespace MacroDeckHost.Application.Network.Discovery;
+
+public interface IServiceAdvertiser : IDisposable
+{
+	event Action? StateChanged;
+
+	bool IsAvailable { get; }
+
+	bool NeedsRepublish { get; }
+
+	void CheckLiveness();
+
+	void Publish(ServiceAdvertisement advertisement);
+
+	void Withdraw();
+}
+
+public interface IDiscoveryAdvertisementRefresher
+{
+	void RequestRefresh();
+}

--- a/host/src/MacroDeckHost.Application/Network/Discovery/NetworkInterfaceSnapshot.cs
+++ b/host/src/MacroDeckHost.Application/Network/Discovery/NetworkInterfaceSnapshot.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using System.Net.NetworkInformation;
+
+namespace MacroDeckHost.Application.Network.Discovery;
+
+public sealed record NetworkInterfaceSnapshot(
+	int Index,
+	string Name,
+	string Description,
+	NetworkInterfaceType Type,
+	bool IsUp,
+	IReadOnlyList<IPAddress> Ipv4Addresses);
+
+public interface INetworkInterfaceSnapshotProvider
+{
+	IReadOnlyList<NetworkInterfaceSnapshot> GetInterfaces();
+}

--- a/host/src/MacroDeckHost.Application/Network/Discovery/ServiceAdvertisement.cs
+++ b/host/src/MacroDeckHost.Application/Network/Discovery/ServiceAdvertisement.cs
@@ -1,0 +1,39 @@
+using System.Net;
+
+namespace MacroDeckHost.Application.Network.Discovery;
+
+public readonly record struct TxtEntry(string Key, string Value);
+
+public readonly record struct AdvertisedInterface(int Index, IPAddress Ipv4);
+
+public sealed class ServiceAdvertisement : IEquatable<ServiceAdvertisement>
+{
+	public ServiceAdvertisement(string wireName,
+		int port,
+		IReadOnlyList<TxtEntry> txt,
+		IReadOnlyList<AdvertisedInterface> interfaces)
+	{
+		WireName = wireName;
+		Port = port;
+		Txt = txt;
+		Interfaces = interfaces;
+	}
+
+	public string WireName { get; }
+
+	public int Port { get; }
+
+	public IReadOnlyList<TxtEntry> Txt { get; }
+
+	public IReadOnlyList<AdvertisedInterface> Interfaces { get; }
+
+	public bool DescribesSameService(ServiceAdvertisement? other)
+		=> other is not null && WireName == other.WireName && Port == other.Port && Txt.SequenceEqual(other.Txt);
+
+	public bool Equals(ServiceAdvertisement? other)
+		=> DescribesSameService(other) && Interfaces.SequenceEqual(other!.Interfaces);
+
+	public override bool Equals(object? obj) => Equals(obj as ServiceAdvertisement);
+
+	public override int GetHashCode() => HashCode.Combine(WireName, Port, Interfaces.Count);
+}

--- a/host/src/MacroDeckHost.Application/Network/Discovery/ServiceAdvertisementPlanner.cs
+++ b/host/src/MacroDeckHost.Application/Network/Discovery/ServiceAdvertisementPlanner.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using MacroDeckHost.Application.Configuration;
+
+namespace MacroDeckHost.Application.Network.Discovery;
+
+public static class ServiceAdvertisementPlanner
+{
+	public const string ServiceType = "_macrodeck._tcp";
+
+	private const int MaximumLabelBytes = 63;
+
+	private static readonly string[] VirtualNamePrefixes =
+	[
+		"vEthernet", "docker", "br-", "veth", "virbr", "vmnet", "bridge", "utun", "tun", "tap", "wg", "zt",
+		"tailscale", "ipsec", "awdl", "llw", "anpi"
+	];
+
+	private static readonly string[] VirtualDescriptionMarkers =
+	[
+		"Hyper-V", "WSL", "Docker", "VirtualBox", "VMware", "TAP-", "WireGuard", "Tailscale", "ZeroTier", "OpenVPN",
+		"Virtual", "Loopback"
+	];
+
+	public static ServiceAdvertisement? Plan(bool enabled,
+		PublicEndpointSet endpoints,
+		string instanceName,
+		string version,
+		IReadOnlyList<NetworkInterfaceSnapshot> interfaces)
+	{
+		// Only plain HTTP is advertised: the companion connects to a discovered host over HTTP, so a TLS-only
+		// listener or a missing public listener means there is nothing a browsing client could use.
+		if (!enabled || endpoints.HttpPort is not { } port || string.IsNullOrWhiteSpace(instanceName))
+		{
+			return null;
+		}
+
+		var advertised = interfaces
+			.Where(IsLanInterface)
+			.Select(nic => (nic.Index, Address: nic.Ipv4Addresses.FirstOrDefault(IsLanAddress)))
+			.Where(entry => entry.Address is not null)
+			.Select(entry => new AdvertisedInterface(entry.Index, entry.Address!))
+			.DistinctBy(entry => entry.Index)
+			.OrderBy(entry => entry.Index)
+			.ToList();
+
+		if (advertised.Count == 0)
+		{
+			return null;
+		}
+
+		return new ServiceAdvertisement(ToDnsLabel(instanceName),
+			port,
+			[new TxtEntry("name", instanceName), new TxtEntry("version", version)],
+			advertised);
+	}
+
+	private static bool IsLanInterface(NetworkInterfaceSnapshot nic)
+		=> nic.IsUp &&
+			nic.Index > 0 &&
+			nic.Type is not (NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel or NetworkInterfaceType.Ppp) &&
+			!VirtualNamePrefixes.Any(prefix => nic.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) &&
+			!VirtualDescriptionMarkers.Any(marker => nic.Description.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+	private static bool IsLanAddress(IPAddress address)
+	{
+		if (address.AddressFamily != AddressFamily.InterNetwork || IPAddress.IsLoopback(address))
+		{
+			return false;
+		}
+
+		var bytes = address.GetAddressBytes();
+		return !(bytes[0] == 169 && bytes[1] == 254);
+	}
+
+	private static string ToDnsLabel(string name)
+	{
+		if (Encoding.UTF8.GetByteCount(name) <= MaximumLabelBytes)
+		{
+			return name;
+		}
+
+		var builder = new StringBuilder();
+		var length = 0;
+		foreach (var rune in name.EnumerateRunes())
+		{
+			if (length + rune.Utf8SequenceLength > MaximumLabelBytes)
+			{
+				break;
+			}
+
+			builder.Append(rune.ToString());
+			length += rune.Utf8SequenceLength;
+		}
+
+		return builder.ToString();
+	}
+}

--- a/host/src/MacroDeckHost.Application/Network/Discovery/ServiceAdvertisementPlanner.cs
+++ b/host/src/MacroDeckHost.Application/Network/Discovery/ServiceAdvertisementPlanner.cs
@@ -60,9 +60,12 @@ public static class ServiceAdvertisementPlanner
 	private static bool IsLanInterface(NetworkInterfaceSnapshot nic)
 		=> nic.IsUp &&
 			nic.Index > 0 &&
-			nic.Type is not (NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel or NetworkInterfaceType.Ppp) &&
+			nic.Type is not (NetworkInterfaceType.Loopback
+				or NetworkInterfaceType.Tunnel
+				or NetworkInterfaceType.Ppp) &&
 			!VirtualNamePrefixes.Any(prefix => nic.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) &&
-			!VirtualDescriptionMarkers.Any(marker => nic.Description.Contains(marker, StringComparison.OrdinalIgnoreCase));
+			!VirtualDescriptionMarkers.Any(marker =>
+				nic.Description.Contains(marker, StringComparison.OrdinalIgnoreCase));
 
 	private static bool IsLanAddress(IPAddress address)
 	{

--- a/host/src/MacroDeckHost.Application/Services/AppPreferenceService.cs
+++ b/host/src/MacroDeckHost.Application/Services/AppPreferenceService.cs
@@ -26,6 +26,8 @@ public partial class AppPreferenceService : IAppPreferenceService
 	public const string TlsModeKey = "network.tls.mode";
 	public const string TlsHttpsPortKey = "network.tls.httpsPort";
 
+	public const string DiscoveryEnabledKey = "network.discovery.enabled";
+
 	public const string AdbEnabledKey = "adb.enabled";
 	public const string AdbExecutablePathKey = "adb.executablePath";
 	public const string AdbUsbConnectionsEnabledKey = "adb.usbConnectionsEnabled";
@@ -183,19 +185,23 @@ public partial class AppPreferenceService : IAppPreferenceService
 		var storedTlsEnabled = (await _repository.GetByKey(TlsEnabledKey))?.Value;
 		var storedTlsMode = (await _repository.GetByKey(TlsModeKey))?.Value;
 		var storedTlsHttpsPort = (await _repository.GetByKey(TlsHttpsPortKey))?.Value;
+		var storedDiscoveryEnabled = (await _repository.GetByKey(DiscoveryEnabledKey))?.Value;
 
 		return BuildNetworkSettings(NormalizePublicPort(storedPort),
 			NormalizeTlsEnabled(storedTlsEnabled),
 			PublicTlsSelector.ParseMode(storedTlsMode),
-			NormalizeTlsHttpsPort(storedTlsHttpsPort));
+			NormalizeTlsHttpsPort(storedTlsHttpsPort),
+			NormalizeFlag(storedDiscoveryEnabled, true));
 	}
 
 	public async Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null)
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null)
 	{
 		var current = await GetNetwork();
+		var resolvedDiscoveryEnabled = discoveryEnabled ?? current.DiscoveryEnabled;
 
 		var resolvedPort = NormalizePublicPort(publicPort?.ToString(CultureInfo.InvariantCulture));
 		var resolvedTlsEnabled = tlsEnabled ?? PublicTlsSelector.DefaultTlsEnabled;
@@ -226,7 +232,16 @@ public partial class AppPreferenceService : IAppPreferenceService
 			await _repository.SetValue(TlsHttpsPortKey, resolvedTlsHttpsPort.ToString(CultureInfo.InvariantCulture));
 		}
 
-		return BuildNetworkSettings(resolvedPort, resolvedTlsEnabled, resolvedTlsMode, resolvedTlsHttpsPort);
+		if (resolvedDiscoveryEnabled != current.DiscoveryEnabled)
+		{
+			await _repository.SetValue(DiscoveryEnabledKey, resolvedDiscoveryEnabled.ToString());
+		}
+
+		return BuildNetworkSettings(resolvedPort,
+			resolvedTlsEnabled,
+			resolvedTlsMode,
+			resolvedTlsHttpsPort,
+			resolvedDiscoveryEnabled);
 	}
 
 	public async Task<AdbSettings> GetAdb()
@@ -489,7 +504,8 @@ public partial class AppPreferenceService : IAppPreferenceService
 	private NetworkSettings BuildNetworkSettings(int publicPort,
 		bool tlsEnabled,
 		PublicTlsMode tlsMode,
-		int tlsHttpsPort)
+		int tlsHttpsPort,
+		bool discoveryEnabled)
 	{
 		var certificateInfo = _certificateStore?.ReadInfo();
 		var authorityInfo = _certificateStore?.ReadAuthorityInfo();
@@ -525,7 +541,8 @@ public partial class AppPreferenceService : IAppPreferenceService
 			authorityInfo?.Subject,
 			authorityInfo?.Fingerprint,
 			authorityInfo?.NotBefore,
-			authorityInfo?.NotAfter);
+			authorityInfo?.NotAfter,
+			discoveryEnabled);
 	}
 
 	private static int NormalizePublicPort(string? value)

--- a/host/src/MacroDeckHost.Application/Services/IAppPreferenceService.cs
+++ b/host/src/MacroDeckHost.Application/Services/IAppPreferenceService.cs
@@ -38,7 +38,8 @@ public record NetworkSettings(
 	string? TlsAuthoritySubject,
 	string? TlsAuthorityFingerprint,
 	DateTimeOffset? TlsAuthorityNotBefore,
-	DateTimeOffset? TlsAuthorityNotAfter);
+	DateTimeOffset? TlsAuthorityNotAfter,
+	bool DiscoveryEnabled);
 
 public record AdbSettings(
 	bool Enabled,
@@ -90,10 +91,13 @@ public interface IAppPreferenceService
 
 	Task<NetworkSettings> GetNetwork();
 
+	// Unlike the TLS parameters, a null discoveryEnabled keeps the stored value, so a caller that only
+	// changes the port or TLS never switches network discovery on or off as a side effect.
 	Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null);
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null);
 
 	Task<AdbSettings> GetAdb();
 

--- a/host/src/MacroDeckHost.Application/Ui/Handlers/GetNetworkSettingsRequestMessageHandler.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Handlers/GetNetworkSettingsRequestMessageHandler.cs
@@ -59,6 +59,7 @@ public class GetNetworkSettingsRequestMessageHandler
 			RestartRequired = view.RestartRequired,
 			RestartSupported = view.RestartSupported,
 			RestartUnsupportedReason = view.RestartUnsupportedReason,
+			DiscoveryEnabled = view.DiscoveryEnabled,
 			MinimumPublicPort = PublicPortSelector.MinimumConfigurablePort,
 			MaximumPublicPort = PublicPortSelector.MaximumConfigurablePort
 		};

--- a/host/src/MacroDeckHost.Application/Ui/Handlers/NetworkSettingsProjection.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Handlers/NetworkSettingsProjection.cs
@@ -37,7 +37,8 @@ internal readonly record struct NetworkSettingsProjection(
 	string? TlsAuthorityNotAfter,
 	bool RestartRequired,
 	bool RestartSupported,
-	string? RestartUnsupportedReason)
+	string? RestartUnsupportedReason,
+	bool DiscoveryEnabled)
 {
 	public static NetworkSettingsProjection From(NetworkSettings settings, RestartAvailability restart)
 	{
@@ -80,6 +81,7 @@ internal readonly record struct NetworkSettingsProjection(
 			settings.TlsAuthorityNotAfter?.ToString("O"),
 			restartRequired,
 			restart.Supported,
-			restart.Reason);
+			restart.Reason,
+			settings.DiscoveryEnabled);
 	}
 }

--- a/host/src/MacroDeckHost.Application/Ui/Handlers/NetworkSettingsResponseFactory.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Handlers/NetworkSettingsResponseFactory.cs
@@ -50,6 +50,7 @@ internal static class NetworkSettingsResponseFactory
 			RestartRequired = view.RestartRequired,
 			RestartSupported = view.RestartSupported,
 			RestartUnsupportedReason = view.RestartUnsupportedReason,
+			DiscoveryEnabled = view.DiscoveryEnabled,
 			MinimumPublicPort = PublicPortSelector.MinimumConfigurablePort,
 			MaximumPublicPort = PublicPortSelector.MaximumConfigurablePort
 		};

--- a/host/src/MacroDeckHost.Application/Ui/Handlers/UpdateNetworkSettingsRequestMessageHandler.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Handlers/UpdateNetworkSettingsRequestMessageHandler.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using MacroDeckHost.Application.Configuration;
 using MacroDeckHost.Application.Lifecycle;
+using MacroDeckHost.Application.Network.Discovery;
 using MacroDeckHost.Application.Notifications;
 using MacroDeckHost.Application.Services;
 using MacroDeckHost.Application.Ui.Transport;
@@ -15,16 +16,19 @@ public class UpdateNetworkSettingsRequestMessageHandler
 	private readonly IApplicationRestartService _restart;
 	private readonly IHostListenerState _listenerState;
 	private readonly INetworkRestartNotifier _restartNotifier;
+	private readonly IDiscoveryAdvertisementRefresher _discovery;
 
 	public UpdateNetworkSettingsRequestMessageHandler(IAppPreferenceService preferences,
 		IApplicationRestartService restart,
 		IHostListenerState listenerState,
-		INetworkRestartNotifier restartNotifier)
+		INetworkRestartNotifier restartNotifier,
+		IDiscoveryAdvertisementRefresher discovery)
 	{
 		_preferences = preferences;
 		_restart = restart;
 		_listenerState = listenerState;
 		_restartNotifier = restartNotifier;
+		_discovery = discovery;
 	}
 
 	public async ValueTask<UpdateNetworkSettingsResponse> Handle(
@@ -54,14 +58,23 @@ public class UpdateNetworkSettingsRequestMessageHandler
 		var unchanged = request.PublicPort == current.PublicPort &&
 			effectiveTlsEnabled == current.TlsEnabled &&
 			effectiveTlsMode == current.TlsMode &&
-			effectiveTlsHttpsPort == current.TlsHttpsPort;
+			effectiveTlsHttpsPort == current.TlsHttpsPort &&
+			(request.DiscoveryEnabled is null || request.DiscoveryEnabled == current.DiscoveryEnabled);
 
+		// Discovery is passed through unresolved: SetNetwork resolves an omitted value from its own fresh
+		// read, so a TLS-only save racing a discovery save cannot write back the stale value read above.
 		var updated = unchanged
 			? current
 			: await _preferences.SetNetwork(request.PublicPort,
 				effectiveTlsEnabled,
 				effectiveTlsMode.ToString(),
-				effectiveTlsHttpsPort);
+				effectiveTlsHttpsPort,
+				request.DiscoveryEnabled);
+
+		if (!unchanged)
+		{
+			_discovery.RequestRefresh();
+		}
 
 		await _restartNotifier.Sync(cancellationToken);
 

--- a/host/src/MacroDeckHost.Application/Ui/Transport/Messages/Settings/GetNetworkSettingsResponse.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Transport/Messages/Settings/GetNetworkSettingsResponse.cs
@@ -24,6 +24,8 @@ public class GetNetworkSettingsResponse
 
 	public int MaximumPublicPort { get; set; }
 
+	public bool DiscoveryEnabled { get; set; }
+
 	public bool TlsEnabled { get; set; }
 
 	public string TlsMode { get; set; } = string.Empty;

--- a/host/src/MacroDeckHost.Application/Ui/Transport/Messages/Settings/UpdateNetworkSettingsRequest.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Transport/Messages/Settings/UpdateNetworkSettingsRequest.cs
@@ -9,4 +9,6 @@ public class UpdateNetworkSettingsRequest
 	public string? TlsMode { get; set; }
 
 	public int? TlsHttpsPort { get; set; }
+
+	public bool? DiscoveryEnabled { get; set; }
 }

--- a/host/src/MacroDeckHost.Application/Ui/Transport/Messages/Settings/UpdateNetworkSettingsResponse.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Transport/Messages/Settings/UpdateNetworkSettingsResponse.cs
@@ -28,6 +28,8 @@ public class UpdateNetworkSettingsResponse
 
 	public int MaximumPublicPort { get; set; }
 
+	public bool DiscoveryEnabled { get; set; }
+
 	public bool TlsEnabled { get; set; }
 
 	public string TlsMode { get; set; } = string.Empty;

--- a/host/src/MacroDeckHost.Infrastructure/Native/NativeUtf8.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Native/NativeUtf8.cs
@@ -1,0 +1,24 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace MacroDeckHost.Infrastructure.Native;
+
+internal static class NativeUtf8
+{
+	public static IntPtr Alloc(string value)
+	{
+		var bytes = Encoding.UTF8.GetBytes(value + "\0");
+		var buffer = Marshal.AllocHGlobal(bytes.Length);
+		Marshal.Copy(bytes, 0, buffer, bytes.Length);
+
+		return buffer;
+	}
+
+	public static void Free(IntPtr buffer)
+	{
+		if (buffer != IntPtr.Zero)
+		{
+			Marshal.FreeHGlobal(buffer);
+		}
+	}
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/DnsSdTxtRecord.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/DnsSdTxtRecord.cs
@@ -1,0 +1,23 @@
+using System.Text;
+using MacroDeckHost.Application.Network.Discovery;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+internal static class DnsSdTxtRecord
+{
+	private const int MaximumEntryBytes = 255;
+
+	public static byte[] Encode(IReadOnlyList<TxtEntry> entries)
+	{
+		var buffer = new List<byte>();
+		foreach (var entry in entries)
+		{
+			var bytes = Encoding.UTF8.GetBytes($"{entry.Key}={entry.Value}");
+			var length = Math.Min(bytes.Length, MaximumEntryBytes);
+			buffer.Add((byte)length);
+			buffer.AddRange(bytes.AsSpan(0, length));
+		}
+
+		return buffer.ToArray();
+	}
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/LinuxAvahiServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/LinuxAvahiServiceAdvertiser.cs
@@ -1,0 +1,362 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using MacroDeckHost.Application.Network.Discovery;
+using MacroDeckHost.Infrastructure.Native;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+[SupportedOSPlatform("linux")]
+internal sealed class LinuxAvahiServiceAdvertiser : IServiceAdvertiser
+{
+	private const string ClientLibrary = "libavahi-client.so.3";
+	private const string CommonLibrary = "libavahi-common.so.3";
+	private const int ClientFlagNoFail = 2;
+	private const int ClientStateRunning = 2;
+	private const int ClientStateFailure = 100;
+	private const int GroupStateCollision = 3;
+	private const int GroupStateFailure = 4;
+	private const int ProtocolInet = 0;
+
+	private static readonly Lazy<bool> Loadable = new(() =>
+		NativeLibrary.TryLoad(ClientLibrary, out var client) &&
+		NativeLibrary.TryLoad(CommonLibrary, out _) &&
+		NativeLibrary.TryGetExport(client, "avahi_entry_group_add_service_strlst", out _));
+
+	private readonly StateCallback _clientCallback;
+	private readonly StateCallback _groupCallback;
+	private IntPtr _poll;
+	private IntPtr _client;
+	private IntPtr _group;
+	private bool _pollStarted;
+	private string? _wireName;
+	private string? _alternativeName;
+	private volatile bool _stale = true;
+	private volatile bool _collision;
+	private volatile bool _clientFailed;
+
+	public LinuxAvahiServiceAdvertiser()
+	{
+		_clientCallback = OnClientState;
+		_groupCallback = OnGroupState;
+	}
+
+	public event Action? StateChanged;
+
+	public bool IsAvailable => Loadable.Value;
+
+	public bool NeedsRepublish => _stale || _collision || _clientFailed;
+
+	public void CheckLiveness()
+	{
+	}
+
+	public void Publish(ServiceAdvertisement advertisement)
+	{
+		EnsureClient();
+		_stale = true;
+
+		// Avahi's threaded poll runs callbacks on its own thread. Every call from outside it has to hold
+		// the poll lock, and the callbacks themselves must never take it.
+		avahi_threaded_poll_lock(_poll);
+		try
+		{
+			if (avahi_client_get_state(_client) != ClientStateRunning)
+			{
+				throw new InvalidOperationException("The Avahi daemon is not available");
+			}
+
+			var name = ResolveName(advertisement.WireName);
+			if (_group != IntPtr.Zero)
+			{
+				_ = avahi_entry_group_free(_group);
+			}
+
+			_group = avahi_entry_group_new(_client, _groupCallback, IntPtr.Zero);
+			if (_group == IntPtr.Zero)
+			{
+				throw Failure("avahi_entry_group_new", avahi_client_errno(_client));
+			}
+
+			AddServices(advertisement, name);
+			_stale = false;
+		}
+		finally
+		{
+			avahi_threaded_poll_unlock(_poll);
+		}
+	}
+
+	public void Withdraw()
+	{
+		if (_group == IntPtr.Zero)
+		{
+			return;
+		}
+
+		avahi_threaded_poll_lock(_poll);
+		try
+		{
+			_ = avahi_entry_group_free(_group);
+			_group = IntPtr.Zero;
+		}
+		finally
+		{
+			avahi_threaded_poll_unlock(_poll);
+		}
+	}
+
+	public void Dispose()
+	{
+		Withdraw();
+		if (_pollStarted)
+		{
+			_ = avahi_threaded_poll_stop(_poll);
+		}
+
+		if (_client != IntPtr.Zero)
+		{
+			avahi_client_free(_client);
+			_client = IntPtr.Zero;
+		}
+
+		if (_poll != IntPtr.Zero)
+		{
+			avahi_threaded_poll_free(_poll);
+			_poll = IntPtr.Zero;
+		}
+
+		GC.SuppressFinalize(this);
+	}
+
+	private void EnsureClient()
+	{
+		if (_client != IntPtr.Zero && !_clientFailed)
+		{
+			return;
+		}
+
+		if (_poll == IntPtr.Zero)
+		{
+			_poll = avahi_threaded_poll_new();
+			if (_poll == IntPtr.Zero)
+			{
+				throw new InvalidOperationException("avahi_threaded_poll_new failed");
+			}
+		}
+
+		avahi_threaded_poll_lock(_poll);
+		try
+		{
+			if (_client != IntPtr.Zero)
+			{
+				avahi_client_free(_client);
+				_client = IntPtr.Zero;
+				_group = IntPtr.Zero;
+			}
+
+			_clientFailed = false;
+			_client = avahi_client_new(avahi_threaded_poll_get(_poll),
+				ClientFlagNoFail,
+				_clientCallback,
+				IntPtr.Zero,
+				out var error);
+			if (_client == IntPtr.Zero)
+			{
+				throw Failure("avahi_client_new", error);
+			}
+		}
+		finally
+		{
+			avahi_threaded_poll_unlock(_poll);
+		}
+
+		if (!_pollStarted)
+		{
+			if (avahi_threaded_poll_start(_poll) < 0)
+			{
+				throw new InvalidOperationException("avahi_threaded_poll_start failed");
+			}
+
+			_pollStarted = true;
+		}
+	}
+
+	private string ResolveName(string wireName)
+	{
+		if (wireName != _wireName)
+		{
+			_wireName = wireName;
+			_alternativeName = null;
+		}
+
+		if (_collision)
+		{
+			_collision = false;
+			var alternative = NativeUtf8.Alloc(_alternativeName ?? wireName);
+			try
+			{
+				var renamed = avahi_alternative_service_name(alternative);
+				_alternativeName = Marshal.PtrToStringUTF8(renamed);
+				avahi_free(renamed);
+			}
+			finally
+			{
+				NativeUtf8.Free(alternative);
+			}
+		}
+
+		return _alternativeName ?? wireName;
+	}
+
+	private void AddServices(ServiceAdvertisement advertisement, string name)
+	{
+		var namePointer = NativeUtf8.Alloc(name);
+		var typePointer = NativeUtf8.Alloc(ServiceAdvertisementPlanner.ServiceType);
+		var entries = advertisement.Txt.Select(entry => NativeUtf8.Alloc($"{entry.Key}={entry.Value}")).ToArray();
+		var txt = avahi_string_list_new_from_array(entries, entries.Length);
+		try
+		{
+			foreach (var target in advertisement.Interfaces)
+			{
+				var result = avahi_entry_group_add_service_strlst(_group,
+					target.Index,
+					ProtocolInet,
+					0,
+					namePointer,
+					typePointer,
+					IntPtr.Zero,
+					IntPtr.Zero,
+					(ushort)advertisement.Port,
+					txt);
+				if (result < 0)
+				{
+					throw Failure("avahi_entry_group_add_service_strlst", result);
+				}
+			}
+
+			var committed = avahi_entry_group_commit(_group);
+			if (committed < 0)
+			{
+				throw Failure("avahi_entry_group_commit", committed);
+			}
+		}
+		finally
+		{
+			avahi_string_list_free(txt);
+			foreach (var entry in entries)
+			{
+				NativeUtf8.Free(entry);
+			}
+
+			NativeUtf8.Free(namePointer);
+			NativeUtf8.Free(typePointer);
+		}
+	}
+
+	private void OnClientState(IntPtr client, int state, IntPtr userData)
+	{
+		if (state == ClientStateFailure)
+		{
+			_clientFailed = true;
+		}
+		else
+		{
+			_stale = true;
+		}
+
+		StateChanged?.Invoke();
+	}
+
+	private void OnGroupState(IntPtr group, int state, IntPtr userData)
+	{
+		if (state == GroupStateCollision)
+		{
+			_collision = true;
+			StateChanged?.Invoke();
+		}
+		else if (state == GroupStateFailure)
+		{
+			// Left to the next periodic check rather than retried at once, so a lasting failure cannot loop.
+			_stale = true;
+		}
+	}
+
+	private static InvalidOperationException Failure(string operation, int error)
+		=> new($"{operation} failed: {Marshal.PtrToStringUTF8(avahi_strerror(error))}");
+
+	[DllImport(CommonLibrary)]
+	private static extern IntPtr avahi_threaded_poll_new();
+
+	[DllImport(CommonLibrary)]
+	private static extern IntPtr avahi_threaded_poll_get(IntPtr poll);
+
+	[DllImport(CommonLibrary)]
+	private static extern int avahi_threaded_poll_start(IntPtr poll);
+
+	[DllImport(CommonLibrary)]
+	private static extern int avahi_threaded_poll_stop(IntPtr poll);
+
+	[DllImport(CommonLibrary)]
+	private static extern void avahi_threaded_poll_free(IntPtr poll);
+
+	[DllImport(CommonLibrary)]
+	private static extern void avahi_threaded_poll_lock(IntPtr poll);
+
+	[DllImport(CommonLibrary)]
+	private static extern void avahi_threaded_poll_unlock(IntPtr poll);
+
+	[DllImport(CommonLibrary)]
+	private static extern IntPtr avahi_string_list_new_from_array(IntPtr[] array, int length);
+
+	[DllImport(CommonLibrary)]
+	private static extern void avahi_string_list_free(IntPtr list);
+
+	[DllImport(CommonLibrary)]
+	private static extern IntPtr avahi_alternative_service_name(IntPtr name);
+
+	[DllImport(CommonLibrary)]
+	private static extern void avahi_free(IntPtr pointer);
+
+	[DllImport(CommonLibrary)]
+	private static extern IntPtr avahi_strerror(int error);
+
+	[DllImport(ClientLibrary)]
+	private static extern IntPtr avahi_client_new(IntPtr poll,
+		int flags,
+		StateCallback callback,
+		IntPtr userData,
+		out int error);
+
+	[DllImport(ClientLibrary)]
+	private static extern void avahi_client_free(IntPtr client);
+
+	[DllImport(ClientLibrary)]
+	private static extern int avahi_client_get_state(IntPtr client);
+
+	[DllImport(ClientLibrary)]
+	private static extern int avahi_client_errno(IntPtr client);
+
+	[DllImport(ClientLibrary)]
+	private static extern IntPtr avahi_entry_group_new(IntPtr client, StateCallback callback, IntPtr userData);
+
+	[DllImport(ClientLibrary)]
+	private static extern int avahi_entry_group_free(IntPtr group);
+
+	[DllImport(ClientLibrary)]
+	private static extern int avahi_entry_group_commit(IntPtr group);
+
+	[DllImport(ClientLibrary)]
+	private static extern int avahi_entry_group_add_service_strlst(IntPtr group,
+		int interfaceIndex,
+		int protocol,
+		int flags,
+		IntPtr name,
+		IntPtr type,
+		IntPtr domain,
+		IntPtr host,
+		ushort port,
+		IntPtr txt);
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate void StateCallback(IntPtr source, int state, IntPtr userData);
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/MacOsDnsSdServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/MacOsDnsSdServiceAdvertiser.cs
@@ -18,7 +18,8 @@ internal sealed class MacOsDnsSdServiceAdvertiser
 	private const short PollHup = 0x10;
 
 	private static readonly Lazy<bool> Loadable = new(() =>
-		NativeLibrary.TryLoad(Library, out var handle) && NativeLibrary.TryGetExport(handle, "DNSServiceRegister", out _));
+		NativeLibrary.TryLoad(Library, out var handle) &&
+		NativeLibrary.TryGetExport(handle, "DNSServiceRegister", out _));
 
 	private readonly ILogger _logger = Log.ForContext<MacOsDnsSdServiceAdvertiser>();
 	private readonly HashSet<IntPtr> _failed = [];

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/MacOsDnsSdServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/MacOsDnsSdServiceAdvertiser.cs
@@ -1,0 +1,164 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using MacroDeckHost.Application.Network.Discovery;
+using MacroDeckHost.Infrastructure.Native;
+using Serilog;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+[SupportedOSPlatform("macos")]
+internal sealed class MacOsDnsSdServiceAdvertiser
+	: PerInterfaceServiceAdvertiser<MacOsDnsSdServiceAdvertiser.Registration>
+{
+	private const string Library = "/usr/lib/libSystem.B.dylib";
+	private const int NoError = 0;
+	private const short PollIn = 0x1;
+	private const short PollErr = 0x8;
+	private const short PollHup = 0x10;
+
+	private static readonly Lazy<bool> Loadable = new(() =>
+		NativeLibrary.TryLoad(Library, out var handle) && NativeLibrary.TryGetExport(handle, "DNSServiceRegister", out _));
+
+	private readonly ILogger _logger = Log.ForContext<MacOsDnsSdServiceAdvertiser>();
+	private readonly HashSet<IntPtr> _failed = [];
+	private readonly RegisterReply _reply;
+
+	public MacOsDnsSdServiceAdvertiser()
+	{
+		_reply = OnReply;
+	}
+
+	public override bool IsAvailable => Loadable.Value;
+
+	// Replies are only ever dispatched here, on the caller's thread, so a reference is never deallocated
+	// while mDNSResponder's client library is still processing it.
+	public override void CheckLiveness()
+	{
+		foreach (var registration in Registrations)
+		{
+			var descriptor = DNSServiceRefSockFD(registration.Reference);
+			if (descriptor < 0)
+			{
+				_failed.Add(registration.Reference);
+				continue;
+			}
+
+			var poll = new PollDescriptor { Descriptor = descriptor, Events = PollIn };
+			if (Poll(ref poll, 1, 0) <= 0 || (poll.ReturnedEvents & (PollIn | PollErr | PollHup)) == 0)
+			{
+				continue;
+			}
+
+			if (DNSServiceProcessResult(registration.Reference) != NoError)
+			{
+				_failed.Add(registration.Reference);
+			}
+		}
+	}
+
+	protected override Registration Register(ServiceAdvertisement service, AdvertisedInterface target)
+	{
+		var txt = DnsSdTxtRecord.Encode(service.Txt);
+		var name = NativeUtf8.Alloc(service.WireName);
+		var type = NativeUtf8.Alloc(ServiceAdvertisementPlanner.ServiceType);
+		try
+		{
+			var port = BitConverter.IsLittleEndian
+				? BinaryPrimitives.ReverseEndianness((ushort)service.Port)
+				: (ushort)service.Port;
+			var error = DNSServiceRegister(out var reference,
+				0,
+				(uint)target.Index,
+				name,
+				type,
+				IntPtr.Zero,
+				IntPtr.Zero,
+				port,
+				(ushort)txt.Length,
+				txt,
+				_reply,
+				IntPtr.Zero);
+
+			return error == NoError
+				? new Registration(reference)
+				: throw new InvalidOperationException($"DNSServiceRegister failed with error {error}");
+		}
+		finally
+		{
+			NativeUtf8.Free(name);
+			NativeUtf8.Free(type);
+		}
+	}
+
+	protected override void Unregister(Registration registration)
+	{
+		_failed.Remove(registration.Reference);
+		DNSServiceRefDeallocate(registration.Reference);
+	}
+
+	protected override bool IsAlive(Registration registration) => !_failed.Contains(registration.Reference);
+
+	private void OnReply(IntPtr reference,
+		uint flags,
+		int errorCode,
+		IntPtr name,
+		IntPtr registrationType,
+		IntPtr domain,
+		IntPtr context)
+	{
+		if (errorCode == NoError)
+		{
+			_logger.Debug("mDNSResponder registered {Name}", Marshal.PtrToStringUTF8(name));
+			return;
+		}
+
+		_logger.Warning("mDNSResponder reported error {ErrorCode} for a network discovery registration", errorCode);
+		_failed.Add(reference);
+	}
+
+	[DllImport(Library)]
+	private static extern int DNSServiceRegister(out IntPtr reference,
+		uint flags,
+		uint interfaceIndex,
+		IntPtr name,
+		IntPtr registrationType,
+		IntPtr domain,
+		IntPtr host,
+		ushort port,
+		ushort txtLength,
+		byte[] txtRecord,
+		RegisterReply callback,
+		IntPtr context);
+
+	[DllImport(Library)]
+	private static extern void DNSServiceRefDeallocate(IntPtr reference);
+
+	[DllImport(Library)]
+	private static extern int DNSServiceRefSockFD(IntPtr reference);
+
+	[DllImport(Library)]
+	private static extern int DNSServiceProcessResult(IntPtr reference);
+
+	[DllImport(Library, EntryPoint = "poll")]
+	private static extern int Poll(ref PollDescriptor descriptors, uint count, int timeout);
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate void RegisterReply(IntPtr reference,
+		uint flags,
+		int errorCode,
+		IntPtr name,
+		IntPtr registrationType,
+		IntPtr domain,
+		IntPtr context);
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct PollDescriptor
+	{
+		public int Descriptor;
+		public short Events;
+		public short ReturnedEvents;
+	}
+
+	internal sealed record Registration(IntPtr Reference);
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/PerInterfaceServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/PerInterfaceServiceAdvertiser.cs
@@ -1,0 +1,98 @@
+using MacroDeckHost.Application.Network.Discovery;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+internal abstract class PerInterfaceServiceAdvertiser<TRegistration> : IServiceAdvertiser
+	where TRegistration : class
+{
+	private readonly Dictionary<int, (AdvertisedInterface Target, TRegistration Registration)> _registered = [];
+	private ServiceAdvertisement? _service;
+	private bool _incomplete;
+
+	public event Action? StateChanged
+	{
+		add { }
+		remove { }
+	}
+
+	public abstract bool IsAvailable { get; }
+
+	public bool NeedsRepublish => _incomplete || _registered.Values.Any(entry => !IsAlive(entry.Registration));
+
+	protected IEnumerable<TRegistration> Registrations => _registered.Values.Select(entry => entry.Registration);
+
+	public virtual void CheckLiveness()
+	{
+	}
+
+	public void Publish(ServiceAdvertisement advertisement)
+	{
+		if (!advertisement.DescribesSameService(_service))
+		{
+			Withdraw();
+		}
+
+		_service = advertisement;
+		_incomplete = false;
+
+		foreach (var (index, entry) in _registered.ToList())
+		{
+			if (advertisement.Interfaces.Contains(entry.Target) && IsAlive(entry.Registration))
+			{
+				continue;
+			}
+
+			Unregister(entry.Registration);
+			_registered.Remove(index);
+		}
+
+		Exception? failure = null;
+		foreach (var target in advertisement.Interfaces)
+		{
+			if (_registered.ContainsKey(target.Index))
+			{
+				continue;
+			}
+
+			try
+			{
+				_registered[target.Index] = (target, Register(advertisement, target));
+			}
+			catch (Exception exception)
+			{
+				_incomplete = true;
+				failure ??= exception;
+			}
+		}
+
+		if (failure is not null)
+		{
+			throw new InvalidOperationException($"Advertising failed on at least one interface: {failure.Message}",
+				failure);
+		}
+	}
+
+	public void Withdraw()
+	{
+		foreach (var entry in _registered.Values)
+		{
+			Unregister(entry.Registration);
+		}
+
+		_registered.Clear();
+		_service = null;
+		_incomplete = false;
+	}
+
+	public void Dispose()
+	{
+		Withdraw();
+		GC.SuppressFinalize(this);
+	}
+
+	protected abstract TRegistration Register(ServiceAdvertisement service, AdvertisedInterface target);
+
+	protected abstract void Unregister(TRegistration registration);
+
+	protected abstract bool IsAlive(TRegistration registration);
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/ServiceAdvertisementBackgroundService.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/ServiceAdvertisementBackgroundService.cs
@@ -1,0 +1,202 @@
+using System.Net.NetworkInformation;
+using MacroDeckHost.Application.Configuration;
+using MacroDeckHost.Application.Network.Discovery;
+using MacroDeckHost.Application.Network.Tls;
+using MacroDeckHost.Application.Services;
+using MacroDeckHost.Infrastructure.BackgroundServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+public sealed class ServiceAdvertisementBackgroundService : HostReadyBackgroundService, IDiscoveryAdvertisementRefresher
+{
+	private static readonly TimeSpan Debounce = TimeSpan.FromSeconds(2);
+	private static readonly TimeSpan RecheckInterval = TimeSpan.FromSeconds(60);
+
+	private readonly IServiceScopeFactory _scopeFactory;
+	private readonly IServiceAdvertiser _advertiser;
+	private readonly IHostNameProvider _hostNames;
+	private readonly IHostListenerState _listenerState;
+	private readonly INetworkInterfaceSnapshotProvider _interfaces;
+	private readonly ILogger _logger = Log.ForContext<ServiceAdvertisementBackgroundService>();
+	private readonly SemaphoreSlim _wake = new(0, 1);
+	private readonly SemaphoreSlim _gate = new(1, 1);
+	private ServiceAdvertisement? _published;
+	private bool _advertised;
+	private string? _lastFailure;
+
+	public ServiceAdvertisementBackgroundService(IHostApplicationLifetime lifetime,
+		IServiceScopeFactory scopeFactory,
+		IServiceAdvertiser advertiser,
+		IHostNameProvider hostNames,
+		IHostListenerState listenerState,
+		INetworkInterfaceSnapshotProvider interfaces)
+		: base(lifetime)
+	{
+		_scopeFactory = scopeFactory;
+		_advertiser = advertiser;
+		_hostNames = hostNames;
+		_listenerState = listenerState;
+		_interfaces = interfaces;
+	}
+
+	public void RequestRefresh()
+	{
+		try
+		{
+			_wake.Release();
+		}
+		catch (SemaphoreFullException)
+		{
+		}
+	}
+
+	public override async Task StopAsync(CancellationToken cancellationToken)
+	{
+		await base.StopAsync(cancellationToken);
+
+		// The host's shutdown timeout can end the wait above while a reconcile is still running.
+		await _gate.WaitAsync(CancellationToken.None);
+		try
+		{
+			Withdraw();
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	public override void Dispose()
+	{
+		_wake.Dispose();
+		_gate.Dispose();
+		base.Dispose();
+	}
+
+	internal async Task Reconcile()
+	{
+		await _gate.WaitAsync(CancellationToken.None);
+		try
+		{
+			_advertiser.CheckLiveness();
+			var plan = ServiceAdvertisementPlanner.Plan(await IsEnabled(),
+				_listenerState.PublicEndpoints,
+				_hostNames.MachineName,
+				HostVersion.Current,
+				_interfaces.GetInterfaces());
+
+			if (plan is null)
+			{
+				Withdraw();
+				return;
+			}
+
+			var changed = !plan.Equals(_published);
+			if (!changed && !_advertiser.NeedsRepublish)
+			{
+				return;
+			}
+
+			_published = null;
+			_advertised = true;
+			_advertiser.Publish(plan);
+			_published = plan;
+			_lastFailure = null;
+
+			if (changed)
+			{
+				_logger.Information("Handed {InstanceName} as {ServiceType} on port {Port} over {InterfaceCount} " +
+					"network interfaces to the system mDNS responder",
+					plan.WireName,
+					ServiceAdvertisementPlanner.ServiceType,
+					plan.Port,
+					plan.Interfaces.Count);
+			}
+		}
+		catch (Exception exception)
+		{
+			if (exception.Message == _lastFailure)
+			{
+				_logger.Debug(exception, "Network discovery advertisement is still failing");
+			}
+			else
+			{
+				_logger.Warning(exception, "Macro Deck could not be advertised on the local network; it keeps running");
+			}
+
+			_lastFailure = exception.Message;
+		}
+		finally
+		{
+			_gate.Release();
+		}
+	}
+
+	protected override async Task ExecuteWhenReady(CancellationToken stoppingToken)
+	{
+		if (!_advertiser.IsAvailable)
+		{
+			_logger.Information("Network discovery is not available on this system, so Macro Deck is not advertised " +
+				"on the local network");
+			return;
+		}
+
+		NetworkChange.NetworkAddressChanged += OnNetworkChanged;
+		NetworkChange.NetworkAvailabilityChanged += OnNetworkChanged;
+		_advertiser.StateChanged += RequestRefresh;
+		try
+		{
+			while (!stoppingToken.IsCancellationRequested)
+			{
+				await Reconcile();
+				if (await _wake.WaitAsync(RecheckInterval, stoppingToken))
+				{
+					await Task.Delay(Debounce, stoppingToken);
+					_wake.Wait(0, CancellationToken.None);
+				}
+			}
+		}
+		catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+		{
+		}
+		finally
+		{
+			NetworkChange.NetworkAddressChanged -= OnNetworkChanged;
+			NetworkChange.NetworkAvailabilityChanged -= OnNetworkChanged;
+			_advertiser.StateChanged -= RequestRefresh;
+		}
+	}
+
+	private void OnNetworkChanged(object? sender, EventArgs e) => RequestRefresh();
+
+	private async Task<bool> IsEnabled()
+	{
+		await using var scope = _scopeFactory.CreateAsyncScope();
+		var settings = await scope.ServiceProvider.GetRequiredService<IAppPreferenceService>().GetNetwork();
+		return settings.DiscoveryEnabled;
+	}
+
+	private void Withdraw()
+	{
+		if (!_advertised)
+		{
+			return;
+		}
+
+		try
+		{
+			_advertiser.Withdraw();
+			_logger.Information("Stopped advertising Macro Deck on the local network");
+		}
+		catch (Exception exception)
+		{
+			_logger.Warning(exception, "Withdrawing the network discovery advertisement failed");
+		}
+
+		_published = null;
+		_advertised = false;
+	}
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/ServiceAdvertisementServiceCollectionExtensions.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/ServiceAdvertisementServiceCollectionExtensions.cs
@@ -1,0 +1,93 @@
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using MacroDeckHost.Application.Network.Discovery;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+public static class ServiceAdvertisementServiceCollectionExtensions
+{
+	public static IServiceCollection AddServiceAdvertisement(this IServiceCollection services)
+	{
+		services.AddSingleton<INetworkInterfaceSnapshotProvider, NetworkInterfaceSnapshotProvider>();
+		services.AddSingleton(CreateAdvertiser);
+		services.AddSingleton<ServiceAdvertisementBackgroundService>();
+		services.AddHostedService(provider => provider.GetRequiredService<ServiceAdvertisementBackgroundService>());
+		services.AddSingleton<IDiscoveryAdvertisementRefresher>(provider =>
+			provider.GetRequiredService<ServiceAdvertisementBackgroundService>());
+		return services;
+	}
+
+	private static IServiceAdvertiser CreateAdvertiser(IServiceProvider _)
+	{
+		if (OperatingSystem.IsMacOS())
+		{
+			return new MacOsDnsSdServiceAdvertiser();
+		}
+
+		if (OperatingSystem.IsWindows())
+		{
+			return new WindowsDnsServiceAdvertiser();
+		}
+
+		return OperatingSystem.IsLinux() ? new LinuxAvahiServiceAdvertiser() : new UnavailableServiceAdvertiser();
+	}
+}
+
+internal sealed class UnavailableServiceAdvertiser : IServiceAdvertiser
+{
+	public event Action? StateChanged
+	{
+		add { }
+		remove { }
+	}
+
+	public bool IsAvailable => false;
+
+	public bool NeedsRepublish => false;
+
+	public void CheckLiveness()
+	{
+	}
+
+	public void Publish(ServiceAdvertisement advertisement)
+	{
+	}
+
+	public void Withdraw()
+	{
+	}
+
+	public void Dispose()
+	{
+	}
+}
+
+internal sealed class NetworkInterfaceSnapshotProvider : INetworkInterfaceSnapshotProvider
+{
+	public IReadOnlyList<NetworkInterfaceSnapshot> GetInterfaces()
+	{
+		var snapshots = new List<NetworkInterfaceSnapshot>();
+		foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+		{
+			try
+			{
+				var properties = nic.GetIPProperties();
+				snapshots.Add(new NetworkInterfaceSnapshot(properties.GetIPv4Properties().Index,
+					nic.Name,
+					nic.Description,
+					nic.NetworkInterfaceType,
+					nic.OperationalStatus == OperationalStatus.Up,
+					properties.UnicastAddresses
+						.Select(address => address.Address)
+						.Where(address => address.AddressFamily == AddressFamily.InterNetwork)
+						.ToList()));
+			}
+			catch (NetworkInformationException)
+			{
+			}
+		}
+
+		return snapshots;
+	}
+}

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/WindowsDnsServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/WindowsDnsServiceAdvertiser.cs
@@ -182,8 +182,10 @@ internal sealed class WindowsDnsServiceAdvertiser
 		ushort priority,
 		ushort weight,
 		uint propertiesCount,
-		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] keys,
-		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] values);
+		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)]
+		string[] keys,
+		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)]
+		string[] values);
 
 	[DllImport(Library)]
 	private static extern uint DnsServiceRegister(IntPtr request, IntPtr cancel);

--- a/host/src/MacroDeckHost.Infrastructure/Network/Discovery/WindowsDnsServiceAdvertiser.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Network/Discovery/WindowsDnsServiceAdvertiser.cs
@@ -1,0 +1,220 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using MacroDeckHost.Application.Network.Discovery;
+using Serilog;
+
+namespace MacroDeckHost.Infrastructure.Network.Discovery;
+
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsDnsServiceAdvertiser
+	: PerInterfaceServiceAdvertiser<WindowsDnsServiceAdvertiser.Registration>
+{
+	private const string Library = "dnsapi.dll";
+	private const uint QueryRequestVersion1 = 1;
+	private const uint RequestPending = 9506;
+
+	private static readonly TimeSpan DeregisterTimeout = TimeSpan.FromSeconds(2);
+
+	private static readonly Lazy<bool> Loadable = new(() =>
+		OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763) &&
+		NativeLibrary.TryLoad(Library, out var handle) &&
+		NativeLibrary.TryGetExport(handle, "DnsServiceRegister", out _));
+
+	private readonly ILogger _logger = Log.ForContext<WindowsDnsServiceAdvertiser>();
+	private readonly ConcurrentDictionary<nint, bool> _failed = new();
+	private readonly ConcurrentDictionary<nint, Registration> _registering = new();
+	private readonly ConcurrentDictionary<nint, Registration> _deregistering = new();
+	private readonly ConcurrentDictionary<nint, bool> _abandoned = new();
+	private readonly ConcurrentDictionary<uint, bool> _loggedRejections = new();
+	private readonly RegisterComplete _complete;
+	private long _nextContext;
+
+	public WindowsDnsServiceAdvertiser()
+	{
+		_complete = OnComplete;
+	}
+
+	public override bool IsAvailable => Loadable.Value;
+
+	protected override Registration Register(ServiceAdvertisement service, AdvertisedInterface target)
+	{
+		var address = BitConverter.ToUInt32(target.Ipv4.GetAddressBytes());
+		var instance = DnsServiceConstructInstance(
+			$"{service.WireName}.{ServiceAdvertisementPlanner.ServiceType}.local",
+			HostName(),
+			ref address,
+			IntPtr.Zero,
+			(ushort)service.Port,
+			0,
+			0,
+			(uint)service.Txt.Count,
+			service.Txt.Select(entry => entry.Key).ToArray(),
+			service.Txt.Select(entry => entry.Value).ToArray());
+		if (instance == IntPtr.Zero)
+		{
+			throw new InvalidOperationException("DnsServiceConstructInstance failed");
+		}
+
+		var context = (nint)Interlocked.Increment(ref _nextContext);
+		var request = Marshal.AllocHGlobal(Marshal.SizeOf<RegisterRequest>());
+		Marshal.StructureToPtr(new RegisterRequest
+			{
+				Version = QueryRequestVersion1,
+				InterfaceIndex = (uint)target.Index,
+				ServiceInstance = instance,
+				Callback = Marshal.GetFunctionPointerForDelegate(_complete),
+				QueryContext = context
+			},
+			request,
+			false);
+
+		var registration = new Registration(instance, request, context);
+		_registering[context] = registration;
+		var status = DnsServiceRegister(request, IntPtr.Zero);
+		if (status == RequestPending)
+		{
+			return registration;
+		}
+
+		_registering.TryRemove(context, out _);
+		DnsServiceFreeInstance(instance);
+		Marshal.FreeHGlobal(request);
+		throw new InvalidOperationException($"DnsServiceRegister failed with status {status}");
+	}
+
+	protected override void Unregister(Registration registration)
+	{
+		// Windows may use the request and instance until each matching callback runs, so a callback that
+		// never arrives leaks them on purpose rather than freeing them under the service.
+		if (!registration.Registered.Task.Wait(DeregisterTimeout))
+		{
+			_abandoned[registration.Context] = true;
+			if (!registration.Registered.Task.IsCompleted || !_abandoned.TryRemove(registration.Context, out _))
+			{
+				_logger.Warning("Windows has not confirmed a network discovery registration yet; it is withdrawn " +
+					"as soon as it does");
+				return;
+			}
+		}
+
+		if (_failed.TryRemove(registration.Context, out _))
+		{
+			DnsServiceFreeInstance(registration.Instance);
+			Marshal.FreeHGlobal(registration.Request);
+			return;
+		}
+
+		_deregistering[registration.Context] = registration;
+		var status = DnsServiceDeRegister(registration.Request, IntPtr.Zero);
+		if (status == RequestPending && !registration.Deregistered.Task.Wait(DeregisterTimeout))
+		{
+			_logger.Warning("Windows did not confirm withdrawing a network discovery registration in time");
+			return;
+		}
+
+		_deregistering.TryRemove(registration.Context, out _);
+		DnsServiceFreeInstance(registration.Instance);
+		Marshal.FreeHGlobal(registration.Request);
+	}
+
+	protected override bool IsAlive(Registration registration) => !_failed.ContainsKey(registration.Context);
+
+	private void LogRejection(uint status)
+	{
+		if (!_loggedRejections.TryAdd(status, true))
+		{
+			_logger.Debug("Windows still rejects a network discovery registration with status {Status}", status);
+			return;
+		}
+
+		_logger.Warning("Windows rejected a network discovery registration with status {Status}; it is retried " +
+			"at the next check",
+			status);
+	}
+
+	private static string HostName()
+	{
+		var host = Dns.GetHostName();
+		return host.EndsWith(".local", StringComparison.OrdinalIgnoreCase) ? host : host + ".local";
+	}
+
+	private void OnComplete(uint status, IntPtr context, IntPtr instance)
+	{
+		if (instance != IntPtr.Zero)
+		{
+			DnsServiceFreeInstance(instance);
+		}
+
+		if (_registering.TryRemove(context, out var registered))
+		{
+			// A rejection waits for the next periodic check instead of waking the reconciler, so a lasting
+			// conflict cannot turn into a probe loop on the network.
+			if (status != 0)
+			{
+				_failed[context] = true;
+				LogRejection(status);
+			}
+
+			registered.Registered.TrySetResult();
+
+			if (_abandoned.TryRemove(context, out _))
+			{
+				_ = Task.Run(() => Unregister(registered));
+			}
+
+			return;
+		}
+
+		if (_deregistering.TryRemove(context, out var withdrawn))
+		{
+			withdrawn.Deregistered.TrySetResult();
+		}
+	}
+
+	[DllImport(Library, CharSet = CharSet.Unicode)]
+	private static extern IntPtr DnsServiceConstructInstance(string serviceName,
+		string hostName,
+		ref uint ipv4,
+		IntPtr ipv6,
+		ushort port,
+		ushort priority,
+		ushort weight,
+		uint propertiesCount,
+		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] keys,
+		[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] values);
+
+	[DllImport(Library)]
+	private static extern uint DnsServiceRegister(IntPtr request, IntPtr cancel);
+
+	[DllImport(Library)]
+	private static extern uint DnsServiceDeRegister(IntPtr request, IntPtr cancel);
+
+	[DllImport(Library)]
+	private static extern void DnsServiceFreeInstance(IntPtr instance);
+
+	[UnmanagedFunctionPointer(CallingConvention.Winapi)]
+	private delegate void RegisterComplete(uint status, IntPtr context, IntPtr instance);
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct RegisterRequest
+	{
+		public uint Version;
+		public uint InterfaceIndex;
+		public IntPtr ServiceInstance;
+		public IntPtr Callback;
+		public IntPtr QueryContext;
+		public IntPtr Credentials;
+		public int UnicastEnabled;
+	}
+
+	internal sealed record Registration(IntPtr Instance, IntPtr Request, nint Context)
+	{
+		public TaskCompletionSource Registered { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public TaskCompletionSource Deregistered { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+	}
+}

--- a/host/src/MacroDeckHost.Infrastructure/Security/KeyRing/KeyStore/LinuxSecretServiceKekStore.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Security/KeyRing/KeyStore/LinuxSecretServiceKekStore.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using MacroDeckHost.Application.Security.KeyRing;
+using MacroDeckHost.Infrastructure.Native;
 using MacroDeckHost.Infrastructure.Security.KeyRing.KeyStore.Native;
 
 namespace MacroDeckHost.Infrastructure.Security.KeyRing.KeyStore;
@@ -91,8 +92,8 @@ public sealed class LinuxSecretServiceKekStore : IKekStore
 		}
 
 		var encoded = Convert.ToBase64String(kek);
-		var label = LinuxSecretServiceInterop.Utf8($"{identity.Service} key ring");
-		var password = LinuxSecretServiceInterop.Utf8(encoded);
+		var label = NativeUtf8.Alloc($"{identity.Service} key ring");
+		var password = NativeUtf8.Alloc(encoded);
 		try
 		{
 			var stored = LinuxSecretServiceInterop.StoreSync(LinuxSecretServiceInterop.Schema,

--- a/host/src/MacroDeckHost.Infrastructure/Security/KeyRing/KeyStore/Native/LinuxSecretServiceInterop.cs
+++ b/host/src/MacroDeckHost.Infrastructure/Security/KeyRing/KeyStore/Native/LinuxSecretServiceInterop.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Text;
+using MacroDeckHost.Infrastructure.Native;
 
 namespace MacroDeckHost.Infrastructure.Security.KeyRing.KeyStore.Native;
 
@@ -53,8 +53,8 @@ internal static class LinuxSecretServiceInterop
 			return LinuxSecretAttributes.None;
 		}
 
-		var key = Utf8("account");
-		var value = Utf8(account);
+		var key = NativeUtf8.Alloc("account");
+		var value = NativeUtf8.Alloc(account);
 		HashTableInsert(table, key, value);
 
 		return new LinuxSecretAttributes(table, key, value);
@@ -77,15 +77,6 @@ internal static class LinuxSecretServiceInterop
 		{
 			ErrorFree(error);
 		}
-	}
-
-	public static IntPtr Utf8(string value)
-	{
-		var bytes = Encoding.UTF8.GetBytes(value + "\0");
-		var buffer = Marshal.AllocHGlobal(bytes.Length);
-		Marshal.Copy(bytes, 0, buffer, bytes.Length);
-
-		return buffer;
 	}
 
 	private static LinuxSecretServiceBinding? Bind()
@@ -131,9 +122,9 @@ internal static class LinuxSecretServiceInterop
 			Marshal.WriteIntPtr(schema, offset, IntPtr.Zero);
 		}
 
-		Marshal.WriteIntPtr(schema, SchemaNameOffset, Utf8(name));
+		Marshal.WriteIntPtr(schema, SchemaNameOffset, NativeUtf8.Alloc(name));
 		Marshal.WriteInt32(schema, SchemaFlagsOffset, SecretSchemaDontMatchName);
-		Marshal.WriteIntPtr(schema, SchemaFirstAttributeNameOffset, Utf8(attribute));
+		Marshal.WriteIntPtr(schema, SchemaFirstAttributeNameOffset, NativeUtf8.Alloc(attribute));
 		Marshal.WriteInt32(schema, SchemaFirstAttributeTypeOffset, SecretSchemaAttributeString);
 
 		return schema;

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.cs.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.cs.resx
@@ -12825,6 +12825,12 @@ Stáhněte jej z webu Macro Deck a aktualizujte nainstalovaný AppImage, DEB neb
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>Port, na kterém Macro Deck naslouchá telefonům, tabletům a prohlížečům v lokální síti.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Umožňuje aplikaci Macro Deck v telefonech a tabletech automaticky najít tento počítač. Ostatní zařízení v síti vidí jeho název a verzi.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Zobrazit v místní síti</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>Pro toto spuštění je nastavena proměnná MACRO_DECK_PORT, která určuje port ({port}). Nastavená hodnota zůstává nevyužitá, dokud toto přepsání nebude odstraněno.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.de.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.de.resx
@@ -12823,6 +12823,12 @@ Lade es von der Macro-Deck-Website herunter und aktualisiere deine installierte 
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>Der Port, über den Smartphones, Tablets und Browser in deinem Netzwerk Macro Deck erreichen.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Damit die Macro Deck App auf Smartphones und Tablets diesen Computer automatisch findet. Andere Geräte im Netzwerk sehen seinen Namen und seine Version.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Im lokalen Netzwerk anzeigen</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>MACRO_DECK_PORT ist für diesen Start gesetzt und bestimmt den Port ({port}). Der konfigurierte Wert bleibt ungenutzt, bis diese Überschreibung entfernt wird.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.es.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.es.resx
@@ -12825,6 +12825,12 @@ Descárgalo desde el sitio web de Macro Deck y actualiza el AppImage, DEB o RPM 
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>El puerto en el que Macro Deck escucha conexiones de teléfonos, tablets y navegadores en tu red.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Permite que la app Macro Deck en móviles y tablets encuentre este equipo automáticamente. Los demás dispositivos de la red ven su nombre y su versión.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Mostrar en la red local</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>MACRO_DECK_PORT está definido para este inicio y determina el puerto ({port}). El valor configurado permanece sin usar hasta que se elimine esa anulación.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.fr.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.fr.resx
@@ -12825,6 +12825,12 @@ Télécharge-le depuis le site web de Macro Deck et mets à jour l'AppImage, le 
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>Le port sur lequel Macro Deck écoute pour les téléphones, tablettes et navigateurs de ton réseau.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Permet à l'app Macro Deck sur téléphones et tablettes de trouver cet ordinateur automatiquement. Les autres appareils du réseau voient son nom et sa version.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Afficher sur le réseau local</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>MACRO_DECK_PORT est défini pour ce lancement et détermine le port ({port}). La valeur configurée reste inutilisée tant que cette variable n'est pas retirée.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.it.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.it.resx
@@ -12825,6 +12825,12 @@ Scaricalo dal sito di Macro Deck e aggiorna l'AppImage, il DEB o l'RPM che hai i
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>La porta su cui Macro Deck resta in ascolto per telefoni, tablet e browser sulla tua rete.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Permette all'app Macro Deck su smartphone e tablet di trovare automaticamente questo computer. Gli altri dispositivi nella rete ne vedono il nome e la versione.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Mostra nella rete locale</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>MACRO_DECK_PORT è impostata per questo avvio e determina la porta ({port}). Il valore configurato resta inutilizzato finché questo override non viene rimosso.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.pl.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.pl.resx
@@ -12825,6 +12825,12 @@ Pobierz go ze strony Macro Deck i zaktualizuj zainstalowany pakiet AppImage, DEB
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>Port, na którym Macro Deck nasłuchuje połączeń z telefonów, tabletów i przeglądarek w sieci.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Umożliwia aplikacji Macro Deck na telefonach i tabletach automatyczne znalezienie tego komputera. Inne urządzenia w sieci widzą jego nazwę i wersję.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Pokaż w sieci lokalnej</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>Dla tego uruchomienia ustawiono zmienną MACRO_DECK_PORT, która decyduje o porcie ({port}). Skonfigurowana wartość pozostaje nieużywana, dopóki to zastąpienie nie zostanie usunięte.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.resx
@@ -12825,6 +12825,12 @@ Download it from the Macro Deck website and update the AppImage, DEB or RPM you 
   <data name="Settings.Network.Description" xml:space="preserve">
     <value>The port Macro Deck listens on for phones, tablets and browsers on your network.</value>
   </data>
+  <data name="Settings.Network.DiscoveryDescription" xml:space="preserve">
+    <value>Lets the Macro Deck app on phones and tablets find this computer automatically. Other devices on the network can see its name and version.</value>
+  </data>
+  <data name="Settings.Network.DiscoveryLabel" xml:space="preserve">
+    <value>Show on the local network</value>
+  </data>
   <data name="Settings.Network.EnvironmentOverrideNote" xml:space="preserve">
     <value>MACRO_DECK_PORT is set for this launch and decides the port ({port}). The configured value stays unused until that override is removed.</value>
     <comment>[port:int]</comment>

--- a/host/src/MacroDeckHost/Startup.cs
+++ b/host/src/MacroDeckHost/Startup.cs
@@ -76,6 +76,7 @@ using MacroDeckHost.Infrastructure.Icons.AppIcons;
 using MacroDeckHost.Infrastructure.Lifecycle;
 using MacroDeckHost.Infrastructure.HostLocking;
 using MacroDeckHost.Infrastructure.MusicPlayer;
+using MacroDeckHost.Infrastructure.Network.Discovery;
 using MacroDeckHost.Infrastructure.Network.Tls;
 using MacroDeckHost.Infrastructure.Notifications;
 using MacroDeckHost.Infrastructure.Migration;
@@ -752,6 +753,7 @@ public class Startup
 		services.AddDbContext<DatabaseContext>();
 
 		services.AddPublicTlsCertificateStore();
+		services.AddServiceAdvertisement();
 
 		// AddDataProtection registers its key manager and hosted service with TryAdd, so they resolve
 		// even though Program.cs's provider wins IDataProtectionProvider - and they would point at the

--- a/host/tests/MacroDeckHost.Tests.PluginContractTests/Harness/DeviceSurfaceSupport.cs
+++ b/host/tests/MacroDeckHost.Tests.PluginContractTests/Harness/DeviceSurfaceSupport.cs
@@ -258,7 +258,8 @@ internal sealed class ContractAppPreferences : IAppPreferenceService
 	public Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null) => throw new NotSupportedException();
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null) => throw new NotSupportedException();
 
 	public Task<AdbSettings> GetAdb() => throw new NotSupportedException();
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Adb/AdbManagerTestHarness.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Adb/AdbManagerTestHarness.cs
@@ -35,7 +35,8 @@ internal sealed class FakeAdbPreferenceService : IAppPreferenceService
 	public Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null)
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null)
 		=> throw new NotSupportedException();
 
 	public Task<DeveloperSettings> GetDeveloper() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/BackgroundServices/HostLockStateBackgroundServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/BackgroundServices/HostLockStateBackgroundServiceTests.cs
@@ -322,7 +322,8 @@ internal sealed class HostLockStateBackgroundServiceTests
 		public Task<NetworkSettings> SetNetwork(int? publicPort,
 			bool? tlsEnabled = null,
 			string? tlsMode = null,
-			int? tlsHttpsPort = null)
+			int? tlsHttpsPort = null,
+			bool? discoveryEnabled = null)
 			=> throw new NotSupportedException();
 
 		public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Configuration/NetworkListenerIdentityTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Configuration/NetworkListenerIdentityTests.cs
@@ -46,7 +46,8 @@ public class NetworkListenerIdentityTests
 			TlsAuthoritySubject: null,
 			TlsAuthorityFingerprint: null,
 			TlsAuthorityNotBefore: null,
-			TlsAuthorityNotAfter: null);
+			TlsAuthorityNotAfter: null,
+			DiscoveryEnabled: true);
 
 	// A fresh installation stores no TLS rows at all, so the reported configuration comes from the same
 	// default the listener was opened with. If the two ever drift apart, every installation gets a

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/DnsSdTxtRecordTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/DnsSdTxtRecordTests.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using MacroDeckHost.Application.Network.Discovery;
+using MacroDeckHost.Infrastructure.Network.Discovery;
+
+namespace MacroDeckHost.Tests.UnitTests.Network.Discovery;
+
+[TestFixture]
+internal sealed class DnsSdTxtRecordTests
+{
+	[Test]
+	public void Entries_are_length_prefixed_key_value_strings()
+	{
+		var encoded = DnsSdTxtRecord.Encode([new TxtEntry("name", "PC"), new TxtEntry("version", "3.1")]);
+
+		byte[] expected = [7, .. "name=PC"u8, 11, .. "version=3.1"u8];
+		Assert.That(encoded, Is.EqualTo(expected));
+	}
+
+	[Test]
+	public void An_entry_is_capped_at_the_255_bytes_a_length_prefix_can_describe()
+	{
+		var encoded = DnsSdTxtRecord.Encode([new TxtEntry("name", new string('x', 300))]);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(encoded[0], Is.EqualTo(255));
+			Assert.That(encoded, Has.Length.EqualTo(256));
+			Assert.That(Encoding.ASCII.GetString(encoded, 1, 5), Is.EqualTo("name="));
+		});
+	}
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementBackgroundServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementBackgroundServiceTests.cs
@@ -1,0 +1,240 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using MacroDeckHost.Application.Configuration;
+using MacroDeckHost.Application.Network.Discovery;
+using MacroDeckHost.Application.Network.Tls;
+using MacroDeckHost.Application.Persistence.Repositories;
+using MacroDeckHost.Application.Services;
+using MacroDeckHost.Domain.Entities;
+using MacroDeckHost.Domain.Enums;
+using MacroDeckHost.Infrastructure.Network.Discovery;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MacroDeckHost.Tests.UnitTests.Network.Discovery;
+
+[TestFixture]
+internal sealed class ServiceAdvertisementBackgroundServiceTests
+{
+	private sealed class RecordingAdvertiser : IServiceAdvertiser
+	{
+		public List<ServiceAdvertisement> Published { get; } = [];
+
+		public int Withdrawals { get; private set; }
+
+		public bool FailNextPublish { get; set; }
+
+		public event Action? StateChanged
+		{
+			add { }
+			remove { }
+		}
+
+		public bool IsAvailable => true;
+
+		public bool NeedsRepublish { get; set; }
+
+		public void CheckLiveness()
+		{
+		}
+
+		public void Publish(ServiceAdvertisement advertisement)
+		{
+			if (FailNextPublish)
+			{
+				FailNextPublish = false;
+				throw new InvalidOperationException("The responder is not running");
+			}
+
+			Published.Add(advertisement);
+			NeedsRepublish = false;
+		}
+
+		public void Withdraw() => Withdrawals++;
+
+		public void Dispose()
+		{
+		}
+	}
+
+	private sealed class FakeInterfaces : INetworkInterfaceSnapshotProvider
+	{
+		public List<NetworkInterfaceSnapshot> Interfaces { get; } =
+		[
+			new(17, "en0", "Wi-Fi", NetworkInterfaceType.Wireless80211, true, [IPAddress.Parse("192.168.20.13")])
+		];
+
+		public IReadOnlyList<NetworkInterfaceSnapshot> GetInterfaces() => Interfaces;
+	}
+
+	private sealed class FakeHostNames : IHostNameProvider
+	{
+		public string MachineName => "Studio PC";
+
+		public IReadOnlyList<string> GetHostNames() => [];
+	}
+
+	private sealed class InMemoryPreferences : IAppPreferenceRepository
+	{
+		private readonly Dictionary<string, AppPreferenceEntity> _store = new();
+
+		public Task<AppPreferenceEntity?> GetByKey(string key) => Task.FromResult(_store.GetValueOrDefault(key));
+
+		public Task SetValue(string key, string value)
+		{
+			_store[key] = new AppPreferenceEntity { Key = key, Value = value };
+			return Task.CompletedTask;
+		}
+	}
+
+	private sealed class FakeBuildEnvironment : IBuildEnvironment
+	{
+		public string Version => "0.0.0-test";
+
+		public bool IsBeta => false;
+
+		public BuildChannel Channel => BuildChannel.Production;
+	}
+
+	private sealed class StartedHostLifetime : IHostApplicationLifetime
+	{
+		public CancellationToken ApplicationStarted => new(true);
+
+		public CancellationToken ApplicationStopping => CancellationToken.None;
+
+		public CancellationToken ApplicationStopped => CancellationToken.None;
+
+		public void StopApplication()
+		{
+		}
+	}
+
+	private sealed record Harness(
+		ServiceAdvertisementBackgroundService Service,
+		RecordingAdvertiser Advertiser,
+		FakeInterfaces Interfaces,
+		InMemoryPreferences Preferences);
+
+	private static Harness Create(PublicEndpointSet? endpoints = null)
+	{
+		var preferences = new InMemoryPreferences();
+		var listenerState = new HostListenerState(endpoints ?? PublicEndpointSet.HttpOnly(8193), false);
+		var services = new ServiceCollection();
+		services.AddScoped<IAppPreferenceService>(_ =>
+			new AppPreferenceService(preferences, new FakeBuildEnvironment(), listenerState));
+		var provider = services.BuildServiceProvider();
+		var advertiser = new RecordingAdvertiser();
+		var interfaces = new FakeInterfaces();
+		var service = new ServiceAdvertisementBackgroundService(new StartedHostLifetime(),
+			provider.GetRequiredService<IServiceScopeFactory>(),
+			advertiser,
+			new FakeHostNames(),
+			listenerState,
+			interfaces);
+
+		return new Harness(service, advertiser, interfaces, preferences);
+	}
+
+	[Test]
+	public async Task An_unchanged_network_is_published_only_once()
+	{
+		var harness = Create();
+
+		await harness.Service.Reconcile();
+		await harness.Service.Reconcile();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(harness.Advertiser.Published, Has.Count.EqualTo(1));
+			Assert.That(harness.Advertiser.Published[0].WireName, Is.EqualTo("Studio PC"));
+			Assert.That(harness.Advertiser.Published[0].Port, Is.EqualTo(8193));
+		});
+	}
+
+	[Test]
+	public async Task A_new_lan_interface_is_published()
+	{
+		var harness = Create();
+		await harness.Service.Reconcile();
+
+		harness.Interfaces.Interfaces.Add(new NetworkInterfaceSnapshot(5, "en7", "USB LAN", NetworkInterfaceType.Ethernet,
+			true, [IPAddress.Parse("192.168.30.4")]));
+		await harness.Service.Reconcile();
+
+		Assert.That(harness.Advertiser.Published.Last().Interfaces, Has.Count.EqualTo(2));
+	}
+
+	[Test]
+	public async Task A_registration_the_responder_lost_is_published_again()
+	{
+		var harness = Create();
+		await harness.Service.Reconcile();
+
+		harness.Advertiser.NeedsRepublish = true;
+		await harness.Service.Reconcile();
+
+		Assert.That(harness.Advertiser.Published, Has.Count.EqualTo(2));
+	}
+
+	[Test]
+	public async Task Turning_discovery_off_withdraws_the_advertisement()
+	{
+		var harness = Create();
+		await harness.Service.Reconcile();
+
+		await harness.Preferences.SetValue(AppPreferenceService.DiscoveryEnabledKey, bool.FalseString);
+		await harness.Service.Reconcile();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(harness.Advertiser.Withdrawals, Is.EqualTo(1));
+			Assert.That(harness.Advertiser.Published, Has.Count.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public async Task A_host_without_a_plain_http_listener_is_never_advertised()
+	{
+		var harness = Create(PublicEndpointSet.HttpsReplacingHttp(8193));
+
+		await harness.Service.Reconcile();
+
+		Assert.That(harness.Advertiser.Published, Is.Empty);
+	}
+
+	[Test]
+	public async Task A_failing_responder_does_not_escape_and_is_retried()
+	{
+		var harness = Create();
+		harness.Advertiser.FailNextPublish = true;
+
+		Assert.DoesNotThrowAsync(harness.Service.Reconcile);
+		await harness.Service.Reconcile();
+
+		Assert.That(harness.Advertiser.Published, Has.Count.EqualTo(1));
+	}
+
+	[Test]
+	public async Task Turning_discovery_off_after_a_partly_failed_publish_still_withdraws()
+	{
+		var harness = Create();
+		harness.Advertiser.FailNextPublish = true;
+		await harness.Service.Reconcile();
+
+		await harness.Preferences.SetValue(AppPreferenceService.DiscoveryEnabledKey, bool.FalseString);
+		await harness.Service.Reconcile();
+
+		Assert.That(harness.Advertiser.Withdrawals, Is.EqualTo(1));
+	}
+
+	[Test]
+	public async Task Stopping_the_host_withdraws_the_advertisement()
+	{
+		var harness = Create();
+		await harness.Service.Reconcile();
+
+		await harness.Service.StopAsync(CancellationToken.None);
+
+		Assert.That(harness.Advertiser.Withdrawals, Is.EqualTo(1));
+	}
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementBackgroundServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementBackgroundServiceTests.cs
@@ -157,8 +157,12 @@ internal sealed class ServiceAdvertisementBackgroundServiceTests
 		var harness = Create();
 		await harness.Service.Reconcile();
 
-		harness.Interfaces.Interfaces.Add(new NetworkInterfaceSnapshot(5, "en7", "USB LAN", NetworkInterfaceType.Ethernet,
-			true, [IPAddress.Parse("192.168.30.4")]));
+		harness.Interfaces.Interfaces.Add(new NetworkInterfaceSnapshot(5,
+			"en7",
+			"USB LAN",
+			NetworkInterfaceType.Ethernet,
+			true,
+			[IPAddress.Parse("192.168.30.4")]));
 		await harness.Service.Reconcile();
 
 		Assert.That(harness.Advertiser.Published.Last().Interfaces, Has.Count.EqualTo(2));

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementPlannerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementPlannerTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using MacroDeckHost.Application.Configuration;
+using MacroDeckHost.Application.Network.Discovery;
+
+namespace MacroDeckHost.Tests.UnitTests.Network.Discovery;
+
+[TestFixture]
+internal sealed class ServiceAdvertisementPlannerTests
+{
+	private static readonly NetworkInterfaceSnapshot Wifi =
+		Nic(17, "en0", "Wi-Fi", NetworkInterfaceType.Wireless80211, "192.168.20.13");
+
+	private static NetworkInterfaceSnapshot Nic(int index,
+		string name,
+		string description,
+		NetworkInterfaceType type,
+		params string[] addresses)
+		=> new(index, name, description, type, true, addresses.Select(IPAddress.Parse).ToList());
+
+	private static ServiceAdvertisement? Plan(PublicEndpointSet? endpoints = null,
+		bool enabled = true,
+		string name = "Studio PC",
+		params NetworkInterfaceSnapshot[] interfaces)
+		=> ServiceAdvertisementPlanner.Plan(enabled,
+			endpoints ?? PublicEndpointSet.HttpOnly(8193),
+			name,
+			"3.1.0",
+			interfaces.Length == 0 ? [Wifi] : interfaces);
+
+	[Test]
+	public void The_txt_record_carries_the_instance_name_and_the_version_under_lower_case_keys()
+	{
+		var plan = Plan();
+
+		Assert.That(plan!.Txt, Is.EqualTo(new[] { new TxtEntry("name", "Studio PC"), new TxtEntry("version", "3.1.0") }));
+	}
+
+	[Test]
+	public void The_service_port_is_the_plain_http_listener_even_when_https_runs_beside_it()
+	{
+		Assert.Multiple(() =>
+		{
+			Assert.That(Plan(PublicEndpointSet.HttpOnly(8193))!.Port, Is.EqualTo(8193));
+			Assert.That(Plan(PublicEndpointSet.HttpAndHttps(8194, 8195))!.Port, Is.EqualTo(8194));
+		});
+	}
+
+	[Test]
+	public void Nothing_is_advertised_without_a_plain_http_public_listener()
+	{
+		Assert.Multiple(() =>
+		{
+			Assert.That(Plan(PublicEndpointSet.HttpsReplacingHttp(8193)), Is.Null);
+			Assert.That(Plan(PublicEndpointSet.HttpOnly(8193).WithoutHttp()), Is.Null);
+		});
+	}
+
+	[Test]
+	public void Nothing_is_advertised_when_discovery_is_turned_off()
+	{
+		Assert.That(Plan(enabled: false), Is.Null);
+	}
+
+	[Test]
+	public void Nothing_is_advertised_when_no_lan_interface_exists()
+	{
+		var loopback = Nic(1, "lo0", "Loopback", NetworkInterfaceType.Loopback, "127.0.0.1");
+
+		Assert.That(Plan(interfaces: loopback), Is.Null);
+	}
+
+	[Test]
+	public void Only_real_lan_interfaces_are_advertised()
+	{
+		var ethernet = Nic(5, "Ethernet", "Intel(R) Ethernet Connection I219-V", NetworkInterfaceType.Ethernet,
+			"192.168.1.5");
+		var interfaces = new[]
+		{
+			Wifi,
+			ethernet,
+			Nic(1, "lo0", "Loopback", NetworkInterfaceType.Loopback, "127.0.0.1"),
+			Nic(6, "en5", "USB Ethernet", NetworkInterfaceType.Ethernet, "169.254.3.4"),
+			Nic(22, "utun4", "utun4", NetworkInterfaceType.Unknown, "100.123.95.52"),
+			Nic(30, "vEthernet (WSL)", "Hyper-V Virtual Ethernet Adapter", NetworkInterfaceType.Ethernet, "172.20.0.1"),
+			Nic(31, "Ethernet 3", "Hyper-V Virtual Ethernet Adapter #2", NetworkInterfaceType.Ethernet, "172.21.0.1"),
+			Nic(32, "docker0", "docker0", NetworkInterfaceType.Ethernet, "172.17.0.1"),
+			Nic(33, "Teredo", "Teredo Tunneling Pseudo-Interface", NetworkInterfaceType.Tunnel, "10.9.9.9"),
+			new NetworkInterfaceSnapshot(34, "en1", "Thunderbolt Ethernet", NetworkInterfaceType.Ethernet, false,
+				[IPAddress.Parse("192.168.30.2")])
+		};
+
+		var plan = Plan(interfaces: interfaces);
+
+		Assert.That(plan!.Interfaces, Is.EqualTo(new[]
+		{
+			new AdvertisedInterface(5, IPAddress.Parse("192.168.1.5")),
+			new AdvertisedInterface(17, IPAddress.Parse("192.168.20.13"))
+		}));
+	}
+
+	[Test]
+	public void An_interface_with_a_link_local_and_a_lan_address_is_advertised_with_the_lan_address()
+	{
+		var nic = Nic(4, "eth0", "eth0", NetworkInterfaceType.Ethernet, "169.254.1.1", "10.0.0.2");
+
+		Assert.That(Plan(interfaces: nic)!.Interfaces.Single().Ipv4, Is.EqualTo(IPAddress.Parse("10.0.0.2")));
+	}
+
+	[Test]
+	public void A_name_longer_than_a_dns_label_is_shortened_on_the_wire_but_kept_whole_in_the_txt_record()
+	{
+		var name = new string('a', 62) + "ébc";
+
+		var plan = Plan(name: name);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(plan!.WireName, Is.EqualTo(new string('a', 62)));
+			Assert.That(plan.Txt.Single(entry => entry.Key == "name").Value, Is.EqualTo(name));
+		});
+	}
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementPlannerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Network/Discovery/ServiceAdvertisementPlannerTests.cs
@@ -33,7 +33,8 @@ internal sealed class ServiceAdvertisementPlannerTests
 	{
 		var plan = Plan();
 
-		Assert.That(plan!.Txt, Is.EqualTo(new[] { new TxtEntry("name", "Studio PC"), new TxtEntry("version", "3.1.0") }));
+		Assert.That(plan!.Txt,
+			Is.EqualTo(new[] { new TxtEntry("name", "Studio PC"), new TxtEntry("version", "3.1.0") }));
 	}
 
 	[Test]
@@ -73,7 +74,10 @@ internal sealed class ServiceAdvertisementPlannerTests
 	[Test]
 	public void Only_real_lan_interfaces_are_advertised()
 	{
-		var ethernet = Nic(5, "Ethernet", "Intel(R) Ethernet Connection I219-V", NetworkInterfaceType.Ethernet,
+		var ethernet = Nic(5,
+			"Ethernet",
+			"Intel(R) Ethernet Connection I219-V",
+			NetworkInterfaceType.Ethernet,
 			"192.168.1.5");
 		var interfaces = new[]
 		{
@@ -86,17 +90,22 @@ internal sealed class ServiceAdvertisementPlannerTests
 			Nic(31, "Ethernet 3", "Hyper-V Virtual Ethernet Adapter #2", NetworkInterfaceType.Ethernet, "172.21.0.1"),
 			Nic(32, "docker0", "docker0", NetworkInterfaceType.Ethernet, "172.17.0.1"),
 			Nic(33, "Teredo", "Teredo Tunneling Pseudo-Interface", NetworkInterfaceType.Tunnel, "10.9.9.9"),
-			new NetworkInterfaceSnapshot(34, "en1", "Thunderbolt Ethernet", NetworkInterfaceType.Ethernet, false,
+			new NetworkInterfaceSnapshot(34,
+				"en1",
+				"Thunderbolt Ethernet",
+				NetworkInterfaceType.Ethernet,
+				false,
 				[IPAddress.Parse("192.168.30.2")])
 		};
 
 		var plan = Plan(interfaces: interfaces);
 
-		Assert.That(plan!.Interfaces, Is.EqualTo(new[]
-		{
-			new AdvertisedInterface(5, IPAddress.Parse("192.168.1.5")),
-			new AdvertisedInterface(17, IPAddress.Parse("192.168.20.13"))
-		}));
+		Assert.That(plan!.Interfaces,
+			Is.EqualTo(new[]
+			{
+				new AdvertisedInterface(5, IPAddress.Parse("192.168.1.5")),
+				new AdvertisedInterface(17, IPAddress.Parse("192.168.20.13"))
+			}));
 	}
 
 	[Test]

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Plugins/PluginPairingServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Plugins/PluginPairingServiceTests.cs
@@ -44,7 +44,8 @@ public class PluginPairingServiceTests
 		public Task<NetworkSettings> SetNetwork(int? publicPort,
 			bool? tlsEnabled = null,
 			string? tlsMode = null,
-			int? tlsHttpsPort = null)
+			int? tlsHttpsPort = null,
+			bool? discoveryEnabled = null)
 			=> throw new NotSupportedException();
 
 		public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Plugins/RemotePluginIntegrationRegistrarTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Plugins/RemotePluginIntegrationRegistrarTests.cs
@@ -1164,7 +1164,8 @@ public class RemotePluginIntegrationRegistrarTests
 		public Task<NetworkSettings> SetNetwork(int? publicPort,
 			bool? tlsEnabled = null,
 			string? tlsMode = null,
-			int? tlsHttpsPort = null)
+			int? tlsHttpsPort = null,
+			bool? discoveryEnabled = null)
 			=> throw new NotSupportedException();
 
 		public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Services/NetworkSettingsHandlersTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Services/NetworkSettingsHandlersTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using MacroDeckHost.Application.Configuration;
 using MacroDeckHost.Application.Lifecycle;
+using MacroDeckHost.Application.Network.Discovery;
 using MacroDeckHost.Application.Network.Tls;
 using MacroDeckHost.Application.Notifications;
 using MacroDeckHost.Application.Persistence.Repositories;
@@ -32,8 +33,19 @@ public class NetworkSettingsHandlersTests
 
 		public int Writes { get; private set; }
 
+		private int _changeReads;
+
+		public (string Key, int OnRead, string Value)? ChangeBehindTheHandler { get; set; }
+
 		public Task<AppPreferenceEntity?> GetByKey(string key)
-			=> Task.FromResult(_store.GetValueOrDefault(key));
+		{
+			if (ChangeBehindTheHandler is { } change && change.Key == key && ++_changeReads == change.OnRead)
+			{
+				_store[key] = new AppPreferenceEntity { Key = key, Value = change.Value };
+			}
+
+			return Task.FromResult(_store.GetValueOrDefault(key));
+		}
 
 		public Task SetValue(string key, string value)
 		{
@@ -76,6 +88,13 @@ public class NetworkSettingsHandlersTests
 		public IReadOnlyList<string> GetHostNames() => ["deck-pc", "deck-pc.local"];
 	}
 
+	private sealed class FakeDiscoveryRefresher : IDiscoveryAdvertisementRefresher
+	{
+		public int Requests { get; private set; }
+
+		public void RequestRefresh() => Requests++;
+	}
+
 	private sealed record Fixture(
 		CountingAppPreferenceRepository Repository,
 		FakePublicTlsCertificateStore CertificateStore,
@@ -83,7 +102,8 @@ public class NetworkSettingsHandlersTests
 		GetNetworkSettingsRequestMessageHandler Get,
 		UpdateNetworkSettingsRequestMessageHandler Update,
 		UpdateNetworkTlsCertificateRequestMessageHandler UpdateCertificate,
-		ReissueTlsCertificateRequestMessageHandler ReissueCertificate);
+		ReissueTlsCertificateRequestMessageHandler ReissueCertificate,
+		FakeDiscoveryRefresher Discovery);
 
 	private static Fixture CreateFixture(
 		bool overriddenByEnvironment = false,
@@ -122,12 +142,13 @@ public class NetworkSettingsHandlersTests
 		var notifications = new UserNotificationStore();
 		var notifier = new NetworkRestartNotifier(service, restartService, notifications, TestLocalization.Resolver);
 		var addressProvider = new FakeLocalAddressProvider();
+		var discovery = new FakeDiscoveryRefresher();
 
 		return new Fixture(repository,
 			certificateStore,
 			notifications,
 			new GetNetworkSettingsRequestMessageHandler(service, restartService),
-			new UpdateNetworkSettingsRequestMessageHandler(service, restartService, listenerState, notifier),
+			new UpdateNetworkSettingsRequestMessageHandler(service, restartService, listenerState, notifier, discovery),
 			new UpdateNetworkTlsCertificateRequestMessageHandler(service, restartService, certificateStore, notifier),
 			new ReissueTlsCertificateRequestMessageHandler(service,
 				restartService,
@@ -135,7 +156,8 @@ public class NetworkSettingsHandlersTests
 					addressProvider,
 					new FakeHostNameProvider(),
 					new LoggerConfiguration().CreateLogger()),
-				notifier));
+				notifier),
+			discovery);
 	}
 
 	private static (string CertificatePem, string PrivateKeyPem, string Fingerprint) ReissueCertificate()
@@ -156,6 +178,71 @@ public class NetworkSettingsHandlersTests
 		return (certificate.ExportCertificatePem(),
 			rsa.ExportPkcs8PrivateKeyPem(),
 			certificate.GetCertHashString(HashAlgorithmName.SHA256));
+	}
+
+	[Test]
+	public async Task Discovery_is_on_for_a_fresh_installation()
+	{
+		var fixture = CreateFixture();
+
+		var response = await fixture.Get.Handle(new GetNetworkSettingsRequest(), CancellationToken.None);
+
+		Assert.That(response.DiscoveryEnabled, Is.True);
+	}
+
+	[Test]
+	public async Task Turning_discovery_off_is_saved_live_without_asking_for_a_restart()
+	{
+		var fixture = CreateFixture();
+
+		var response = await fixture.Update.Handle(
+			new UpdateNetworkSettingsRequest { PublicPort = ActivePort, DiscoveryEnabled = false },
+			CancellationToken.None);
+		var stored = await fixture.Repository.GetByKey(AppPreferenceService.DiscoveryEnabledKey);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(response.Success, Is.True);
+			Assert.That(response.DiscoveryEnabled, Is.False);
+			Assert.That(response.RestartRequired, Is.False);
+			Assert.That(stored?.Value, Is.EqualTo(bool.FalseString));
+			Assert.That(fixture.Discovery.Requests, Is.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public async Task A_save_that_omits_discovery_keeps_the_stored_value()
+	{
+		var fixture = CreateFixture();
+		fixture.Repository.Seed(AppPreferenceService.DiscoveryEnabledKey, bool.FalseString);
+
+		var response = await fixture.Update.Handle(new UpdateNetworkSettingsRequest { PublicPort = 9100 },
+			CancellationToken.None);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(response.PublicPort, Is.EqualTo(9100));
+			Assert.That(response.DiscoveryEnabled, Is.False);
+		});
+	}
+
+	[Test]
+	public async Task A_tls_save_does_not_revert_a_discovery_change_that_landed_after_the_handler_read()
+	{
+		var fixture = CreateFixture();
+		fixture.Repository.ChangeBehindTheHandler = (AppPreferenceService.DiscoveryEnabledKey, 2, bool.FalseString);
+
+		var response = await fixture.Update.Handle(
+			new UpdateNetworkSettingsRequest { PublicPort = ActivePort, TlsHttpsPort = 9443 },
+			CancellationToken.None);
+		var stored = await fixture.Repository.GetByKey(AppPreferenceService.DiscoveryEnabledKey);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(response.TlsHttpsPort, Is.EqualTo(9443));
+			Assert.That(response.DiscoveryEnabled, Is.False);
+			Assert.That(stored?.Value, Is.EqualTo(bool.FalseString));
+		});
 	}
 
 	[Test]

--- a/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/FakeDeveloperModePreferences.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/FakeDeveloperModePreferences.cs
@@ -34,7 +34,8 @@ internal sealed class FakeDeveloperModePreferences : IAppPreferenceService
 	public Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null)
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null)
 		=> throw new NotSupportedException();
 
 	public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/FakeOnboardingPreferences.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/FakeOnboardingPreferences.cs
@@ -30,7 +30,8 @@ internal sealed class FakeOnboardingPreferences : IAppPreferenceService
 	public Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null)
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null)
 		=> throw new NotSupportedException();
 
 	public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/TestLocalization.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/TestLocalization.cs
@@ -79,7 +79,8 @@ internal sealed class FakeLocalizationPreferences : IAppPreferenceService
 	public Task<NetworkSettings> SetNetwork(int? publicPort,
 		bool? tlsEnabled = null,
 		string? tlsMode = null,
-		int? tlsHttpsPort = null)
+		int? tlsHttpsPort = null,
+		bool? discoveryEnabled = null)
 		=> throw new NotSupportedException();
 
 	public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Ui/GetLocalizationRequestMessageHandlerTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Ui/GetLocalizationRequestMessageHandlerTests.cs
@@ -32,7 +32,8 @@ public class GetLocalizationRequestMessageHandlerTests
 		public Task<NetworkSettings> SetNetwork(int? publicPort,
 			bool? tlsEnabled = null,
 			string? tlsMode = null,
-			int? tlsHttpsPort = null)
+			int? tlsHttpsPort = null,
+			bool? discoveryEnabled = null)
 			=> throw new NotSupportedException();
 
 		public Task<AdbSettings> GetAdb() => throw new NotSupportedException();

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-settings.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-settings.component.html
@@ -98,10 +98,23 @@
         </shared-button>
       </div>
     }
+
+    <shared-settings-row
+      [label]="'macrodeck.app:Settings.Network.DiscoveryLabel' | translate"
+      [description]="'macrodeck.app:Settings.Network.DiscoveryDescription' | translate">
+      <shared-toggle-switch
+        [disabled]="!loaded() || saving() || tlsBusy()"
+        [busy]="discoverySaving()"
+        [checked]="discoveryEnabled()"
+        (changed)="setDiscoveryEnabled($event)" />
+    </shared-settings-row>
   </shared-settings-section>
 
   @if (loaded() && networkState(); as state) {
-    <app-network-tls-settings [state]="state" (stateChange)="onTlsStateChanged($event)" />
+    <app-network-tls-settings
+      [state]="state"
+      (stateChange)="onTlsStateChanged($event)"
+      (busyChange)="tlsBusy.set($event)" />
   }
 
   @if (restartPromptOpen()) {

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-settings.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-settings.component.spec.ts
@@ -1,8 +1,10 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { GetNetworkSettingsResponse } from '@macro-deck/runtime';
 import { ApiService } from '@shared';
 import { NetworkSettingsComponent } from './network-settings.component';
+import { NetworkTlsSettingsComponent } from './network-tls-settings.component';
 import { EMPTY } from 'rxjs';
 
 describe('NetworkSettingsComponent', () => {
@@ -43,6 +45,7 @@ describe('NetworkSettingsComponent', () => {
     tlsAuthorityFingerprint: null,
     tlsAuthorityNotBefore: null,
     tlsAuthorityNotAfter: null,
+    discoveryEnabled: true,
   };
 
   function installApi(state: Partial<GetNetworkSettingsResponse> = {}): GetNetworkSettingsResponse {
@@ -263,5 +266,35 @@ describe('NetworkSettingsComponent', () => {
 
     expect(api.getNetworkSettings).toHaveBeenCalledTimes(2);
     expect(fixture.componentInstance.error()).toBe('The port could not be saved.');
+  });
+
+  it('shows the network discovery state the host reports', async () => {
+    installApi({ discoveryEnabled: false });
+    const fixture = await create();
+
+    expect(fixture.componentInstance.discoveryEnabled()).toBeFalse();
+  });
+
+  it('switches network discovery with the configured port and no TLS values', async () => {
+    installApi({ publicPort: 9100, activePublicPort: 8193 });
+    const fixture = await create();
+
+    await fixture.componentInstance.setDiscoveryEnabled(false);
+
+    expect(api.updateNetworkSettings).toHaveBeenCalledOnceWith({ publicPort: 9100, discoveryEnabled: false });
+  });
+
+  it('keeps network discovery locked while an HTTPS change is being saved', async () => {
+    const fixture = await create();
+    const tls = fixture.debugElement.query(By.directive(NetworkTlsSettingsComponent))
+      .componentInstance as NetworkTlsSettingsComponent;
+
+    tls.httpsBusy.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await fixture.componentInstance.setDiscoveryEnabled(false);
+
+    expect(fixture.componentInstance.tlsBusy()).toBeTrue();
+    expect(api.updateNetworkSettings).not.toHaveBeenCalled();
   });
 });

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-settings.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-settings.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AppStrings, GetNetworkSettingsResponse } from '@macro-deck/runtime';
-import { ApiService, ButtonComponent, ErrorBannerComponent, InputComponent, LocalizationService, SettingsRowComponent, SettingsSectionComponent, TranslatePipe } from '@shared';
+import { ApiService, ButtonComponent, ErrorBannerComponent, InputComponent, LocalizationService, SettingsRowComponent, SettingsSectionComponent, ToggleSwitchComponent, TranslatePipe } from '@shared';
 import { ConfirmationModalComponent } from '../../../overlay/confirmation-modal/confirmation-modal.component';
 import { RestartNoticeService } from '../../../../services/restart-notice.service';
 import { NetworkTlsSettingsComponent } from './network-tls-settings.component';
@@ -14,6 +14,7 @@ import { NetworkTlsSettingsComponent } from './network-tls-settings.component';
     SettingsSectionComponent,
     SettingsRowComponent,
     InputComponent,
+    ToggleSwitchComponent,
     ButtonComponent,
     ErrorBannerComponent,
     ConfirmationModalComponent,
@@ -46,6 +47,14 @@ export class NetworkSettingsComponent {
   readonly restartUnsupportedReason = signal<string | null>(null);
 
   readonly draft = signal('');
+
+  readonly discoveryEnabled = signal(true);
+  readonly discoverySaving = signal(false);
+  readonly tlsBusy = signal(false);
+
+  // A save sends every TLS value it read earlier, so two overlapping saves can undo each other.
+  readonly discoveryLocked = computed(() =>
+    !this.loaded() || this.saving() || this.discoverySaving() || this.tlsBusy());
 
   readonly networkState = signal<GetNetworkSettingsResponse | null>(null);
 
@@ -114,6 +123,31 @@ export class NetworkSettingsComponent {
     }
   }
 
+  async setDiscoveryEnabled(value: boolean): Promise<void> {
+    if (this.discoveryLocked()) {
+      return;
+    }
+
+    this.discoverySaving.set(true);
+    this.discoveryEnabled.set(value);
+    this.error.set(null);
+    try {
+      const response = await this.api.updateNetworkSettings({
+        publicPort: this.configuredPort(),
+        discoveryEnabled: value,
+      });
+      this.applyState(response);
+      if (!response.success) {
+        this.error.set(response.error ?? this.localization.translateKey(AppStrings.Settings.Network.Tls.SaveFailed));
+      }
+    } catch {
+      this.error.set(this.localization.translateKey(AppStrings.Settings.Network.Tls.SaveFailed));
+      await this.load();
+    } finally {
+      this.discoverySaving.set(false);
+    }
+  }
+
   askToRestart(): void {
     if (this.canRestart()) {
       this.restartPromptOpen.set(true);
@@ -164,6 +198,7 @@ export class NetworkSettingsComponent {
     this.publicListenerUnavailable.set(state.publicListenerUnavailable);
     this.restartSupported.set(state.restartSupported);
     this.restartUnsupportedReason.set(state.restartUnsupportedReason);
+    this.discoveryEnabled.set(state.discoveryEnabled);
     this.draft.set(String(state.publicPort));
   }
 }

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-tls-settings.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-tls-settings.component.spec.ts
@@ -43,6 +43,7 @@ describe('NetworkTlsSettingsComponent', () => {
     tlsAuthorityFingerprint: 'CC:DD',
     tlsAuthorityNotBefore: null,
     tlsAuthorityNotAfter: null,
+    discoveryEnabled: true,
   };
 
   let current: GetNetworkSettingsResponse;

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-tls-settings.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/network-tls-settings.component.ts
@@ -68,6 +68,10 @@ export class NetworkTlsSettingsComponent {
   readonly authorityBusy = signal(false);
   readonly uploadModalOpen = signal(false);
 
+  readonly busyChange = output<boolean>();
+  private readonly busy = computed(() =>
+    this.httpsBusy() || this.modeBusy() || this.portSaving() || this.certificateBusy() || this.authorityBusy());
+
   readonly sourceLabel = computed(() => {
     const source = this.state().tlsCertificateSource;
     if (!source) {
@@ -146,6 +150,7 @@ export class NetworkTlsSettingsComponent {
 
   constructor() {
     effect(() => this.httpsPortDraft.set(String(this.state().tlsHttpsPort)));
+    effect(() => this.busyChange.emit(this.busy()));
   }
 
   async setHttpsEnabled(value: boolean): Promise<void> {

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/settings-modal.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/settings-modal.component.spec.ts
@@ -30,6 +30,7 @@ const TLS_DEFAULTS = {
   tlsAuthorityFingerprint: null,
   tlsAuthorityNotBefore: null,
   tlsAuthorityNotAfter: null,
+  discoveryEnabled: true,
 };
 
 const ENGLISH_SETTINGS_LABELS: Record<string, string> = {

--- a/ui/angular/projects/desktop-ui/src/app/services/restart-notice.service.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/services/restart-notice.service.spec.ts
@@ -45,6 +45,7 @@ describe('RestartNoticeService', () => {
     tlsAuthorityFingerprint: null,
     tlsAuthorityNotBefore: null,
     tlsAuthorityNotAfter: null,
+    discoveryEnabled: true,
   };
 
   beforeEach(() => {

--- a/ui/runtime/src/localization/generated/app-strings.ts
+++ b/ui/runtime/src/localization/generated/app-strings.ts
@@ -5184,6 +5184,8 @@ export const AppStrings = {
 		Network: {
 			ConfiguredPortIgnoredNote: 'macrodeck.app:Settings.Network.ConfiguredPortIgnoredNote',
 			Description: 'macrodeck.app:Settings.Network.Description',
+			DiscoveryDescription: 'macrodeck.app:Settings.Network.DiscoveryDescription',
+			DiscoveryLabel: 'macrodeck.app:Settings.Network.DiscoveryLabel',
 			EnvironmentOverrideNote: 'macrodeck.app:Settings.Network.EnvironmentOverrideNote',
 			ListenerUnavailableChoosePort: 'macrodeck.app:Settings.Network.ListenerUnavailableChoosePort',
 			ListenerUnavailableClearOverride: 'macrodeck.app:Settings.Network.ListenerUnavailableClearOverride',
@@ -10841,6 +10843,8 @@ export const AppStringsDefaults: Readonly<Record<string, string>> = {
 	'macrodeck.app:Settings.Modal.RestartNow': 'Restart now',
 	'macrodeck.app:Settings.Network.ConfiguredPortIgnoredNote': 'Port {configuredPort} could not be used at the last start, so Macro Deck is listening on {activePort}. Choose a different port.',
 	'macrodeck.app:Settings.Network.Description': 'The port Macro Deck listens on for phones, tablets and browsers on your network.',
+	'macrodeck.app:Settings.Network.DiscoveryDescription': 'Lets the Macro Deck app on phones and tablets find this computer automatically. Other devices on the network can see its name and version.',
+	'macrodeck.app:Settings.Network.DiscoveryLabel': 'Show on the local network',
 	'macrodeck.app:Settings.Network.EnvironmentOverrideNote': 'MACRO_DECK_PORT is set for this launch and decides the port ({port}). The configured value stays unused until that override is removed.',
 	'macrodeck.app:Settings.Network.ListenerUnavailableChoosePort': 'Choose a different port below and restart Macro Deck.',
 	'macrodeck.app:Settings.Network.ListenerUnavailableClearOverride': 'Clear MACRO_DECK_PORT or set it to a free port, then restart Macro Deck.',

--- a/ui/runtime/src/protocol/messages/settings.ts
+++ b/ui/runtime/src/protocol/messages/settings.ts
@@ -99,6 +99,8 @@ export interface GetNetworkSettingsResponse {
   tlsAuthorityFingerprint: string | null;
   tlsAuthorityNotBefore: string | null;
   tlsAuthorityNotAfter: string | null;
+
+  discoveryEnabled: boolean;
 }
 
 export interface UpdateNetworkSettingsRequest {
@@ -106,6 +108,7 @@ export interface UpdateNetworkSettingsRequest {
   tlsEnabled?: boolean;
   tlsMode?: TlsMode;
   tlsHttpsPort?: number;
+  discoveryEnabled?: boolean;
 }
 
 export interface UpdateNetworkSettingsResponse extends GetNetworkSettingsResponse {


### PR DESCRIPTION
## Summary

The host now advertises its plain-HTTP public listener as _macrodeck._tcp through the operating system's own mDNS responder, so the companion app finds it without scanning the subnet. Advertising can be turned off in Settings > Network (ADR 0082).

## Testing

Full solution build and test suites pass, with new tests for the advertisement rules, the reconciler and the setting. On macOS, dns-sd showed the host on the LAN interface only with the right port and TXT, the switch removed and restored it live, and shutdown withdrew it at once. Windows and Linux were not run.

## Notes

The companion contract is unchanged: service type, instance name, SRV port and TXT keys follow it as documented.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
