### PR TITLE
Show the update splash as soon as install starts

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/app.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/app.component.spec.ts
@@ -314,15 +314,74 @@ describe('AppComponent (desktop-ui) - splash status during an update install (is
     expect(statusText(fixture)).toBe(CONNECTING);
   });
 
-  it('A7: connected + installing (the @default branch) still shows connecting, not preparing-update', async () => {
+  it('A7: an install in progress shows the preparing-update message even before auth is known', async () => {
     setShell({
       getUpdateState: () => Promise.resolve(makeState({ phase: 'installing' })),
     });
 
     const fixture = await createFixture('unknown', 'connected');
 
-    expect(statusText(fixture)).toBe(CONNECTING);
-    expect(statusText(fixture)).not.toContain('Preparing update');
+    expect(statusText(fixture)).toBe(PREPARING_UPDATE);
+  });
+
+  it('starting an install replaces the app with the preparing-update splash while the host is still connected', async () => {
+    let push!: (state: ShellUpdateState) => void;
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ phase: 'downloaded' })),
+      onUpdateState: (callback: (state: ShellUpdateState) => void) => {
+        push = callback;
+        return Promise.resolve(() => {});
+      },
+    });
+
+    const fixture = await createFixture('authenticated', 'connected');
+    expect(fixture.nativeElement.querySelector('router-outlet')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('app-splash')).toBeNull();
+
+    push(makeState({ phase: 'installing' }));
+    await settle(fixture);
+
+    expect(fixture.nativeElement.querySelector('router-outlet')).toBeNull();
+    expect(statusText(fixture)).toBe(PREPARING_UPDATE);
+  });
+
+  it('an install that fails before the host stops brings the app back', async () => {
+    let push!: (state: ShellUpdateState) => void;
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ phase: 'installing' })),
+      onUpdateState: (callback: (state: ShellUpdateState) => void) => {
+        push = callback;
+        return Promise.resolve(() => {});
+      },
+    });
+
+    const fixture = await createFixture('authenticated', 'connected');
+    expect(statusText(fixture)).toBe(PREPARING_UPDATE);
+
+    push(makeState({ phase: 'failed', error: 'The pre-update backup failed.' }));
+    await settle(fixture);
+
+    expect(fixture.nativeElement.querySelector('app-splash')).toBeNull();
+    expect(fixture.nativeElement.querySelector('router-outlet')).not.toBeNull();
+  });
+
+  it('a quit announced during an install shows the stopping message while the host is still connected', async () => {
+    let announce!: () => void;
+    setShell({
+      getUpdateState: () => Promise.resolve(makeState({ phase: 'installing' })),
+      onHostStopping: (callback: () => void) => {
+        announce = callback;
+        return Promise.resolve(() => {});
+      },
+    });
+
+    const fixture = await createFixture('authenticated', 'connected');
+    expect(statusText(fixture)).toBe(PREPARING_UPDATE);
+
+    announce();
+    await settle(fixture);
+
+    expect(statusText(fixture)).toBe(STOPPING);
   });
 
   it('a quit announced by the shell turns the connecting message into the stopping message', async () => {

--- a/ui/angular/projects/desktop-ui/src/app/app.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/app.component.ts
@@ -43,7 +43,7 @@ const BOOTSTRAP_RETRY_MS = 1500;
           </div>
         }
         @case ('authenticated') {
-          @if (isConnected()) {
+          @if (isConnected() && !installingUpdate()) {
             <router-outlet></router-outlet>
           } @else {
             <app-splash [status]="splashStatus()"></app-splash>
@@ -99,18 +99,18 @@ export class AppComponent implements OnInit, OnDestroy {
 
   readonly isConnected = computed(() => this.api.connectionStateSignal() === 'connected');
 
+  protected readonly installingUpdate = computed(() => this.updateService.phase() === 'installing');
+
   protected readonly splashStatus = computed(() => {
-    if (!this.isConnected()) {
-      if (this.hostSession.stopping()) {
-        return this.localizationService.translateKey(AppStrings.Shell.Splash.Stopping);
-      }
-      if (this.updateService.phase() === 'installing') {
-        return this.localizationService.translateKey(AppStrings.Shell.Splash.PreparingUpdate);
-      }
-      if (this.updateService.installFailed()) {
-        return this.updateService.error()
-          ?? this.localizationService.translateKey(AppStrings.Settings.Update.InstallFailed);
-      }
+    if (this.hostSession.stopping()) {
+      return this.localizationService.translateKey(AppStrings.Shell.Splash.Stopping);
+    }
+    if (this.installingUpdate()) {
+      return this.localizationService.translateKey(AppStrings.Shell.Splash.PreparingUpdate);
+    }
+    if (!this.isConnected() && this.updateService.installFailed()) {
+      return this.updateService.error()
+        ?? this.localizationService.translateKey(AppStrings.Settings.Update.InstallFailed);
     }
     return this.localizationService.translateKey(AppStrings.WebClient.Connecting);
   });


### PR DESCRIPTION
Closes #722

## Summary

The desktop UI now shows the Preparing update splash as soon as the shell reports the install, instead of waiting for the host to disconnect after the pre-update backup and shutdown. If the install fails before the host stops, the app comes back.

## Testing

Full desktop-ui suite, production build and the .NET solution build and tests pass (three host log-file tests failed only under load and pass alone). New app component specs cover the connected cases. Verified in a browser against a running host with a stubbed shell bridge; a real packaged install could not be exercised locally.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
