### PR TITLE
Show a stopping message while Macro Deck quits

### DIFF
--- a/host/src/MacroDeckHost.Localization/Localization/Strings.cs.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.cs.resx
@@ -13567,6 +13567,9 @@ Stáhněte jej z webu Macro Deck a aktualizujte nainstalovaný AppImage, DEB neb
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Příprava aktualizace…</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Ukončování aplikace Macro Deck…</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Vývojová verze</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.de.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.de.resx
@@ -13565,6 +13565,9 @@ Lade es von der Macro-Deck-Website herunter und aktualisiere deine installierte 
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Update wird vorbereitet …</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Macro Deck wird beendet …</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Entwicklungsversion</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.es.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.es.resx
@@ -13567,6 +13567,9 @@ Descárgalo desde el sitio web de Macro Deck y actualiza el AppImage, DEB o RPM 
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Preparando la actualización…</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Cerrando Macro Deck…</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Compilación de desarrollo</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.fr.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.fr.resx
@@ -13567,6 +13567,9 @@ Télécharge-le depuis le site web de Macro Deck et mets à jour l'AppImage, le 
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Préparation de la mise à jour…</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Fermeture de Macro Deck…</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Build de développement</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.it.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.it.resx
@@ -13567,6 +13567,9 @@ Scaricalo dal sito di Macro Deck e aggiorna l'AppImage, il DEB o l'RPM che hai i
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Preparazione dell'aggiornamento…</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Chiusura di Macro Deck…</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Build di sviluppo</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.pl.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.pl.resx
@@ -13567,6 +13567,9 @@ Pobierz go ze strony Macro Deck i zaktualizuj zainstalowany pakiet AppImage, DEB
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Przygotowywanie aktualizacji…</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Zamykanie aplikacji Macro Deck…</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Build deweloperski</value>
   </data>

--- a/host/src/MacroDeckHost.Localization/Localization/Strings.resx
+++ b/host/src/MacroDeckHost.Localization/Localization/Strings.resx
@@ -13567,6 +13567,9 @@ Download it from the Macro Deck website and update the AppImage, DEB or RPM you 
   <data name="Shell.Splash.PreparingUpdate" xml:space="preserve">
     <value>Preparing update…</value>
   </data>
+  <data name="Shell.Splash.Stopping" xml:space="preserve">
+    <value>Stopping Macro Deck…</value>
+  </data>
   <data name="Shell.Statusbar.DevelopmentBuild" xml:space="preserve">
     <value>Development Build</value>
   </data>

--- a/ui/angular/projects/desktop-ui/src/app/app.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/app.component.spec.ts
@@ -142,6 +142,7 @@ describe('AppComponent (desktop-ui) - splash status during an update install (is
   const PREPARING_UPDATE = 'Preparing update…';
   const INSTALL_FAILED_DEFAULT = 'Couldn\'t install the update. Please try again.';
   const CONNECTING = 'Connecting to Macro Deck…';
+  const STOPPING = 'Stopping Macro Deck…';
 
   afterEach(() => {
     delete (window as { macroDeckShell?: unknown }).macroDeckShell;
@@ -177,6 +178,7 @@ describe('AppComponent (desktop-ui) - splash status during an update install (is
       [AppStrings.Shell.Splash.PreparingUpdate]: PREPARING_UPDATE,
       [AppStrings.Settings.Update.InstallFailed]: INSTALL_FAILED_DEFAULT,
       [AppStrings.WebClient.Connecting]: CONNECTING,
+      [AppStrings.Shell.Splash.Stopping]: STOPPING,
     };
     return map[key] ?? key;
   }
@@ -321,6 +323,52 @@ describe('AppComponent (desktop-ui) - splash status during an update install (is
 
     expect(statusText(fixture)).toBe(CONNECTING);
     expect(statusText(fixture)).not.toContain('Preparing update');
+  });
+
+  it('a quit announced by the shell turns the connecting message into the stopping message', async () => {
+    let announce!: () => void;
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ phase: 'idle' })),
+      onHostStopping: (callback: () => void) => {
+        announce = callback;
+        return Promise.resolve(() => {});
+      },
+    });
+
+    const fixture = await createFixture('authenticated', 'reconnecting');
+    expect(statusText(fixture)).toBe(CONNECTING);
+
+    announce();
+    await settle(fixture);
+
+    expect(statusText(fixture)).toBe(STOPPING);
+  });
+
+  it('a quit after a failed install shows the stopping message, not the install error', async () => {
+    let push!: (state: ShellUpdateState) => void;
+    let announce!: () => void;
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ phase: 'idle' })),
+      onUpdateState: (callback: (state: ShellUpdateState) => void) => {
+        push = callback;
+        return Promise.resolve(() => {});
+      },
+      onHostStopping: (callback: () => void) => {
+        announce = callback;
+        return Promise.resolve(() => {});
+      },
+    });
+
+    const fixture = await createFixture('authenticated', 'disconnected');
+    push(makeState({ phase: 'installing' }));
+    await settle(fixture);
+    push(makeState({ phase: 'failed', error: 'The update signature could not be verified.' }));
+    await settle(fixture);
+
+    announce();
+    await settle(fixture);
+
+    expect(statusText(fixture)).toBe(STOPPING);
   });
 
   it('A8: the message updates reactively as the phase moves from installing to failed', async () => {

--- a/ui/angular/projects/desktop-ui/src/app/app.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/app.component.ts
@@ -101,6 +101,9 @@ export class AppComponent implements OnInit, OnDestroy {
 
   protected readonly splashStatus = computed(() => {
     if (!this.isConnected()) {
+      if (this.hostSession.stopping()) {
+        return this.localizationService.translateKey(AppStrings.Shell.Splash.Stopping);
+      }
       if (this.updateService.phase() === 'installing') {
         return this.localizationService.translateKey(AppStrings.Shell.Splash.PreparingUpdate);
       }

--- a/ui/angular/projects/desktop-ui/src/app/core/shell.d.ts
+++ b/ui/angular/projects/desktop-ui/src/app/core/shell.d.ts
@@ -28,6 +28,7 @@ declare global {
       takeOpenedFiles?: () => Promise<string[]>;
       onMenuAction?: (callback: (event: ShellMenuActionEvent) => void) => Promise<() => void>;
       takeMenuAction?: () => Promise<string | null>;
+      onHostStopping?: (callback: () => void) => Promise<() => void>;
       setHotkeyCapture?: (active: boolean) => Promise<void>;
       checkForUpdate?: () => Promise<ShellUpdateStatus>;
       installUpdate?: () => Promise<void>;

--- a/ui/angular/projects/desktop-ui/src/app/services/host-session.service.ts
+++ b/ui/angular/projects/desktop-ui/src/app/services/host-session.service.ts
@@ -1,5 +1,7 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { ApiService } from '@shared';
+
+import { shellBridge } from '../util/shell-bridge';
 
 const STORAGE_KEY = 'macro-deck.host-session';
 
@@ -9,7 +11,11 @@ export class HostSessionService {
 
   private checking = false;
 
+  private readonly stoppingSignal = signal(false);
+  readonly stopping = this.stoppingSignal.asReadonly();
+
   start(): void {
+    void shellBridge()?.onHostStopping?.(() => this.stoppingSignal.set(true));
     this.api.connectionState$.subscribe(state => {
       if (state === 'connected') {
         void this.check();

--- a/ui/angular/projects/desktop-ui/src/app/util/shell-bridge.ts
+++ b/ui/angular/projects/desktop-ui/src/app/util/shell-bridge.ts
@@ -48,6 +48,7 @@ export interface ShellBridge {
   takeOpenedFiles?: () => Promise<string[]>;
   onMenuAction?: (callback: (event: ShellMenuActionEvent) => void) => Promise<() => void>;
   takeMenuAction?: () => Promise<string | null>;
+  onHostStopping?: (callback: () => void) => Promise<() => void>;
   saveFile?: (options: ShellSaveFileOptions) => Promise<ShellSaveFileResult>;
   setHotkeyCapture?: (active: boolean) => Promise<void>;
 }

--- a/ui/bootstrapper/src/bridge.rs
+++ b/ui/bootstrapper/src/bridge.rs
@@ -608,6 +608,14 @@ mod tests {
     }
 
     #[test]
+    fn shell_bridge_exposes_the_host_stopping_event() {
+        let script = include_str!("shell-bridge.js");
+
+        assert!(script.contains("onHostStopping"));
+        assert!(script.contains(&format!("'{}'", crate::HOST_STOPPING_EVENT)));
+    }
+
+    #[test]
     fn save_file_extensions_keep_only_plain_extensions() {
         assert_eq!(
             parse_save_file_extensions(".macroDeckProfile, zip"),

--- a/ui/bootstrapper/src/main.rs
+++ b/ui/bootstrapper/src/main.rs
@@ -31,7 +31,9 @@ mod windows_file_dialog;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use tauri::{AppHandle, Manager, RunEvent};
+use tauri::{AppHandle, Emitter, Manager, RunEvent};
+
+pub const HOST_STOPPING_EVENT: &str = "host-stopping";
 
 static QUITTING: AtomicBool = AtomicBool::new(false);
 
@@ -50,6 +52,11 @@ pub fn is_quitting() -> bool {
 pub fn request_quit(app: &AppHandle) {
     if QUITTING.swap(true, Ordering::SeqCst) {
         return;
+    }
+    if let Err(error) = app.emit(HOST_STOPPING_EVENT, ()) {
+        logging::error(&format!(
+            "[app] could not emit host-stopping event: {error}"
+        ));
     }
     let app = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/ui/bootstrapper/src/shell-bridge.js
+++ b/ui/bootstrapper/src/shell-bridge.js
@@ -79,6 +79,9 @@
     onMenuAction: function (callback) {
       return listen('menu-action', callback);
     },
+    onHostStopping: function (callback) {
+      return listen('host-stopping', callback);
+    },
     takeMenuAction: function () {
       return invoke('take_menu_action');
     },

--- a/ui/runtime/src/localization/generated/app-strings.ts
+++ b/ui/runtime/src/localization/generated/app-strings.ts
@@ -5468,6 +5468,7 @@ export const AppStrings = {
 		},
 		Splash: {
 			PreparingUpdate: 'macrodeck.app:Shell.Splash.PreparingUpdate',
+			Stopping: 'macrodeck.app:Shell.Splash.Stopping',
 		},
 		Statusbar: {
 			DevelopmentBuild: 'macrodeck.app:Shell.Statusbar.DevelopmentBuild',
@@ -11095,6 +11096,7 @@ export const AppStringsDefaults: Readonly<Record<string, string>> = {
 	'macrodeck.app:Shell.RestartNotice.PortRetry': 'Macro Deck could not open port {port}; restarting tries it again.',
 	'macrodeck.app:Shell.RestartNotice.RestartFailed': 'Macro Deck could not restart.',
 	'macrodeck.app:Shell.Splash.PreparingUpdate': 'Preparing update…',
+	'macrodeck.app:Shell.Splash.Stopping': 'Stopping Macro Deck…',
 	'macrodeck.app:Shell.Statusbar.DevelopmentBuild': 'Development Build',
 	'macrodeck.app:Store.Cancelled': 'Cancelled',
 	'macrodeck.app:Store.Details': 'Details',


### PR DESCRIPTION
Closes #699

## Summary

Quitting Macro Deck showed "Connecting to Macro Deck…" while the host was shutting down. The bootstrapper now tells the desktop UI it is stopping before it stops the host, and the splash shows "Stopping Macro Deck…".

## Testing

Full .NET build and tests, the desktop UI suite and the bootstrapper tests pass, with new specs for the stopping splash and a test for the bridge event. Verified against a running host and desktop UI: after the stopping event and the quit shutdown the splash shows the new message, without the event it still shows connecting. Not verified in a packaged build, and the macOS lock-state test was not re-run locally because the screen was locked.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
