### PR TITLE
Keep the host alive when an X11 window vanishes

### DIFF
--- a/host/src/MacroDeckHost.Integrations/Keyboard/Native/LinuxKeyboardInputProvider.cs
+++ b/host/src/MacroDeckHost.Integrations/Keyboard/Native/LinuxKeyboardInputProvider.cs
@@ -182,7 +182,7 @@ public sealed class LinuxKeyboardInputProvider : IKeyboardInputProvider, IDispos
 	{
 		try
 		{
-			return XOpenDisplay(IntPtr.Zero);
+			return X11Windows.OpenDisplay();
 		}
 		catch (DllNotFoundException)
 		{
@@ -264,9 +264,6 @@ public sealed class LinuxKeyboardInputProvider : IKeyboardInputProvider, IDispos
 			_ = XCloseDisplay(_display);
 		}
 	}
-
-	[DllImport(LibX11)]
-	private static extern IntPtr XOpenDisplay(IntPtr display);
 
 	[DllImport(LibX11)]
 	private static extern int XCloseDisplay(IntPtr display);

--- a/host/src/MacroDeckHost.Integrations/Mouse/Native/LinuxMouseInputProvider.cs
+++ b/host/src/MacroDeckHost.Integrations/Mouse/Native/LinuxMouseInputProvider.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using MacroDeck.Localization;
+using MacroDeckHost.Integrations.Native;
 using MacroDeckHost.Localization;
 
 namespace MacroDeckHost.Integrations.Mouse.Native;
@@ -214,7 +215,7 @@ public sealed class LinuxMouseInputProvider : IMouseInputProvider, IDisposable
 		IntPtr display;
 		try
 		{
-			display = XOpenDisplay(IntPtr.Zero);
+			display = X11Windows.OpenDisplay();
 		}
 		catch (DllNotFoundException)
 		{
@@ -262,9 +263,6 @@ public sealed class LinuxMouseInputProvider : IMouseInputProvider, IDisposable
 		_disposed = true;
 		_ = XCloseDisplay(_display);
 	}
-
-	[DllImport(LibX11)]
-	private static extern IntPtr XOpenDisplay(IntPtr display);
 
 	[DllImport(LibX11)]
 	private static extern int XCloseDisplay(IntPtr display);

--- a/host/src/MacroDeckHost.Integrations/Native/X11Windows.cs
+++ b/host/src/MacroDeckHost.Integrations/Native/X11Windows.cs
@@ -9,6 +9,15 @@ internal static class X11Windows
 {
 	private const string LibX11 = "libX11.so.6";
 
+	// Xlib's default error handler exits the process, and a foreign window can vanish between two requests.
+	private static readonly XErrorHandler _ignoreErrors = static (_, _) => 0;
+
+	public static IntPtr OpenDisplay()
+	{
+		_ = XSetErrorHandler(_ignoreErrors);
+		return XOpenDisplay(IntPtr.Zero);
+	}
+
 	public static nuint InternAtom(IntPtr display, string name)
 		=> XInternAtom(display, Encoding.UTF8.GetBytes(name + '\0'), true);
 
@@ -76,6 +85,15 @@ internal static class X11Windows
 		var values = ReadLongProperty(display, window, atom);
 		return values.Count > 0 ? (int)values[0] : null;
 	}
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate int XErrorHandler(IntPtr display, IntPtr errorEvent);
+
+	[DllImport(LibX11)]
+	private static extern IntPtr XSetErrorHandler(XErrorHandler handler);
+
+	[DllImport(LibX11)]
+	private static extern IntPtr XOpenDisplay(IntPtr display);
 
 	[DllImport(LibX11)]
 	private static extern nuint XInternAtom(

--- a/host/src/MacroDeckHost.Integrations/System/Focus/LinuxFocusedWindowReader.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Focus/LinuxFocusedWindowReader.cs
@@ -96,7 +96,7 @@ public sealed class LinuxFocusedWindowReader : IFocusedWindowReader, IDisposable
 	{
 		try
 		{
-			return XOpenDisplay(IntPtr.Zero);
+			return X11Windows.OpenDisplay();
 		}
 		catch (DllNotFoundException)
 		{
@@ -114,9 +114,6 @@ public sealed class LinuxFocusedWindowReader : IFocusedWindowReader, IDisposable
 		_disposed = true;
 		_ = XCloseDisplay(_display);
 	}
-
-	[DllImport(LibX11)]
-	private static extern IntPtr XOpenDisplay(IntPtr display);
 
 	[DllImport(LibX11)]
 	private static extern int XCloseDisplay(IntPtr display);

--- a/host/tests/MacroDeckHost.Tests.UnitTests.Linux/System/X11WindowsLinuxTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests.Linux/System/X11WindowsLinuxTests.cs
@@ -1,0 +1,64 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using MacroDeckHost.Integrations.Native;
+
+namespace MacroDeckHost.Tests.UnitTests.Linux.System;
+
+[Platform("Linux")]
+[SupportedOSPlatform("linux")]
+public class X11WindowsLinuxTests
+{
+	private const string LibX11 = "libX11.so.6";
+
+	[Test]
+	public void Reading_a_window_that_was_just_closed_returns_nothing_instead_of_terminating_the_process()
+	{
+		var display = X11Windows.OpenDisplay();
+		Assume.That(display, Is.Not.EqualTo(IntPtr.Zero), "needs an X11 display, for example Xvfb");
+
+		try
+		{
+			// A bare Xvfb has no window manager, so nothing has created the atom a real desktop always has.
+			_ = XInternAtom(display, "_NET_WM_PID\0"u8.ToArray(), false);
+			var window = XCreateSimpleWindow(display, XDefaultRootWindow(display), 0, 0, 10, 10, 0, 0, 0);
+			_ = XDestroyWindow(display, window);
+			_ = XSync(display, false);
+
+			Assert.That(X11Windows.GetWindowPid(display, window), Is.Null);
+		}
+		finally
+		{
+			_ = XCloseDisplay(display);
+		}
+	}
+
+	[DllImport(LibX11)]
+	private static extern int XCloseDisplay(IntPtr display);
+
+	[DllImport(LibX11)]
+	private static extern nuint XInternAtom(
+		IntPtr display,
+		byte[] name,
+		[MarshalAs(UnmanagedType.Bool)] bool onlyIfExists);
+
+	[DllImport(LibX11)]
+	private static extern nuint XDefaultRootWindow(IntPtr display);
+
+	[DllImport(LibX11)]
+	private static extern nuint XCreateSimpleWindow(
+		IntPtr display,
+		nuint parent,
+		int x,
+		int y,
+		uint width,
+		uint height,
+		uint borderWidth,
+		nuint border,
+		nuint background);
+
+	[DllImport(LibX11)]
+	private static extern int XDestroyWindow(IntPtr display, nuint window);
+
+	[DllImport(LibX11)]
+	private static extern int XSync(IntPtr display, [MarshalAs(UnmanagedType.Bool)] bool discard);
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests.Linux/System/X11WindowsLinuxTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests.Linux/System/X11WindowsLinuxTests.cs
@@ -13,8 +13,8 @@ public class X11WindowsLinuxTests
 	[Test]
 	public void Reading_a_window_that_was_just_closed_returns_nothing_instead_of_terminating_the_process()
 	{
-		var display = X11Windows.OpenDisplay();
-		Assume.That(display, Is.Not.EqualTo(IntPtr.Zero), "needs an X11 display, for example Xvfb");
+		var display = TryOpenDisplay();
+		Assume.That(display, Is.Not.EqualTo(IntPtr.Zero), "needs libX11 and an X11 display, for example Xvfb");
 
 		try
 		{
@@ -29,6 +29,18 @@ public class X11WindowsLinuxTests
 		finally
 		{
 			_ = XCloseDisplay(display);
+		}
+	}
+
+	private static IntPtr TryOpenDisplay()
+	{
+		try
+		{
+			return X11Windows.OpenDisplay();
+		}
+		catch (DllNotFoundException)
+		{
+			return IntPtr.Zero;
 		}
 	}
 


### PR DESCRIPTION
Closes #725

## Summary

Xlib's default error handler terminates the process, so an X request against a window that had just closed (such as the Macro Deck window) killed the host. All host X11 displays now open through X11Windows.OpenDisplay, which installs a non-fatal handler, and the read simply returns nothing for that poll.

## Testing

Full solution build with warnings as errors and all test suites pass on macOS. The new X11WindowsLinuxTests crashed the test host with the reported BadWindow error before the fix and passes after it, run in a Linux container under Xvfb. CI skips it because the Linux job has no display, and the real AppImage close flow on Arch was not tested.

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [ ] I reviewed and understand every submitted change
