### PR TITLE
Write -webkit- spelling for floor inline styles

### DIFF
--- a/ui/runtime/src/render/dom-writes.spec.ts
+++ b/ui/runtime/src/render/dom-writes.spec.ts
@@ -1,0 +1,37 @@
+import { setStyle } from './dom-writes';
+
+// A recording style, because reading a style declaration back cannot show which of the two
+// spellings was actually written.
+function recordingElement(): { element: HTMLElement; written: { [property: string]: string } } {
+  const written: { [property: string]: string } = {};
+  const style = { setProperty: (name: string, value: string) => { written[name] = value; } };
+  return { element: { style } as unknown as HTMLElement, written };
+}
+
+describe('setStyle on the compatibility floor', () => {
+  for (const [name, prefixed, value] of [
+    ['transform', '-webkit-transform', 'scale(2)'],
+    ['transform-origin', '-webkit-transform-origin', '0 0'],
+    ['filter', '-webkit-filter', 'brightness(1.2)'],
+  ]) {
+    it(`writes ${name} under both spellings and clears both together`, () => {
+      const { element, written } = recordingElement();
+
+      setStyle(element, name, value);
+      expect(written[name]).toBe(value);
+      expect(written[prefixed]).toBe(value);
+
+      setStyle(element, name, null);
+      expect(written[name]).toBe('');
+      expect(written[prefixed]).toBe('');
+    });
+  }
+
+  it('writes an unprefixed property under its own name only', () => {
+    const { element, written } = recordingElement();
+
+    setStyle(element, 'opacity', '0.5');
+
+    expect(Object.keys(written)).toEqual(['opacity']);
+  });
+});

--- a/ui/runtime/src/render/dom-writes.ts
+++ b/ui/runtime/src/render/dom-writes.ts
@@ -2,6 +2,14 @@ interface StyleCache {
   [property: string]: string;
 }
 
+// The compatibility floor only knows these behind the prefix (PREFIXED_AT_FLOOR in the web client)
+// and silently drops the standard name, so both are always written and cleared together.
+const PREFIXED_AT_FLOOR: { [property: string]: string } = {
+  'transform': '-webkit-transform',
+  'transform-origin': '-webkit-transform-origin',
+  'filter': '-webkit-filter',
+};
+
 function styleCacheOf(element: HTMLElement | SVGElement): StyleCache {
   const withCache = element as unknown as { __mdStyleCache?: StyleCache };
   if (withCache.__mdStyleCache === undefined) withCache.__mdStyleCache = {};
@@ -15,7 +23,10 @@ export function setStyle(element: HTMLElement | SVGElement, name: string, value:
   cache[name] = normalized;
   // `setProperty(name, null)` is the documented removal, but the oldest engines in the baseline
   // ignore it, so an empty string does the removing instead.
-  (element as HTMLElement).style.setProperty(name, normalized);
+  const style = (element as HTMLElement).style;
+  const prefixed = PREFIXED_AT_FLOOR[name];
+  if (prefixed !== undefined) style.setProperty(prefixed, normalized);
+  style.setProperty(name, normalized);
   return true;
 }
 

--- a/ui/runtime/src/render/widget-border.spec.ts
+++ b/ui/runtime/src/render/widget-border.spec.ts
@@ -1,3 +1,4 @@
+import { setCustomPropertySupportForTesting } from './custom-properties';
 import { renderWidgetBorder } from './widget-border';
 
 describe('widget border', () => {
@@ -78,6 +79,18 @@ describe('widget border', () => {
 
     expect(ring()).not.toBe(before);
     expect(phase()).not.toBe(phaseBefore);
+  });
+
+  it('phase-locks the ring on an engine that only knows the prefixed animation properties', () => {
+    setCustomPropertySupportForTesting(false);
+    const writes = spyOn(CSSStyleDeclaration.prototype, 'setProperty').and.callThrough();
+    try {
+      renderWidgetBorder(overlay, () => 1500).update({ style: 'breathing', color: '#ff0000' });
+
+      expect(writes).toHaveBeenCalledWith('-webkit-animation-delay', phase());
+    } finally {
+      setCustomPropertySupportForTesting(null);
+    }
   });
 
   it('ignores a clock reading that only differs by the time the two reads took', () => {

--- a/ui/runtime/src/render/widget-border.ts
+++ b/ui/runtime/src/render/widget-border.ts
@@ -59,6 +59,7 @@ export function renderWidgetBorder(
         // one scale factor thick on an engine from 2015 beats no ring at all.
         element.style.padding = `${WIDGET_BORDER_WIDTH}px`;
         element.style.animationDelay = phase;
+        element.style.setProperty('-webkit-animation-delay', phase);
         if (TINTED_RING_STYLES.indexOf(resolved.style) !== -1) element.style.background = resolved.color;
       }
       overlay.appendChild(element);


### PR DESCRIPTION
No issue: found while auditing the web client's compatibility floor.

## Summary

Inline writes of transform, filter and the border ring's animation delay used only the standard name, which Chrome 30-35 and Android 4.4 drop, so tiles did not scale and artwork lost offset, zoom and filters there. The -webkit- spelling is now written and cleared alongside them.

## Testing

Runtime, web client and legacy suites pass, plus the full .NET build and tests. The new specs fail without the fix. Not verified on a real Chrome 30 or Android 4.4 engine, none was available.

## Notes

Filter and the ring's animation delay are on the same floor prefix list as transform, so they are fixed here too.

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
