### PR TITLE
Keep trailing blank lines in wrapping labels

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/shared/components/ui-render/widget-text-ink.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/shared/components/ui-render/widget-text-ink.spec.ts
@@ -100,4 +100,34 @@ describe('ui.text ink', () => {
 
     expect(below.top - root.top).toBeCloseTo(BASIS * 0.1, 1);
   });
+
+  describe('wrapping text with blank lines after it', () => {
+    const wrapping = (id: string, value: string): UiNode => ({
+      id,
+      type: Types.Text,
+      properties: { [Props.Text]: value, [Props.Size]: { basis: 0.1 }, [Props.Wrap]: true },
+    });
+
+    async function heightOf(value: string): Promise<number> {
+      const rendered = await renderTree(
+        { id: 'root', type: Types.Stack, properties: {}, children: [wrapping('value', value)] },
+        withBasis(BASIS),
+      );
+      const height = node(rendered, 'value').getBoundingClientRect().height;
+      TestBed.resetTestingModule();
+      return height;
+    }
+
+    it('keeps one trailing blank line as a line of its own', async () => {
+      expect(await heightOf('Back\n')).toBeCloseTo(await heightOf('a\nb'), 0);
+    });
+
+    it('keeps every trailing blank line', async () => {
+      expect(await heightOf('Back\n\n')).toBeCloseTo(await heightOf('a\nb\nc'), 0);
+    });
+
+    it('adds no line to text without a trailing break', async () => {
+      expect(await heightOf('Back')).toBeCloseTo(await heightOf('a'), 0);
+    });
+  });
 });

--- a/ui/runtime/src/ui-components/text-paint.ts
+++ b/ui/runtime/src/ui-components/text-paint.ts
@@ -42,7 +42,10 @@ export function paintTextCommon<TState>(
   ctx.setStyle(element, '-webkit-line-clamp', maxLines > 1 ? String(maxLines) : null);
   ctx.setStyle(element, 'min-width', digits === null ? null : `${digits}ch`);
 
-  if (element.textContent !== text) element.textContent = text;
+  // A final line break in pre-wrap text opens no line of its own, so a label's trailing blank line
+  // would vanish. One more break keeps it, the way a native text view lays it out.
+  const painted = wraps && text.endsWith('\n') ? `${text}\n` : text;
+  if (element.textContent !== painted) element.textContent = painted;
 
   const size = resolveLength(nodeLength(node, UiComponentProperties.Size), ctx.basis, ctx.crossExtent);
   const minSize = resolveLength(nodeLength(node, UiComponentProperties.MinSize), ctx.basis, ctx.crossExtent);


### PR DESCRIPTION
Reported on Discord (no issue)

## Summary

Blank lines after the text of a wrapping label were dropped on the desktop UI and web client, so button labels sat lower than in the Companion app. The runtime now keeps them, for every wrapping text that ends in a line break, plugin widgets included.

## Testing

Full solution build and tests and desktop-ui Karma passed before rebasing onto current main; after it, the runtime and web client suites and the three new layout specs (which fail without the fix) pass. Verified in the web client against a running host: a label with two trailing blank lines now paints three lines like the Companion. Not checked by hand in the Tauri window.

## Notes

Text with wrap off but maxLines above 1 still collapses line breaks on the web while the Companion keeps them; button labels always wrap, so this is left for a follow-up.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
