### PR TITLE
Keep object and array event parameters as JSON

### DIFF
--- a/docs/src/content/docs/reference/websocket.md
+++ b/docs/src/content/docs/reference/websocket.md
@@ -234,7 +234,7 @@ it reports for push. See [Push or poll](/sdk/variables/#push-or-poll).
 
 | Type | Direction | Purpose | Payload |
 | --- | --- | --- | --- |
-| `event.publish` | plugin → host | Publishes a domain event. **Fire-and-forget** - no reply message. | `eventId` (required, unqualified; the host qualifies it with the authenticated plugin id), `parameters` |
+| `event.publish` | plugin → host | Publishes a domain event. **Fire-and-forget** - no reply message. | `eventId` (required, unqualified; the host qualifies it with the authenticated plugin id), `parameters` (an object; a value that is itself an object or array is delivered to triggers and templates as its JSON text) |
 | `log.publish` | plugin → host | Forwards a batch of structured log events. **Fire-and-forget.** | `events` (array, required), `dropped` (int) |
 | `state.update` | plugin → host | "This kind's snapshot is stale, re-describe it." Deliberately **not** data-carrying. | `kind` (required), `localId`, `reason` |
 

--- a/docs/src/content/docs/sdk/capabilities.md
+++ b/docs/src/content/docs/sdk/capabilities.md
@@ -99,6 +99,8 @@ paging, push versus poll, binding lifetime, and how all of it crosses the plugin
 
 `IEventProvider` declares events an integration can emit. `IEventPublisher` publishes occurrences through the host event system.
 
+A parameter value that serializes to a JSON object or array, such as `new { modifiers = new[] { "Ctrl", "Shift" }, key = "F3" }`, reaches triggers and templates as its compact JSON text (`{"modifiers":["Ctrl","Shift"],"key":"F3"}`). A condition on it compares that text. Strings, numbers and booleans arrive as themselves.
+
 Event definition ids are stable public identities. Dynamic option providers may supply runtime choices for configuration and payload parameters alike, without changing the event definition itself.
 
 Payload parameters are not only documentation. An event's `PayloadParameters` are ordinary `ActionParameter` declarations, and Macro Deck reuses that metadata when a user writes a condition against `$event`: the value being compared against is authored with the control the payload parameter's own type implies, while the condition still stores the raw value the occurrence carries. Declare a payload value the integration can enumerate the same way its matching filter is declared, so a user picks a friendly name instead of pasting an id.

--- a/host/src/MacroDeckHost/Plugins/PluginWebSocketEndpoint.cs
+++ b/host/src/MacroDeckHost/Plugins/PluginWebSocketEndpoint.cs
@@ -929,7 +929,7 @@ public sealed class PluginWebSocketEndpoint
 		}
 	}
 
-	private void HandleEventPublish(string pluginId, ProtocolEnvelope envelope)
+	internal void HandleEventPublish(string pluginId, ProtocolEnvelope envelope)
 	{
 		EventPublishPayload? payload;
 		try
@@ -966,6 +966,7 @@ public sealed class PluginWebSocketEndpoint
 				JsonValueKind.Number => property.Value.TryGetInt64(out var i) ? i : property.Value.GetDouble(),
 				JsonValueKind.True => true,
 				JsonValueKind.False => false,
+				JsonValueKind.Object or JsonValueKind.Array => property.Value.GetRawText(),
 				_ => null
 			};
 		}

--- a/host/tests/MacroDeckHost.Tests.PluginContractTests/CallbackSupport.cs
+++ b/host/tests/MacroDeckHost.Tests.PluginContractTests/CallbackSupport.cs
@@ -636,6 +636,7 @@ internal sealed class CallbackHostLink(
 				JsonValueKind.Number => property.Value.TryGetInt64(out var i) ? i : property.Value.GetDouble(),
 				JsonValueKind.True => true,
 				JsonValueKind.False => false,
+				JsonValueKind.Object or JsonValueKind.Array => property.Value.GetRawText(),
 				_ => null
 			};
 		}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Plugins/PluginWebSocketEndpointDispatchTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Plugins/PluginWebSocketEndpointDispatchTests.cs
@@ -6,6 +6,7 @@ using MacroDeck.Plugin.Protocol.Capabilities;
 using MacroDeck.Plugin.Protocol.Capabilities.Variables;
 using MacroDeck.Plugin.Protocol.Envelope;
 using MacroDeck.Plugin.Protocol.Errors;
+using MacroDeck.Plugin.Protocol.Events;
 using MacroDeck.Plugin.Protocol.Handshake;
 using MacroDeck.Plugin.Protocol.Limits;
 using MacroDeck.Plugin.Protocol.Logging;
@@ -34,7 +35,7 @@ public class PluginWebSocketEndpointDispatchTests
 {
 	private static (PluginWebSocketEndpoint Endpoint, FakePluginConnection Connection, FakePluginCapabilityInvoker
 		Invoker)
-		CreateEndpoint()
+		CreateEndpoint(IEventBus? eventBus = null)
 	{
 		var registry = new PluginSessionRegistry(TimeProvider.System, Serilog.Core.Logger.None);
 		var invoker = new FakePluginCapabilityInvoker();
@@ -48,7 +49,7 @@ public class PluginWebSocketEndpointDispatchTests
 			new FakePluginCallbackRouter(),
 			new PluginAssetReceiver(new InMemoryPluginAssetCache()),
 			statePusher,
-			new FakeEventBus(),
+			eventBus ?? new FakeEventBus(),
 			throttle,
 			TimeProvider.System,
 			new RecordingMediator(),
@@ -392,6 +393,42 @@ public class PluginWebSocketEndpointDispatchTests
 		{
 			Assert.That(connection.Sent, Is.Empty);
 			Assert.That(registrar.RegisteredPluginIds, Is.Empty);
+		});
+	}
+
+	[Test]
+	public void Event_publish_delivers_object_and_array_parameters_as_their_json_text()
+	{
+		var events = new FakeEventBus();
+		var (endpoint, _, _) = CreateEndpoint(events);
+		var parameters = JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+			{
+				["combo"] = new { modifiers = new[] { "Ctrl", "Shift" }, key = "F3" },
+				["keys"] = new[] { "A", "B" },
+				["count"] = 3,
+				["label"] = "text",
+				["missing"] = null
+			},
+			PluginProtocolJson.Options);
+
+		endpoint.HandleEventPublish("com.example.plugin",
+			new ProtocolEnvelope
+			{
+				Type = MessageTypes.EventPublish,
+				Id = "1",
+				Payload = JsonSerializer.SerializeToElement(
+					new EventPublishPayload { EventId = "hotkey-pressed", Parameters = parameters },
+					PluginProtocolJson.Options)
+			});
+
+		Assert.That(events.Reader.TryRead(out var occurrence), Is.True);
+		Assert.Multiple(() =>
+		{
+			Assert.That(occurrence!.Parameters["combo"], Is.EqualTo("""{"modifiers":["Ctrl","Shift"],"key":"F3"}"""));
+			Assert.That(occurrence.Parameters["keys"], Is.EqualTo("""["A","B"]"""));
+			Assert.That(occurrence.Parameters["count"], Is.EqualTo(3L));
+			Assert.That(occurrence.Parameters["label"], Is.EqualTo("text"));
+			Assert.That(occurrence.Parameters["missing"], Is.Null);
 		});
 	}
 


### PR DESCRIPTION
Closes #750

## Summary

Object and array values in a plugin's event.publish parameters were turned into null by the host. They now reach triggers and templates as their JSON text.

## Testing

Full solution Release build with warnings as errors and all test suites pass, including a new endpoint test with the issue's payload. Not verified end to end with a packaged plugin against a running host.

## Plugin SDK / API compatibility

- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed
- [ ] Contracts were only extended additively (new members with defaults, new optional fields, new message types)
- [ ] Anything being retired carries [Obsolete] and [MacroDeckDeprecated], is in the deprecation registry, and still works
- [x] A plugin compiled against the previous SDK still loads and behaves identically (source and binary compatible)
- [ ] The conformance suite passes and the sample plugin builds and runs unchanged
- [ ] Any intentional break was explicitly agreed beforehand and is described below

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
