### PR TITLE
Merge GPUs that Windows lists twice

### DIFF
--- a/host/src/MacroDeckHost.Integrations/System/Metrics/WindowsGpuAdapter.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Metrics/WindowsGpuAdapter.cs
@@ -6,4 +6,11 @@ internal sealed record WindowsGpuAdapter(
 	uint LuidLow,
 	ulong DedicatedVideoMemory,
 	ulong SharedSystemMemory,
-	bool IsSoftware);
+	bool IsSoftware)
+{
+	public uint VendorId { get; init; }
+	public uint DeviceId { get; init; }
+	public uint SubSysId { get; init; }
+	public uint Revision { get; init; }
+	public IReadOnlyList<(int High, uint Low)> Luids { get; init; } = [(LuidHigh, LuidLow)];
+}

--- a/host/src/MacroDeckHost.Integrations/System/Metrics/WindowsGpuInterop.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Metrics/WindowsGpuInterop.cs
@@ -95,7 +95,13 @@ internal sealed class WindowsGpuInterop : IDisposable
 						description.AdapterLuidLow,
 						(ulong)description.DedicatedVideoMemory,
 						(ulong)description.SharedSystemMemory,
-						(description.Flags & DxgiAdapterFlagSoftware) != 0));
+						(description.Flags & DxgiAdapterFlagSoftware) != 0)
+					{
+						VendorId = description.VendorId,
+						DeviceId = description.DeviceId,
+						SubSysId = description.SubSysId,
+						Revision = description.Revision
+					});
 				}
 				finally
 				{

--- a/host/src/MacroDeckHost.Integrations/System/Metrics/WindowsGpuSnapshotBuilder.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Metrics/WindowsGpuSnapshotBuilder.cs
@@ -13,6 +13,10 @@ internal static class WindowsGpuSnapshotBuilder
 	public static IReadOnlyList<WindowsGpuAdapter> Surviving(IReadOnlyList<WindowsGpuAdapter> adapters)
 		=> adapters
 			.Where(a => !a.IsSoftware && (a.DedicatedVideoMemory > 0 || a.SharedSystemMemory > 0))
+			// On multi-GPU machines DXGI can list the default adapter again under another LUID. Two
+			// physically identical cards are indistinguishable here and collapse too.
+			.GroupBy(a => (a.Name, a.VendorId, a.DeviceId, a.SubSysId, a.Revision, a.DedicatedVideoMemory))
+			.Select(g => g.First() with { Luids = g.SelectMany(a => a.Luids).ToArray() })
 			.OrderByDescending(a => a.DedicatedVideoMemory)
 			.ToArray();
 
@@ -58,10 +62,10 @@ internal static class WindowsGpuSnapshotBuilder
 	{
 		var usage = WindowsGpuCounterParser.Aggregate(entries);
 
-		if (adapters.Any(a => usage.ContainsKey((a.LuidHigh, a.LuidLow))))
+		if (adapters.Any(a => a.Luids.Any(usage.ContainsKey)))
 		{
 			join = LuidJoin.Matched;
-			return adapters.Select(a => Sample(a, usage.GetValueOrDefault((a.LuidHigh, a.LuidLow)))).ToArray();
+			return adapters.Select(a => Sample(a, a.Luids.Max(luid => usage.GetValueOrDefault(luid)))).ToArray();
 		}
 
 		// Which adapter an instance belongs to is unknown here. A single GPU still gets a correct

--- a/host/tests/MacroDeckHost.Tests.UnitTests/System/WindowsGpuSnapshotBuilderTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/System/WindowsGpuSnapshotBuilderTests.cs
@@ -9,8 +9,9 @@ public class WindowsGpuSnapshotBuilderTests
 		uint luidLow,
 		ulong dedicated = 4UL * 1024 * 1024 * 1024,
 		ulong shared = 8UL * 1024 * 1024 * 1024,
-		bool software = false)
-		=> new(name, 0, luidLow, dedicated, shared, software);
+		bool software = false,
+		uint deviceId = 0)
+		=> new(name, 0, luidLow, dedicated, shared, software) { DeviceId = deviceId };
 
 	private static string Instance(uint luidLow, int engine, string engineType, int pid = 1234)
 		=> $"pid_{pid}_luid_0x00000000_0x{luidLow:X8}_phys_0_eng_{engine}_engtype_{engineType}";
@@ -38,6 +39,56 @@ public class WindowsGpuSnapshotBuilderTests
 		var surviving = WindowsGpuSnapshotBuilder.Surviving([real, software, virtualDisplay]);
 
 		Assert.That(surviving.Select(a => a.Name), Is.EqualTo(new[] { "Radeon" }));
+	}
+
+	[Test]
+	public void A_card_dxgi_lists_twice_under_two_luids_is_one_gpu()
+	{
+		var surviving = WindowsGpuSnapshotBuilder.Surviving([
+			Adapter("NVIDIA GeForce RTX 4070", 0x2, deviceId: 0x2786),
+			Adapter("AMD Radeon(TM) Graphics", 0x1, dedicated: 512 * 1024 * 1024, deviceId: 0x164E),
+			Adapter("NVIDIA GeForce RTX 4070", 0x3, deviceId: 0x2786)
+		]);
+
+		Assert.That(surviving.Select(a => a.Name),
+			Is.EqualTo(new[] { "NVIDIA GeForce RTX 4070", "AMD Radeon(TM) Graphics" }));
+	}
+
+	[Test]
+	public void A_card_listed_twice_reads_its_usage_from_whichever_luid_has_counters()
+	{
+		var surviving = WindowsGpuSnapshotBuilder.Surviving([
+			Adapter("NVIDIA GeForce RTX 4070", 0x2, deviceId: 0x2786),
+			Adapter("AMD Radeon(TM) Graphics", 0x1, dedicated: 512 * 1024 * 1024, deviceId: 0x164E),
+			Adapter("NVIDIA GeForce RTX 4070", 0x3, deviceId: 0x2786)
+		]);
+
+		var samples = WindowsGpuSnapshotBuilder.Build(surviving,
+			Counters(new CounterEntry(Instance(0x3, 0, "3D"), 35), new CounterEntry(Instance(0x1, 0, "3D"), 5)),
+			null,
+			out var join);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(join, Is.EqualTo(WindowsGpuSnapshotBuilder.LuidJoin.Matched));
+			Assert.That(samples,
+				Is.EqualTo(new[]
+				{
+					new GpuSample("NVIDIA GeForce RTX 4070", 35),
+					new GpuSample("AMD Radeon(TM) Graphics", 5)
+				}));
+		});
+	}
+
+	[Test]
+	public void Cards_with_the_same_name_but_different_device_ids_stay_separate()
+	{
+		var surviving = WindowsGpuSnapshotBuilder.Surviving([
+			Adapter("NVIDIA GeForce RTX 4070", 0x2, deviceId: 0x2786),
+			Adapter("NVIDIA GeForce RTX 4070", 0x3, deviceId: 0x2709)
+		]);
+
+		Assert.That(surviving, Has.Count.EqualTo(2));
 	}
 
 	[Test]


### PR DESCRIPTION
Reported on Discord (no issue)

## Summary

On some multi-GPU Windows machines DXGI lists the default adapter a second time under another LUID, so the System integration showed one RTX 4070 as two GPUs. Adapters with the same name, PCI ids and dedicated memory now count as one GPU, reading usage from whichever LUID has counters.

## Testing

Full Release build with warnings as errors and the full test suite pass, with three new snapshot builder tests. Not run on Windows: no multi-GPU Windows machine was available, so the reporter should confirm with a build.

## Notes

Two physically identical cards (same PCI ids and memory) now show as one GPU; accepted trade-off. On affected machines the variables renumber, for example the iGPU moves from system_gpu_2 to system_gpu_1.

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
