### PR TITLE
Follow system volume changes in real time on macOS and Windows

### DIFF
--- a/host/src/MacroDeckHost.Application/Variables/VariableRefreshSignal.cs
+++ b/host/src/MacroDeckHost.Application/Variables/VariableRefreshSignal.cs
@@ -14,6 +14,10 @@ public interface IVariableRefreshSignal
 	/// <summary>Removes and returns every variable id pending for <paramref name="integrationId"/>.</summary>
 	IReadOnlyList<Guid> DrainFor(string integrationId);
 
+	void RequestDefinitionRefresh(string integrationId, string definitionId);
+
+	IReadOnlyList<string> DrainDefinitionsFor(string integrationId);
+
 	/// <summary>
 	/// Asks for every eager variable of <paramref name="integrationId"/> to be read again. The catalog
 	/// half is polled by a different loop and is not covered.
@@ -27,6 +31,9 @@ public interface IVariableRefreshSignal
 public sealed class VariableRefreshSignal : IVariableRefreshSignal
 {
 	private readonly ConcurrentDictionary<string, ConcurrentDictionary<Guid, byte>> _pending =
+		new(StringComparer.Ordinal);
+
+	private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> _pendingDefinitions =
 		new(StringComparer.Ordinal);
 
 	private readonly ConcurrentDictionary<string, byte> _pendingEager = new(StringComparer.Ordinal);
@@ -50,6 +57,37 @@ public sealed class VariableRefreshSignal : IVariableRefreshSignal
 		}
 
 		var drained = new List<Guid>();
+		foreach (var id in ids.Keys)
+		{
+			if (ids.TryRemove(id, out _))
+			{
+				drained.Add(id);
+			}
+		}
+
+		return drained;
+	}
+
+	public void RequestDefinitionRefresh(string integrationId, string definitionId)
+	{
+		if (string.IsNullOrEmpty(integrationId) || string.IsNullOrEmpty(definitionId))
+		{
+			return;
+		}
+
+		var ids = _pendingDefinitions.GetOrAdd(integrationId,
+			static _ => new ConcurrentDictionary<string, byte>(StringComparer.Ordinal));
+		ids.TryAdd(definitionId, 0);
+	}
+
+	public IReadOnlyList<string> DrainDefinitionsFor(string integrationId)
+	{
+		if (!_pendingDefinitions.TryGetValue(integrationId, out var ids) || ids.IsEmpty)
+		{
+			return [];
+		}
+
+		var drained = new List<string>();
 		foreach (var id in ids.Keys)
 		{
 			if (ids.TryRemove(id, out _))

--- a/host/src/MacroDeckHost.Infrastructure/BackgroundServices/IntegrationVariablePollingBackgroundService.cs
+++ b/host/src/MacroDeckHost.Infrastructure/BackgroundServices/IntegrationVariablePollingBackgroundService.cs
@@ -84,6 +84,7 @@ public sealed class IntegrationVariablePollingBackgroundService : HostReadyBackg
 			}
 
 			runtime.BringForward(_refresh.DrainFor(integration.Id));
+			runtime.BringForwardDefinitions(_refresh.DrainDefinitionsFor(integration.Id));
 			if (_refresh.DrainEagerRefreshRequested(integration.Id))
 			{
 				runtime.BringForwardAll();
@@ -267,6 +268,17 @@ public sealed class IntegrationVariablePollingBackgroundService : HostReadyBackg
 			foreach (var state in Variables.Values)
 			{
 				state.Schedule.MarkDueNow();
+			}
+		}
+
+		public void BringForwardDefinitions(IReadOnlyList<string> definitionIds)
+		{
+			foreach (var definitionId in definitionIds)
+			{
+				if (Variables.TryGetValue(definitionId, out var state))
+				{
+					state.Schedule.MarkDueNow();
+				}
 			}
 		}
 

--- a/host/src/MacroDeckHost.Integrations/System/SystemIntegration.cs
+++ b/host/src/MacroDeckHost.Integrations/System/SystemIntegration.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Threading.Channels;
+using MacroDeckHost.Application.Variables;
 using MacroDeckHost.Integrations.System.Actions;
 using MacroDeckHost.Integrations.System.Application;
 using MacroDeckHost.Integrations.System.Focus;
@@ -26,7 +27,8 @@ public sealed class SystemIntegration
 		IVariableProvider,
 		IIntegrationIssueProvider,
 		IIntegrationIconProvider,
-		IMigrationProvider
+		IMigrationProvider,
+		IVariableRefreshSignalConsumer
 {
 	public const string IntegrationId = "app.macro-deck.system";
 
@@ -42,6 +44,7 @@ public sealed class SystemIntegration
 	private const string GigabyteUnit = "GB";
 
 	private const string VolumePercentId = "system-volume-percent";
+	private const string MutedId = "system-muted";
 
 	private const int MaxIndexedGpus = 8;
 
@@ -86,6 +89,7 @@ public sealed class SystemIntegration
 	private VariableHandle? _focusedAppHandle;
 	private VariableHandle? _focusedAppPathHandle;
 	private VariableHandle? _focusedAppBundleIdHandle;
+	private IVariableRefreshSignal? _refreshSignal;
 
 	public SystemIntegration()
 		: this(ApplicationServiceFactory.Create(),
@@ -281,6 +285,9 @@ public sealed class SystemIntegration
 	{
 		_variableAccessor.Current = context.Variables;
 
+		_volume.Changed -= OnVolumeChanged;
+		_volume.Changed += OnVolumeChanged;
+
 		_focusedAppHandle = null;
 		_focusedAppPathHandle = null;
 		_focusedAppBundleIdHandle = null;
@@ -303,6 +310,7 @@ public sealed class SystemIntegration
 
 	public async Task ShutdownAsync()
 	{
+		_volume.Changed -= OnVolumeChanged;
 		FocusedApplicationSnapshot.Current.Changed -= OnFocusChanged;
 		_focusChannel?.Writer.TryComplete();
 
@@ -315,6 +323,14 @@ public sealed class SystemIntegration
 	}
 
 	private void OnFocusChanged(FocusedAppInfo? info) => _focusChannel?.Writer.TryWrite(info);
+
+	public void UseVariableRefreshSignal(IVariableRefreshSignal signal) => _refreshSignal = signal;
+
+	private void OnVolumeChanged()
+	{
+		_refreshSignal?.RequestDefinitionRefresh(IntegrationId, VolumePercentId);
+		_refreshSignal?.RequestDefinitionRefresh(IntegrationId, MutedId);
+	}
 
 	// One consumer draining a capacity-1 drop-oldest channel, rather than an unordered Task per focus
 	// change: the variable API is async and Changed fires synchronously on the focus pipeline's own
@@ -362,7 +378,7 @@ public sealed class SystemIntegration
 				await _volume.GetVolumeAsync(cancellationToken) is { } volume
 					? VariableReading.Of((int)Math.Round(volume * 100), MinVolumePercent, MaxVolumePercent, 1)
 					: VariableReading.Unavailable,
-			"system-muted" when _volume.IsSupported =>
+			MutedId when _volume.IsSupported =>
 				VariableReading.Of(await _volume.GetMuteAsync(cancellationToken)),
 			"system-cpu-usage-percent" =>
 				VariableReading.Of(RoundPercent(await _metrics.GetCpuUsageAsync(cancellationToken))),

--- a/host/src/MacroDeckHost.Integrations/System/Volume/IVolumeService.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Volume/IVolumeService.cs
@@ -4,6 +4,8 @@ public interface IVolumeService
 {
 	bool IsSupported { get; }
 
+	event Action? Changed;
+
 	Task<float?> GetVolumeAsync(CancellationToken cancellationToken = default);
 
 	Task SetVolumeAsync(float level, CancellationToken cancellationToken = default);

--- a/host/src/MacroDeckHost.Integrations/System/Volume/LinuxVolumeService.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Volume/LinuxVolumeService.cs
@@ -14,6 +14,12 @@ internal sealed partial class LinuxVolumeService : IVolumeService
 
 	public bool IsSupported => _hasPactl || _hasAmixer;
 
+	public event Action? Changed
+	{
+		add { }
+		remove { }
+	}
+
 	public async Task<float?> GetVolumeAsync(CancellationToken cancellationToken = default)
 	{
 		if (_hasPactl)

--- a/host/src/MacroDeckHost.Integrations/System/Volume/MacOSVolumeService.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Volume/MacOSVolumeService.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using Serilog;
 
 namespace MacroDeckHost.Integrations.System.Volume;
 
@@ -21,7 +23,58 @@ internal sealed class MacOsVolumeService : IVolumeService
 
 	private static readonly uint[] _stereoElements = [1, 2];
 
+	private static readonly AudioObjectPropertyAddress[] _deviceAddresses =
+	[
+		new(VolumeScalarSelector, OutputScope, MainElement),
+		new(VolumeScalarSelector, OutputScope, 1),
+		new(VolumeScalarSelector, OutputScope, 2),
+		new(MuteSelector, OutputScope, MainElement)
+	];
+
+	private static readonly ILogger _logger = Log.ForContext<MacOsVolumeService>();
+
+	// CoreAudio keeps this pointer for as long as any listener is registered, so the delegate has to stay
+	// reachable for the process lifetime.
+	private static readonly PropertyListener _listener = OnPropertyChanged;
+	private static readonly IntPtr _listenerPointer = Marshal.GetFunctionPointerForDelegate(_listener);
+
+	private static long _nextToken;
+	private static readonly ConcurrentDictionary<IntPtr, MacOsVolumeService> _instances = new();
+
+	private readonly object _gate = new();
+
+	private volatile Action? _changed;
+	private volatile bool _armed;
+	private IntPtr _token;
+	private uint _listenedDevice = UnknownDevice;
+
 	public bool IsSupported => true;
+
+	public event Action? Changed
+	{
+		add
+		{
+			lock (_gate)
+			{
+				_changed += value;
+				if (!_armed && _changed is not null)
+				{
+					Arm();
+				}
+			}
+		}
+		remove
+		{
+			lock (_gate)
+			{
+				_changed -= value;
+				if (_armed && _changed is null)
+				{
+					Disarm();
+				}
+			}
+		}
+	}
 
 	public Task<float?> GetVolumeAsync(CancellationToken cancellationToken = default)
 		=> Task.FromResult(ReadVolume());
@@ -39,6 +92,91 @@ internal sealed class MacOsVolumeService : IVolumeService
 	{
 		_ = TryWriteMute(mute);
 		return Task.CompletedTask;
+	}
+
+	private void Arm()
+	{
+		_token = checked((IntPtr)Interlocked.Increment(ref _nextToken));
+		_instances[_token] = this;
+		_armed = true;
+
+		var address = new AudioObjectPropertyAddress(DefaultOutputDeviceSelector, GlobalScope, MainElement);
+		_ = AudioObjectAddPropertyListener(SystemObject, ref address, _listenerPointer, _token);
+		ListenTo(ReadDefaultOutputDevice() ?? UnknownDevice);
+	}
+
+	private void Disarm()
+	{
+		_armed = false;
+
+		var address = new AudioObjectPropertyAddress(DefaultOutputDeviceSelector, GlobalScope, MainElement);
+		_ = AudioObjectRemovePropertyListener(SystemObject, ref address, _listenerPointer, _token);
+		ListenTo(UnknownDevice);
+		_instances.TryRemove(_token, out _);
+	}
+
+	private void Retarget()
+	{
+		lock (_gate)
+		{
+			if (_armed)
+			{
+				ListenTo(ReadDefaultOutputDevice() ?? UnknownDevice);
+			}
+		}
+	}
+
+	private void ListenTo(uint device)
+	{
+		if (_listenedDevice != UnknownDevice)
+		{
+			foreach (var entry in _deviceAddresses)
+			{
+				var address = entry;
+				_ = AudioObjectRemovePropertyListener(_listenedDevice, ref address, _listenerPointer, _token);
+			}
+		}
+
+		_listenedDevice = device;
+		if (device == UnknownDevice)
+		{
+			return;
+		}
+
+		foreach (var entry in _deviceAddresses)
+		{
+			var address = entry;
+			if (HasProperty(device, ref address))
+			{
+				_ = AudioObjectAddPropertyListener(device, ref address, _listenerPointer, _token);
+			}
+		}
+	}
+
+	private static int OnPropertyChanged(uint objectId, uint addressCount, IntPtr addresses, IntPtr clientData)
+	{
+		try
+		{
+			if (!_instances.TryGetValue(clientData, out var service) || !service._armed)
+			{
+				return 0;
+			}
+
+			// Moving the listeners locks the gate, and a CoreAudio callback must never block on it.
+			if (objectId == SystemObject)
+			{
+				ThreadPool.QueueUserWorkItem(static s => s.Retarget(), service, preferLocal: false);
+			}
+
+			service._changed?.Invoke();
+		}
+		catch (Exception e)
+		{
+			// Runs inside a CoreAudio call frame: an exception unwinding into native code is undefined behaviour.
+			_logger.Error(e, "The macOS volume change callback failed");
+		}
+
+		return 0;
 	}
 
 	private static float? ReadVolume()
@@ -160,6 +298,23 @@ internal sealed class MacOsVolumeService : IVolumeService
 		=> HasProperty(device, ref address) &&
 			AudioObjectIsPropertySettable(device, ref address, out var settable) == 0 &&
 			settable != 0;
+
+	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+	private delegate int PropertyListener(uint objectId, uint addressCount, IntPtr addresses, IntPtr clientData);
+
+	[DllImport(CoreAudioLibrary)]
+	private static extern int AudioObjectAddPropertyListener(
+		uint objectId,
+		ref AudioObjectPropertyAddress address,
+		IntPtr listener,
+		IntPtr clientData);
+
+	[DllImport(CoreAudioLibrary)]
+	private static extern int AudioObjectRemovePropertyListener(
+		uint objectId,
+		ref AudioObjectPropertyAddress address,
+		IntPtr listener,
+		IntPtr clientData);
 
 	[DllImport(CoreAudioLibrary)]
 	private static extern int AudioObjectGetPropertyData(

--- a/host/src/MacroDeckHost.Integrations/System/Volume/NullVolumeService.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Volume/NullVolumeService.cs
@@ -4,6 +4,12 @@ internal sealed class NullVolumeService : IVolumeService
 {
 	public bool IsSupported => false;
 
+	public event Action? Changed
+	{
+		add { }
+		remove { }
+	}
+
 	public Task<float?> GetVolumeAsync(CancellationToken cancellationToken = default)
 		=> Task.FromResult<float?>(null);
 

--- a/host/src/MacroDeckHost.Integrations/System/Volume/WindowsVolumeService.cs
+++ b/host/src/MacroDeckHost.Integrations/System/Volume/WindowsVolumeService.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using Serilog;
 
 namespace MacroDeckHost.Integrations.System.Volume;
 
@@ -12,7 +13,49 @@ internal sealed class WindowsVolumeService : IVolumeService
 
 	private static readonly Guid _audioEndpointVolumeIid = typeof(IAudioEndpointVolume).GUID;
 
+	private static readonly ILogger _logger = Log.ForContext<WindowsVolumeService>();
+
+	private readonly object _gate = new();
+	private readonly VolumeCallback _callback;
+
+	private volatile Action? _changed;
+	private volatile bool _armed;
+	private IAudioEndpointVolume? _listened;
+	private string? _listenedId;
+
+	public WindowsVolumeService()
+	{
+		_callback = new VolumeCallback(this);
+	}
+
 	public bool IsSupported => true;
+
+	public event Action? Changed
+	{
+		add
+		{
+			lock (_gate)
+			{
+				_changed += value;
+				if (!_armed && _changed is not null)
+				{
+					Arm();
+				}
+			}
+		}
+		remove
+		{
+			lock (_gate)
+			{
+				_changed -= value;
+				if (_armed && _changed is null)
+				{
+					_armed = false;
+					StopListening();
+				}
+			}
+		}
+	}
 
 	public Task<float?> GetVolumeAsync(CancellationToken cancellationToken = default)
 	{
@@ -94,7 +137,23 @@ internal sealed class WindowsVolumeService : IVolumeService
 		return Task.CompletedTask;
 	}
 
-	private static IAudioEndpointVolume? GetEndpointVolume()
+	private void Arm()
+	{
+		_armed = true;
+		try
+		{
+			if (GetEndpointVolume() is { } endpoint)
+			{
+				Marshal.ReleaseComObject(endpoint);
+			}
+		}
+		catch (COMException e)
+		{
+			_logger.Debug(e, "Could not listen for Windows volume changes yet");
+		}
+	}
+
+	private IAudioEndpointVolume? GetEndpointVolume()
 	{
 		var enumerator = (IMMDeviceEnumerator)(object)new MMDeviceEnumerator();
 		try
@@ -111,6 +170,7 @@ internal sealed class WindowsVolumeService : IVolumeService
 			Marshal.ThrowExceptionForHR(hr);
 			try
 			{
+				FollowDefaultEndpoint(device);
 				var iid = _audioEndpointVolumeIid;
 				Marshal.ThrowExceptionForHR(device.Activate(ref iid, ClsCtxAll, IntPtr.Zero, out var instance));
 				return (IAudioEndpointVolume)instance;
@@ -123,6 +183,82 @@ internal sealed class WindowsVolumeService : IVolumeService
 		finally
 		{
 			Marshal.ReleaseComObject(enumerator);
+		}
+	}
+
+	private void FollowDefaultEndpoint(IMMDevice device)
+	{
+		if (!_armed || device.GetId(out var id) != 0)
+		{
+			return;
+		}
+
+		lock (_gate)
+		{
+			if (!_armed || id == _listenedId)
+			{
+				return;
+			}
+
+			StopListening();
+
+			var iid = _audioEndpointVolumeIid;
+			if (device.Activate(ref iid, ClsCtxAll, IntPtr.Zero, out var instance) != 0)
+			{
+				return;
+			}
+
+			var endpoint = (IAudioEndpointVolume)instance;
+			if (endpoint.RegisterControlChangeNotify(_callback) != 0)
+			{
+				_logger.Debug("Could not register for Windows volume change notifications");
+				Marshal.ReleaseComObject(endpoint);
+				return;
+			}
+
+			_listened = endpoint;
+			_listenedId = id;
+		}
+	}
+
+	private void StopListening()
+	{
+		if (_listened is null)
+		{
+			return;
+		}
+
+		_ = _listened.UnregisterControlChangeNotify(_callback);
+		Marshal.ReleaseComObject(_listened);
+		_listened = null;
+		_listenedId = null;
+	}
+
+	[ComVisible(true)]
+	private sealed class VolumeCallback : IAudioEndpointVolumeCallback
+	{
+		private readonly WindowsVolumeService _owner;
+
+		public VolumeCallback(WindowsVolumeService owner)
+		{
+			_owner = owner;
+		}
+
+		public int OnNotify(IntPtr notifyData)
+		{
+			try
+			{
+				if (_owner._armed)
+				{
+					_owner._changed?.Invoke();
+				}
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "The Windows volume change callback failed");
+			}
+
+			return 0;
 		}
 	}
 
@@ -153,6 +289,21 @@ internal sealed class WindowsVolumeService : IVolumeService
 			int clsCtx,
 			IntPtr activationParams,
 			[MarshalAs(UnmanagedType.IUnknown)] out object instance);
+
+		[PreserveSig]
+		int OpenPropertyStore(int stgmAccess, out IntPtr properties);
+
+		[PreserveSig]
+		int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+	}
+
+	[ComImport]
+	[Guid("657804FA-D6AD-4496-8A60-352752AF4F89")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	private interface IAudioEndpointVolumeCallback
+	{
+		[PreserveSig]
+		int OnNotify(IntPtr notifyData);
 	}
 
 	[ComImport]
@@ -161,10 +312,10 @@ internal sealed class WindowsVolumeService : IVolumeService
 	private interface IAudioEndpointVolume
 	{
 		[PreserveSig]
-		int RegisterControlChangeNotify(IntPtr notify);
+		int RegisterControlChangeNotify(IAudioEndpointVolumeCallback notify);
 
 		[PreserveSig]
-		int UnregisterControlChangeNotify(IntPtr notify);
+		int UnregisterControlChangeNotify(IAudioEndpointVolumeCallback notify);
 
 		[PreserveSig]
 		int GetChannelCount(out uint channelCount);

--- a/host/tests/MacroDeckHost.Tests.UnitTests.MacOS/System/VolumeServiceMacOsTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests.MacOS/System/VolumeServiceMacOsTests.cs
@@ -1,0 +1,22 @@
+using MacroDeckHost.Integrations.System.Volume;
+
+namespace MacroDeckHost.Tests.UnitTests.MacOS.System;
+
+[Platform("MacOsX")]
+public class VolumeServiceMacOsTests
+{
+	[Test]
+	public void Subscribing_to_and_unsubscribing_from_volume_changes_does_not_throw()
+	{
+		var service = VolumeServiceFactory.Create();
+		Action handler = () => { };
+
+		Assert.Multiple(() =>
+		{
+			Assert.DoesNotThrow(() => service.Changed += handler);
+			Assert.DoesNotThrow(() => service.Changed -= handler);
+			Assert.DoesNotThrow(() => service.Changed += handler);
+			Assert.DoesNotThrow(() => service.Changed -= handler);
+		});
+	}
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests.Windows/System/VolumeServiceWindowsTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests.Windows/System/VolumeServiceWindowsTests.cs
@@ -32,4 +32,18 @@ public class VolumeServiceWindowsTests
 				"Both readings come from the same default endpoint, so they are available together.");
 		});
 	}
+
+	[Test]
+	public void Subscribing_to_and_unsubscribing_from_volume_changes_does_not_throw()
+	{
+		var service = VolumeServiceFactory.Create();
+		Action handler = () => { };
+
+		Assert.Multiple(() =>
+		{
+			Assert.DoesNotThrow(() => service.Changed += handler);
+			Assert.DoesNotThrowAsync(() => service.GetVolumeAsync());
+			Assert.DoesNotThrow(() => service.Changed -= handler);
+		});
+	}
 }

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Integrations/IntegrationVariablePollingBackgroundServiceTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Integrations/IntegrationVariablePollingBackgroundServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using MacroDeckHost.Application.Events;
 using MacroDeckHost.Application.Events.Handlers;
 using MacroDeckHost.Application.Rendering;
@@ -213,6 +214,49 @@ internal sealed class IntegrationVariablePollingBackgroundServiceTests
 		Assert.That(two.ReadCount, Is.EqualTo(1));
 	}
 
+	[Test]
+	public async Task A_definition_request_reads_that_variable_early_once_and_leaves_its_siblings_alone()
+	{
+		var integration = CountingIntegration("app.test.one");
+		integration.Variables =
+		[
+			VariableDefinition.Eager("first", SdkVariableType.Text, refreshInterval: TimeSpan.FromMinutes(5)),
+			VariableDefinition.Eager("second", SdkVariableType.Text, refreshInterval: TimeSpan.FromMinutes(5))
+		];
+		var refresh = new VariableRefreshSignal();
+		var service = CreateService(new ConfigurableIntegrationRegistry([integration]),
+			new RecordingVariableService(),
+			new VariablePollingInvalidationSignal(),
+			refresh);
+
+		await DispatchUntil(service, () => integration.ReadsOf("first") == 1 && integration.ReadsOf("second") == 1);
+
+		refresh.RequestDefinitionRefresh("app.test.one", "first");
+		await DispatchUntil(service, () => integration.ReadsOf("first") == 2);
+		await service.DispatchDue(CancellationToken.None);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(integration.ReadsOf("first"), Is.EqualTo(2));
+			Assert.That(integration.ReadsOf("second"), Is.EqualTo(1));
+		});
+	}
+
+	private static async Task DispatchUntil(IntegrationVariablePollingBackgroundService service, Func<bool> done)
+	{
+		var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+		while (!done())
+		{
+			if (DateTime.UtcNow > deadline)
+			{
+				Assert.Fail("the expected reads never happened");
+			}
+
+			await service.DispatchDue(CancellationToken.None);
+			await Task.Delay(5);
+		}
+	}
+
 	private static Task DispatchUntilRead(
 		IntegrationVariablePollingBackgroundService service,
 		CountingVariableProviderIntegration integration,
@@ -256,14 +300,18 @@ internal sealed class IntegrationVariablePollingBackgroundServiceTests
 
 	private sealed class CountingVariableProviderIntegration : FakeVariableProviderIntegration
 	{
+		private readonly ConcurrentDictionary<string, int> _readsById = new(StringComparer.Ordinal);
 		private int _readCount;
 
 		public int ReadCount => Volatile.Read(ref _readCount);
+
+		public int ReadsOf(string localId) => _readsById.TryGetValue(localId, out var reads) ? reads : 0;
 
 		public override ValueTask<VariableReading> ReadAsync(
 			string localId,
 			CancellationToken cancellationToken = default)
 		{
+			_readsById.AddOrUpdate(localId, 1, static (_, reads) => reads + 1);
 			Interlocked.Increment(ref _readCount);
 			return ValueTask.FromResult(VariableReading.Of("value"));
 		}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/System/FakeVolumeService.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/System/FakeVolumeService.cs
@@ -15,6 +15,10 @@ internal sealed class FakeVolumeService : IVolumeService
 
 	public bool? Muted { get; set; }
 
+	public event Action? Changed;
+
+	public void RaiseChanged() => Changed?.Invoke();
+
 	public Task<float?> GetVolumeAsync(CancellationToken cancellationToken = default) => Task.FromResult(Volume);
 
 	public Task SetVolumeAsync(float level, CancellationToken cancellationToken = default)

--- a/host/tests/MacroDeckHost.Tests.UnitTests/System/SystemIntegrationTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/System/SystemIntegrationTests.cs
@@ -1,3 +1,4 @@
+using MacroDeckHost.Application.Variables;
 using MacroDeckHost.Integrations.System;
 using MacroDeckHost.Integrations.System.Focus;
 using MacroDeckHost.Integrations.System.Lock;
@@ -577,6 +578,50 @@ public class SystemIntegrationTests
 		{
 			await integration.ShutdownAsync();
 		}
+	}
+
+	[Test]
+	public async Task A_volume_change_asks_for_the_volume_and_mute_variables_only()
+	{
+		var volume = new FakeVolumeService();
+		var signal = new VariableRefreshSignal();
+		var integration = Create(volume);
+		integration.UseVariableRefreshSignal(signal);
+
+		try
+		{
+			await integration.InitializeAsync(new FakeIntegrationContext(new RecordingVariableApi()));
+
+			volume.RaiseChanged();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(signal.DrainDefinitionsFor(SystemIntegration.IntegrationId),
+					Is.EquivalentTo(new[] { "system-volume-percent", "system-muted" }));
+				Assert.That(signal.DrainEagerRefreshRequested(SystemIntegration.IntegrationId), Is.False);
+			});
+		}
+		finally
+		{
+			await integration.ShutdownAsync();
+		}
+	}
+
+	[Test]
+	public async Task After_shutdown_a_volume_change_asks_for_nothing_even_after_a_repeated_initialization()
+	{
+		var volume = new FakeVolumeService();
+		var signal = new VariableRefreshSignal();
+		var integration = Create(volume);
+		integration.UseVariableRefreshSignal(signal);
+
+		await integration.InitializeAsync(new FakeIntegrationContext(new RecordingVariableApi()));
+		await integration.InitializeAsync(new FakeIntegrationContext(new RecordingVariableApi()));
+		await integration.ShutdownAsync();
+
+		volume.RaiseChanged();
+
+		Assert.That(signal.DrainDefinitionsFor(SystemIntegration.IntegrationId), Is.Empty);
 	}
 
 	private sealed class FakeNotificationService : INotificationService

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableRefreshSignalTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Variables/VariableRefreshSignalTests.cs
@@ -60,4 +60,35 @@ internal sealed class VariableRefreshSignalTests
 			Assert.That(signal.DrainFor("app.test.one"), Is.EqualTo(new[] { variable }));
 		});
 	}
+
+	[Test]
+	public void Definition_requests_are_reported_once_and_coalesce()
+	{
+		var signal = new VariableRefreshSignal();
+
+		signal.RequestDefinitionRefresh("app.test.one", "volume");
+		signal.RequestDefinitionRefresh("app.test.one", "volume");
+		signal.RequestDefinitionRefresh("app.test.one", "muted");
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(signal.DrainDefinitionsFor("app.test.one"), Is.EquivalentTo(new[] { "volume", "muted" }));
+			Assert.That(signal.DrainDefinitionsFor("app.test.one"), Is.Empty);
+		});
+	}
+
+	[Test]
+	public void A_definition_request_belongs_to_one_integration_and_raises_no_other_request()
+	{
+		var signal = new VariableRefreshSignal();
+
+		signal.RequestDefinitionRefresh("app.test.one", "volume");
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(signal.DrainDefinitionsFor("app.test.two"), Is.Empty);
+			Assert.That(signal.DrainFor("app.test.one"), Is.Empty);
+			Assert.That(signal.DrainEagerRefreshRequested("app.test.one"), Is.False);
+		});
+	}
 }


### PR DESCRIPTION
Requested directly by the maintainer (no issue).

## Summary

System volume and mute now follow external changes near real time on macOS and Windows. Native change notifications ask the host to re-read just those two variables, and the 2 s poll stays as a fallback.

## Testing

Full solution build with warnings as errors and all test suites pass, with new tests for the scoped refresh and the subscription lifecycle. On macOS an external volume change reached the variable in 0.2 to 0.5 s instead of 1.4 to 1.8 s, and a slider in the desktop UI followed the volume keys. Windows was built and unit tested only, not run.

## Notes

On Windows a switch of the default output device is picked up by the next 2 s poll rather than by an event. Worth a quick check on a real Windows machine before merge.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
