### PR TITLE
Render keyboard editors in config flow fields

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/components/config-flow/config-field.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/config-flow/config-field.component.spec.ts
@@ -4,6 +4,9 @@ import { By } from '@angular/platform-browser';
 import { ActionParameterDef, ActionParameterType } from '@macro-deck/runtime';
 import { ConfigFieldComponent } from './config-field.component';
 import { WidgetTargetPickerComponent } from '../forms/widget-target-picker/widget-target-picker.component';
+import { HotkeyRecorderComponent } from '../forms/hotkey-recorder/hotkey-recorder.component';
+import { KeyboardComboEditorComponent } from '../forms/keyboard-combo-editor/keyboard-combo-editor.component';
+import { KeyboardSequenceEditorComponent } from '../forms/keyboard-sequence-editor/keyboard-sequence-editor.component';
 import { ActionOptionsService } from '../../services/action-options.service';
 import { provideLocalizationTesting } from '../../../testing/localization-test-support';
 
@@ -37,6 +40,54 @@ describe('ConfigFieldComponent', () => {
     fixture = TestBed.createComponent(ConfigFieldComponent);
     component = fixture.componentInstance;
   });
+
+  it('submits the structured combo a keyboard combo field records, not display text', () => {
+    component.field = field(ActionParameterType.KeyboardCombo);
+    const emitted: unknown[] = [];
+    component.valueChange.subscribe(v => emitted.push(v));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('input.cf-input')).toBeNull();
+    fixture.debugElement.query(By.directive(KeyboardComboEditorComponent))
+      .componentInstance.valueChange.emit({ modifiers: [], key: '+' });
+
+    expect(emitted).toEqual([{ modifiers: [], key: '+' }]);
+  });
+
+  it('pre-fills the combo editor with a stored combo', () => {
+    component.field = field(ActionParameterType.KeyboardCombo);
+    component.value = { modifiers: ['ctrl'], key: 'a' };
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.directive(KeyboardComboEditorComponent)).componentInstance.value)
+      .toEqual({ modifiers: ['ctrl'], key: 'a' });
+  });
+
+  it('renders the hotkey recorder and keyboard sequence editor for their field types', () => {
+    component.field = field(ActionParameterType.Hotkey);
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.directive(HotkeyRecorderComponent))).toBeTruthy();
+
+    const sequenceFixture = TestBed.createComponent(ConfigFieldComponent);
+    sequenceFixture.componentInstance.field = field(ActionParameterType.KeyboardSequence);
+    sequenceFixture.detectChanges();
+    expect(sequenceFixture.debugElement.query(By.directive(KeyboardSequenceEditorComponent))).toBeTruthy();
+  });
+
+  for (const [type, value] of [
+    [ActionParameterType.Hotkey, '+'],
+    [ActionParameterType.Hotkey, {}],
+    [ActionParameterType.KeyboardCombo, '+'],
+    [ActionParameterType.KeyboardSequence, '+'],
+    [ActionParameterType.KeyboardSequence, { steps: {} }],
+  ] as const) {
+    it(`starts the ${type} editor empty for a value of the wrong shape (${JSON.stringify(value)})`, () => {
+      component.field = field(type);
+      component.value = value;
+      expect(() => fixture.detectChanges()).not.toThrow();
+      expect(fixture.nativeElement.querySelector('input.cf-input')).toBeNull();
+    });
+  }
 
   it('renders a text input for string fields', () => {
     component.field = field(ActionParameterType.String);

--- a/ui/angular/projects/desktop-ui/src/app/components/config-flow/config-field.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/config-flow/config-field.component.ts
@@ -11,11 +11,14 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ActionParameterDef, ActionParameterType, AppStrings, LocalizedText, resolveLocalizedText } from '@macro-deck/runtime';
+import { ActionParameterDef, ActionParameterType, AppStrings, HotkeyValue, KeyboardComboValue, KeyboardSequenceValue, LocalizedText, isHotkeyValue, resolveLocalizedText } from '@macro-deck/runtime';
 import { ButtonComponent, CheckboxComponent, LocalizationService, LocalizedTextPipe, TranslatePipe } from '@shared';
 import { SelectComponent, SelectOption } from '../forms/select/select.component';
 import { MultiSelectComponent, MultiSelectOption } from '../forms/multi-select/multi-select.component';
 import { WidgetTargetPickerComponent } from '../forms/widget-target-picker/widget-target-picker.component';
+import { HotkeyRecorderComponent } from '../forms/hotkey-recorder/hotkey-recorder.component';
+import { KeyboardComboEditorComponent } from '../forms/keyboard-combo-editor/keyboard-combo-editor.component';
+import { KeyboardSequenceEditorComponent } from '../forms/keyboard-sequence-editor/keyboard-sequence-editor.component';
 import { ComboboxOption } from '../forms/combobox/combobox.component';
 import { ActionOptionsService } from '../../services/action-options.service';
 
@@ -30,6 +33,9 @@ import { ActionOptionsService } from '../../services/action-options.service';
     ButtonComponent,
     MultiSelectComponent,
     WidgetTargetPickerComponent,
+    HotkeyRecorderComponent,
+    KeyboardComboEditorComponent,
+    KeyboardSequenceEditorComponent,
     LocalizedTextPipe,
     TranslatePipe,
   ],
@@ -97,6 +103,15 @@ import { ActionOptionsService } from '../../services/action-options.service';
             (valueChange)="emit($event)"
             (filterChange)="loadWidgetOptions($event)"
             (opened)="loadWidgetOptions()" />
+        }
+        @case ('hotkey') {
+          <shared-hotkey-recorder [value]="hotkeyValue" (valueChange)="emit($event)" />
+        }
+        @case ('keyboard-combo') {
+          <shared-keyboard-combo-editor [value]="keyboardComboValue" (valueChange)="emit($event)" />
+        }
+        @case ('keyboard-sequence') {
+          <shared-keyboard-sequence-editor [value]="keyboardSequenceValue" (valueChange)="emit($event)" />
         }
         @case ('multiselect') {
           <shared-multi-select
@@ -176,7 +191,8 @@ export class ConfigFieldComponent {
   protected readonly clearStoredSecretLabel = computed(() =>
     this.localization.translateKey(AppStrings.ConfigFlow.ClearStoredSecret));
 
-  get controlType(): 'secret' | 'choice' | 'boolean' | 'number' | 'multiselect' | 'widget-target' | 'text' {
+  get controlType(): 'secret' | 'choice' | 'boolean' | 'number' | 'multiselect' | 'widget-target' | 'hotkey'
+    | 'keyboard-combo' | 'keyboard-sequence' | 'text' {
     switch (this.field.type) {
       case ActionParameterType.Password:
       case ActionParameterType.Secret:
@@ -191,6 +207,12 @@ export class ConfigFieldComponent {
         return 'multiselect';
       case ActionParameterType.WidgetTarget:
         return 'widget-target';
+      case ActionParameterType.Hotkey:
+        return 'hotkey';
+      case ActionParameterType.KeyboardCombo:
+        return 'keyboard-combo';
+      case ActionParameterType.KeyboardSequence:
+        return 'keyboard-sequence';
       default:
         return 'text';
     }
@@ -222,6 +244,21 @@ export class ConfigFieldComponent {
 
   get arrayValue(): string[] {
     return Array.isArray(this.value) ? this.value : [];
+  }
+
+  get hotkeyValue(): HotkeyValue | null {
+    return isHotkeyValue(this.value) ? this.value : null;
+  }
+
+  get keyboardComboValue(): KeyboardComboValue | null {
+    return isHotkeyValue(this.value) ? this.value : null;
+  }
+
+  get keyboardSequenceValue(): KeyboardSequenceValue | null {
+    const v = this.value;
+    return v && typeof v === 'object' && !Array.isArray(v) && Array.isArray((v as { steps?: unknown }).steps)
+      ? v as KeyboardSequenceValue
+      : null;
   }
 
   emit(value: unknown): void {


### PR DESCRIPTION
Closes #752

## Summary

Config flow fields of type KeyboardCombo, KeyboardSequence and Hotkey rendered as a plain text input, so a step submitted the typed text instead of the structured value. They now use the same editors as the action and trigger editors.

## Testing

Full desktop-ui suite and the .NET solution tests pass, with new specs for the three field types. Verified in the desktop UI against a running host: recording Numpad + now submits {"modifiers":[],"key":"+"} instead of "+".

## Notes

The host still hands object values to SubmitAsync as JSON text, unchanged here. Color, Duration, DateTime, Json, KeyValue, Object and Array fields still render as text in config flows and are out of scope.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
