### PR TITLE
Add reorderable multi-select list input

### DIFF
--- a/ui-model/src/MacroDeck.Ui/Config/UiChoiceInputs.cs
+++ b/ui-model/src/MacroDeck.Ui/Config/UiChoiceInputs.cs
@@ -63,8 +63,23 @@ public sealed record UiAutocompleteInput : UiOptionsInput<string>
 /// </summary>
 public sealed record UiMultiSelectInput : UiOptionsInput<IReadOnlyList<string>>
 {
+	/// <summary>Draws the options as a list whose selected rows the user drags or moves into order, so the order
+	/// of the bound list is meaningful - a presentation flag like <see cref="UiChoiceInput.Segmented" />. The
+	/// value keeps its shape; a renderer that does not know the flag draws the plain multiple selection.</summary>
+	public UiValue<bool> Reorderable { get; init; }
+
 	/// <inheritdoc />
 	public override string Type => UiConfigPrimitives.MultiSelect;
+
+	/// <inheritdoc />
+	protected internal override void DeclareProperties(UiPropertyDeclaration properties)
+	{
+		ArgumentNullException.ThrowIfNull(properties);
+
+		base.DeclareProperties(properties);
+
+		properties.Set(UiConfigProperties.Reorderable, Reorderable);
+	}
 }
 
 /// <summary>

--- a/ui-model/src/MacroDeck.Ui/Config/UiConfigProperties.cs
+++ b/ui-model/src/MacroDeck.Ui/Config/UiConfigProperties.cs
@@ -218,6 +218,10 @@ public static class UiConfigProperties
 	/// heading above it, or a sibling it is paired with.</summary>
 	public const string HideLabel = "hideLabel";
 
+	/// <summary>Whether a multiple selection renders as a list the user puts in order, making the order of its
+	/// value meaningful.</summary>
+	public const string Reorderable = "reorderable";
+
 #pragma warning restore CA1720
 
 	/// <summary>The property keys this package ships names for, in declaration order. Not exhaustive - see the
@@ -231,5 +235,6 @@ public static class UiConfigProperties
 		CanSubmit, Direction, Text, Url, DefaultExpanded, ClearOnCollapse, Severity, For, Triggers, CanRun,
 		IntegrationId, VariableTypes, WritableOnly, Capability, ConfigurationEntries, Segmented, Cards, Icon,
 		AspectRatio, Background, States, FalseLabel, TrueLabel, RowWeight, Wrap, HideLabel,
+		Reorderable,
 	];
 }

--- a/ui-model/tests/MacroDeck.Ui.Tests.UnitTests/Config/UiConfigVocabularyTests.cs
+++ b/ui-model/tests/MacroDeck.Ui.Tests.UnitTests/Config/UiConfigVocabularyTests.cs
@@ -217,7 +217,8 @@ public class UiConfigVocabularyTests
 						Configure(WithOptions(new UiDynamicChoiceInput { Key = "dynamicChoice" })),
 						Configure(WithOptions(new UiAutocompleteInput { Key = "autocomplete" })),
 						Configure(WithOptions(new UiMultiSelectInput { Key = "multiSelect" })),
-						Configure(WithOptions(new UiMultiSelectInput { Key = "orderedMultiSelect", Reorderable = true })),
+						Configure(
+							WithOptions(new UiMultiSelectInput { Key = "orderedMultiSelect", Reorderable = true })),
 						Configure(new UiColorInput { Key = "color" }),
 						Configure(new UiFileInput
 							{ Key = "file", FileExtensions = UiValue.Of<IReadOnlyList<string>>(["txt"]) }),

--- a/ui-model/tests/MacroDeck.Ui.Tests.UnitTests/Config/UiConfigVocabularyTests.cs
+++ b/ui-model/tests/MacroDeck.Ui.Tests.UnitTests/Config/UiConfigVocabularyTests.cs
@@ -146,6 +146,28 @@ public class UiConfigVocabularyTests
 		});
 	}
 
+	[Test]
+	public void A_multiple_selection_authored_without_the_reorderable_flag_emits_the_same_node_as_before()
+	{
+		var tree = UiViewBuilder.Build(ConfigSurface(),
+			Configure(WithOptions(new UiMultiSelectInput { Key = "devices" })));
+
+		var node = Walk(tree.Root).Single(n => n.Type == UiConfigPrimitives.MultiSelect);
+
+		Assert.That(node.Properties.Keys, Does.Not.Contain(UiConfigProperties.Reorderable));
+	}
+
+	[Test]
+	public void A_reorderable_multiple_selection_emits_the_flag_on_the_multiselect_node()
+	{
+		var tree = UiViewBuilder.Build(ConfigSurface(),
+			Configure(WithOptions(new UiMultiSelectInput { Key = "devices", Reorderable = true })));
+
+		var node = Walk(tree.Root).Single(n => n.Type == UiConfigPrimitives.MultiSelect);
+
+		Assert.That(node.Properties[UiConfigProperties.Reorderable].GetBoolean(), Is.True);
+	}
+
 	/// <summary>
 	/// One element of each of the forty-one types, with every property the DSL exposes populated. The option
 	/// properties are set explicitly rather than through a <see cref="UiOptionsState" />, because
@@ -195,6 +217,7 @@ public class UiConfigVocabularyTests
 						Configure(WithOptions(new UiDynamicChoiceInput { Key = "dynamicChoice" })),
 						Configure(WithOptions(new UiAutocompleteInput { Key = "autocomplete" })),
 						Configure(WithOptions(new UiMultiSelectInput { Key = "multiSelect" })),
+						Configure(WithOptions(new UiMultiSelectInput { Key = "orderedMultiSelect", Reorderable = true })),
 						Configure(new UiColorInput { Key = "color" }),
 						Configure(new UiFileInput
 							{ Key = "file", FileExtensions = UiValue.Of<IReadOnlyList<string>>(["txt"]) }),

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/reorderable-list/reorderable-list.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/reorderable-list/reorderable-list.component.spec.ts
@@ -1,0 +1,86 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReorderableListComponent } from './reorderable-list.component';
+import { provideLocalizationTesting } from '../../../../testing/localization-test-support';
+
+describe('ReorderableListComponent', () => {
+  let fixture: ComponentFixture<ReorderableListComponent>;
+  let component: ReorderableListComponent;
+  let emitted: string[][];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ReorderableListComponent],
+      providers: [provideZonelessChangeDetection(), ...provideLocalizationTesting()],
+    });
+    fixture = TestBed.createComponent(ReorderableListComponent);
+    component = fixture.componentInstance;
+    component.options = [
+      { value: 'cpu', label: 'CPU' },
+      { value: 'gpu', label: 'GPU' },
+      { value: 'ram', label: 'RAM' },
+    ];
+    component.value = ['cpu', 'gpu'];
+    emitted = [];
+    component.valueChange.subscribe(v => emitted.push(v));
+  });
+
+  function rowLabels(): string[] {
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    return Array.from(fixture.nativeElement.querySelectorAll('.rl-row') as NodeListOf<HTMLElement>)
+      .map(row => row.textContent?.trim() ?? '');
+  }
+
+  it('shows the selected items in their bound order, then the unselected options', () => {
+    component.value = ['gpu', 'cpu'];
+    expect(rowLabels()).toEqual(['GPU', 'CPU', 'RAM']);
+  });
+
+  it('appends a newly checked option to the end of the order', () => {
+    component.toggle('ram');
+    expect(emitted).toEqual([['cpu', 'gpu', 'ram']]);
+  });
+
+  it('removes an unchecked item and keeps the order of the rest', () => {
+    component.value = ['cpu', 'gpu', 'ram'];
+    component.toggle('gpu');
+    expect(emitted).toEqual([['cpu', 'ram']]);
+  });
+
+  it('moves an item down with its button', () => {
+    rowLabels();
+    (fixture.nativeElement.querySelector('.rl-down button') as HTMLButtonElement).click();
+    expect(emitted).toEqual([['gpu', 'cpu']]);
+  });
+
+  it('appends an option checked through its checkbox', () => {
+    rowLabels();
+    const boxes = fixture.nativeElement.querySelectorAll('.rl-row input[type="checkbox"]') as NodeListOf<HTMLInputElement>;
+    boxes[2].click();
+    expect(emitted).toEqual([['cpu', 'gpu', 'ram']]);
+  });
+
+  it('reorders to where a dragged row is dropped', () => {
+    component.value = ['cpu', 'gpu', 'ram'];
+    component.onDrop({ previousIndex: 2, currentIndex: 0 } as never);
+    expect(emitted).toEqual([['ram', 'cpu', 'gpu']]);
+  });
+
+  it('keeps a bound value that is no longer offered, labelled by its raw value', () => {
+    component.value = ['gone', 'cpu'];
+    expect(rowLabels()).toEqual(['gone', 'CPU', 'GPU', 'RAM']);
+
+    component.toggle('gpu');
+    expect(emitted).toEqual([['gone', 'cpu', 'gpu']]);
+  });
+
+  it('offers no move buttons that work while disabled', () => {
+    component.disabled = true;
+    rowLabels();
+    const buttons = Array.from(fixture.nativeElement.querySelectorAll('.rl-up button, .rl-down button')) as HTMLButtonElement[];
+    expect(buttons.length).toBeGreaterThan(0);
+    expect(buttons.every(b => b.disabled)).toBeTrue();
+  });
+});

--- a/ui/angular/projects/desktop-ui/src/app/components/forms/reorderable-list/reorderable-list.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/forms/reorderable-list/reorderable-list.component.ts
@@ -1,0 +1,134 @@
+import { CdkDrag, CdkDragDrop, CdkDragHandle, CdkDropList, moveItemInArray } from '@angular/cdk/drag-drop';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { ButtonComponent, CheckboxComponent, TranslatePipe } from '@shared';
+import { MultiSelectOption } from '../multi-select/multi-select.component';
+
+@Component({
+  selector: 'shared-reorderable-list',
+  standalone: true,
+  imports: [FormsModule, CdkDropList, CdkDrag, CdkDragHandle, ButtonComponent, CheckboxComponent, TranslatePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div
+      class="rl-list"
+      cdkDropList
+      cdkDropListLockAxis="y"
+      [cdkDropListDisabled]="disabled"
+      (cdkDropListDropped)="onDrop($event)">
+      @for (item of value; track item; let i = $index) {
+        <div class="rl-row" cdkDrag cdkDragPreviewContainer="parent">
+          <span
+            class="rl-handle"
+            cdkDragHandle
+            role="img"
+            [attr.aria-label]="'macrodeck.app:ActionBuilder.DragToReorder' | translate">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
+              <circle cx="4" cy="3" r="1.2"/>
+              <circle cx="4" cy="7" r="1.2"/>
+              <circle cx="4" cy="11" r="1.2"/>
+              <circle cx="10" cy="3" r="1.2"/>
+              <circle cx="10" cy="7" r="1.2"/>
+              <circle cx="10" cy="11" r="1.2"/>
+            </svg>
+          </span>
+          <shared-checkbox
+            class="rl-check"
+            [label]="labelOf(item)"
+            [disabled]="disabled"
+            [ngModel]="true"
+            (ngModelChange)="toggle(item)" />
+          <shared-button class="rl-up" variant="ghost" size="icon-compact"
+            [ariaLabel]="'macrodeck.app:Forms.KeyboardSequenceEditor.MoveUp' | translate"
+            [disabled]="disabled || i === 0" (click)="move(i, -1)">
+            <span class="icon icon-arrow-up icon-sm" aria-hidden="true"></span>
+          </shared-button>
+          <shared-button class="rl-down" variant="ghost" size="icon-compact"
+            [ariaLabel]="'macrodeck.app:Forms.KeyboardSequenceEditor.MoveDown' | translate"
+            [disabled]="disabled || i === value.length - 1" (click)="move(i, 1)">
+            <span class="icon icon-arrow-down icon-sm" aria-hidden="true"></span>
+          </shared-button>
+        </div>
+      }
+    </div>
+    @for (option of unselected(); track option.value) {
+      <div class="rl-row">
+        <span class="rl-handle-space" aria-hidden="true"></span>
+        <shared-checkbox
+          class="rl-check"
+          [label]="option.label ?? option.value"
+          [disabled]="disabled"
+          [ngModel]="false"
+          (ngModelChange)="toggle(option.value)" />
+      </div>
+    }
+    @if (loading) {
+      <div class="rl-status">{{ 'macrodeck:Common.Loading' | translate }}</div>
+    } @else if (value.length === 0 && options.length === 0) {
+      <div class="rl-status">{{ 'macrodeck.app:Forms.MultiSelect.NoOptions' | translate }}</div>
+    }
+  `,
+  styles: [`
+    :host { display: flex; flex-direction: column; gap: var(--space-1); flex: 1 1 0; min-width: 6.5rem; }
+    .rl-list { display: flex; flex-direction: column; gap: var(--space-1); }
+    .rl-row {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: 0.125rem 0.25rem;
+      border-radius: var(--radius-sm);
+      background-color: var(--color-bg-surface, transparent);
+      overflow-wrap: anywhere;
+    }
+    .rl-handle, .rl-handle-space { flex: 0 0 14px; display: flex; color: var(--color-text-muted); }
+    .rl-handle { cursor: grab; touch-action: none; }
+    .rl-check { flex: 1 1 auto; min-width: 0; }
+    .rl-status { padding: var(--space-2) 0.5rem; color: var(--color-text-muted); font-size: var(--text-xs); }
+    .cdk-drag-preview { box-shadow: var(--shadow-md); background-color: var(--color-bg-elevated); }
+    .cdk-drag-placeholder { opacity: 0.4; }
+    .cdk-drag-animating, .rl-list.cdk-drop-list-dragging .rl-row:not(.cdk-drag-placeholder) {
+      transition: transform 150ms ease;
+    }
+  `],
+})
+export class ReorderableListComponent {
+  @Input() value: string[] = [];
+  @Input() options: MultiSelectOption[] = [];
+  @Input() loading = false;
+  @Input() disabled = false;
+
+  @Output() valueChange = new EventEmitter<string[]>();
+
+  labelOf(value: string): string {
+    return this.options.find(o => o.value === value)?.label ?? value;
+  }
+
+  unselected(): MultiSelectOption[] {
+    return this.options.filter(o => !this.value.includes(o.value));
+  }
+
+  toggle(value: string): void {
+    this.emit(this.value.includes(value) ? this.value.filter(v => v !== value) : [...this.value, value]);
+  }
+
+  move(index: number, delta: number): void {
+    this.reorder(index, index + delta);
+  }
+
+  onDrop(event: CdkDragDrop<unknown>): void {
+    this.reorder(event.previousIndex, event.currentIndex);
+  }
+
+  private reorder(from: number, to: number): void {
+    if (from === to || to < 0 || to >= this.value.length) return;
+    const next = [...this.value];
+    moveItemInArray(next, from, to);
+    this.emit(next);
+  }
+
+  private emit(next: string[]): void {
+    this.value = next;
+    this.valueChange.emit(next);
+  }
+}

--- a/ui/angular/projects/desktop-ui/src/app/components/ui-render/config-node-primitives.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/ui-render/config-node-primitives.spec.ts
@@ -363,4 +363,43 @@ describe('shared-ui-node every configuration primitive', () => {
     expect(host.querySelector('shared-segmented-control')).toBeNull();
     expect(host.querySelector('shared-select')).not.toBeNull();
   });
+
+  it('draws a reorderable multiselect as an ordered list, and emits the new order when a row moves', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'multiselect',
+      properties: {
+        reorderable: true,
+        value: ['a', 'b'],
+        events: ['change'],
+        options: [
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+          { value: 'c', label: 'Gamma' },
+        ],
+      },
+    });
+    const host = el(rendered);
+
+    expect(host.querySelector('shared-multi-select')).toBeNull();
+    const rows = Array.from(host.querySelectorAll<HTMLElement>('.rl-row'));
+    expect(rows.map(r => r.textContent?.trim())).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+    host.querySelector<HTMLButtonElement>('.rl-down button')!.click();
+    await tick(rendered);
+
+    expect(rendered.events).toEqual([{ nodeId: 'n', name: 'change', data: ['b', 'a'] }]);
+  });
+
+  it('draws a multiselect with no reorderable property as the dropdown, unchanged', async () => {
+    const rendered = await renderTree({
+      id: 'n',
+      type: 'multiselect',
+      properties: { value: ['a'], options: [{ value: 'a', label: 'Alpha' }] },
+    });
+    const host = el(rendered);
+
+    expect(host.querySelector('shared-reorderable-list')).toBeNull();
+    expect(host.querySelector('shared-multi-select')).not.toBeNull();
+  });
 });

--- a/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.html
+++ b/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.html
@@ -213,10 +213,19 @@
           (opened)="onOpen()" />
       }
       @case (types.MultiSelect) {
-        <shared-multi-select
-          [value]="arrayValue()"
-          [options]="multiSelectOptions()"
-          (valueChange)="onChange($event)" />
+        @if (reorderable()) {
+          <shared-reorderable-list
+            [value]="arrayValue()"
+            [options]="multiSelectOptions()"
+            [loading]="loading()"
+            [disabled]="disabled()"
+            (valueChange)="onChange($event)" />
+        } @else {
+          <shared-multi-select
+            [value]="arrayValue()"
+            [options]="multiSelectOptions()"
+            (valueChange)="onChange($event)" />
+        }
       }
       @case (types.Password) {
         <shared-input

--- a/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/ui-render/ui-input.component.ts
@@ -8,6 +8,7 @@ import { normalizeHttpsUrl } from '../../domain/url-input.util';
 import { SelectComponent, SelectOption } from '../forms/select/select.component';
 import { ComboboxComponent, ComboboxOption } from '../forms/combobox/combobox.component';
 import { MultiSelectComponent, MultiSelectOption } from '../forms/multi-select/multi-select.component';
+import { ReorderableListComponent } from '../forms/reorderable-list/reorderable-list.component';
 import { ColorPickerComponent } from '../forms/color-picker/color-picker.component';
 import { FilePathInputComponent, FilePathKind } from '../forms/file-path-input/file-path-input.component';
 import { HotkeyRecorderComponent } from '../forms/hotkey-recorder/hotkey-recorder.component';
@@ -47,6 +48,7 @@ const Properties = UiConfigProperties;
     SelectComponent,
     ComboboxComponent,
     MultiSelectComponent,
+    ReorderableListComponent,
     ColorPickerComponent,
     FilePathInputComponent,
     HotkeyRecorderComponent,
@@ -103,6 +105,7 @@ export class UiInputComponent {
   );
   protected readonly segmented = computed(() => nodeBoolean(this.node(), Properties.Segmented) === true);
   protected readonly cards = computed(() => nodeBoolean(this.node(), Properties.Cards) === true);
+  protected readonly reorderable = computed(() => nodeBoolean(this.node(), Properties.Reorderable) === true);
 
   protected readonly toggleRow = computed(
     () => this.node().type === UiConfigPrimitives.Boolean && !this.segmented() && !this.hideLabel(),

--- a/ui/runtime/src/ui-config/config-properties.ts
+++ b/ui/runtime/src/ui-config/config-properties.ts
@@ -60,6 +60,7 @@ export const UiConfigProperties = {
   RowWeight: 'rowWeight',
   Wrap: 'wrap',
   HideLabel: 'hideLabel',
+  Reorderable: 'reorderable',
 } as const;
 
 export interface UiNodeOption {


### PR DESCRIPTION
Closes #712

## Summary

UiMultiSelectInput gets a Reorderable flag. The desktop UI then shows the options as a list with drag handles and move buttons, and the bound list keeps the order the user sets.

## Testing

Release build with warnings as errors, the full .NET suites and the full desktop-ui suite pass; one conformance test failed only under full-suite load and passes alone. Verified in the desktop UI against a running host with a temporary reorderable field on the Weather widget: move buttons, checking, and dragging change the order, and it survives save and reload. Dragging inside the Tauri window was not tested.

## Notes

Additive only: a flag-less UiMultiSelectInput emits the same node as before, and clients that do not know the flag keep showing the dropdown.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
