### PR TITLE
Keep structured Streamer.bot values as JSON text

### DIFF
--- a/host/src/MacroDeckHost.Integrations/Streamerbot/StreamerbotEventPayload.cs
+++ b/host/src/MacroDeckHost.Integrations/Streamerbot/StreamerbotEventPayload.cs
@@ -62,21 +62,13 @@ internal static class StreamerbotEventPayload
 			}
 
 			var name = prefix is null ? property.Name : $"{prefix}.{property.Name}";
-			switch (property.Value.ValueKind)
+			if (property.Value.ValueKind == JsonValueKind.Object && depth + 1 < MaxDepth)
 			{
-				case JsonValueKind.Object:
-					Flatten(property.Value, name, depth + 1, target);
-					break;
-				case JsonValueKind.Array:
-					// Deliberately skipped; the full payload stays available as `data`.
-					break;
-				default:
-					if (!IsReserved(name))
-					{
-						target[name] = ToPrimitive(property.Value);
-					}
-
-					break;
+				Flatten(property.Value, name, depth + 1, target);
+			}
+			else if (!IsReserved(name))
+			{
+				target[name] = ToPrimitive(property.Value);
 			}
 		}
 	}
@@ -87,6 +79,7 @@ internal static class StreamerbotEventPayload
 		JsonValueKind.True => true,
 		JsonValueKind.False => false,
 		JsonValueKind.Number => value.TryGetInt64(out var integer) ? integer : value.GetDouble(),
+		JsonValueKind.Object or JsonValueKind.Array => value.GetRawText(),
 		_ => null
 	};
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Streamerbot/StreamerbotEventPayloadTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Streamerbot/StreamerbotEventPayloadTests.cs
@@ -103,15 +103,11 @@ internal sealed class StreamerbotEventPayloadTests
 	}
 
 	[Test]
-	public void Build_skips_arrays_but_keeps_them_in_the_raw_data()
+	public void Build_carries_arrays_as_json_text()
 	{
 		var payload = Build("Twitch", "Sub", """{ "userName": "Ada", "emotes": [ { "name": "Kappa" } ] }""");
 
-		Assert.Multiple(() =>
-		{
-			Assert.That(payload.ContainsKey("emotes"), Is.False);
-			Assert.That(payload["data"] as string, Does.Contain("Kappa"));
-		});
+		Assert.That(payload["emotes"], Is.EqualTo("""[ { "name": "Kappa" } ]"""));
 	}
 
 	[Test]
@@ -162,7 +158,11 @@ internal sealed class StreamerbotEventPayloadTests
 	{
 		var payload = Build("Misc", "Test", """{ "a": { "b": { "c": { "d": "too deep" } } } }""");
 
-		Assert.That(payload.Keys, Has.No.Member("a.b.c.d"));
+		Assert.Multiple(() =>
+		{
+			Assert.That(payload.Keys, Has.No.Member("a.b.c.d"));
+			Assert.That(payload["a.b.c"], Is.EqualTo("""{ "d": "too deep" }"""));
+		});
 	}
 
 	private static IReadOnlyDictionary<string, object?> Build(string source, string type, string data)


### PR DESCRIPTION
No issue: follow-up to #750, which fixes the same discard for plugin event parameters (open in #754).

## Summary

Streamer.bot event payloads dropped arrays and objects nested past the flattening depth, so they never reached triggers or templates. They now arrive as their JSON text, the same representation #754 uses and the data parameter already carries.

## Testing

Full solution build with warnings as errors and all test suites pass; the two changed StreamerbotEventPayload tests fail on the old code. One macOS frontmost-app test failed once from a desktop focus change and passed on rerun. Not verified against a live Streamer.bot instance.

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
