### PR TITLE
Fill the whole screen with the folder background

### DIFF
--- a/ui/web-client/src/shell.spec.ts
+++ b/ui/web-client/src/shell.spec.ts
@@ -316,14 +316,58 @@ describe('Shell', () => {
     expect(root.querySelectorAll('.deck-grid-tile').length).toBe(1);
   });
 
-  it('paints the folder background over the theme default', () => {
-    mount();
-    const coloured = folder('root') as unknown as { background: string };
-    coloured.background = '#101820';
-    client.deck.load([coloured as never]);
-    client.app.set({ probed: true, authenticated: true, connected: true });
+  describe('the folder background', () => {
+    const coloured = (id: string, background: string, viewId = 'macrodeck.widget-grid') =>
+      ({ ...(folder(id) as unknown as Record<string, unknown>), background, viewId }) as never;
 
-    expect((root.querySelector('.deck-grid') as HTMLElement).style.background).toBe('rgb(16, 24, 32)');
+    const showDeck = () => client.app.set({ probed: true, authenticated: true, connected: true });
+
+    it('fills the whole screen, not only the letterboxed grid', () => {
+      mount();
+      client.deck.load([coloured('root', 'rgba(16, 24, 32, 0.5)')]);
+      showDeck();
+
+      expect(root.style.background).toBe('rgba(16, 24, 32, 0.5)');
+      expect((root.querySelector('.deck-grid') as HTMLElement).style.background).toBe('');
+    });
+
+    it('leaves the screen to the theme when the folder has none', () => {
+      mount();
+      client.deck.load([folder('root')]);
+      showDeck();
+
+      expect(root.style.background).toBe('');
+    });
+
+    it('follows the folder the deck walks into', () => {
+      mount();
+      client.deck.load([coloured('root', '#101820'), coloured('other', '#203040')]);
+      showDeck();
+
+      client.deck.openFolder('other');
+
+      expect(root.style.background).toBe('rgb(32, 48, 64)');
+    });
+
+    it('is not left behind when the deck leaves the screen', () => {
+      mount();
+      client.deck.load([coloured('root', '#101820')]);
+      showDeck();
+
+      client.app.set({ authenticated: false, deckRendered: false });
+
+      expect(root.style.background).toBe('');
+    });
+
+    it('is not carried into a folder a provider draws', () => {
+      mount();
+      client.deck.load([coloured('root', '#101820'), coloured('other', '', 'acme.now-playing')]);
+      showDeck();
+
+      client.deck.openFolder('other');
+
+      expect(root.style.background).toBe('');
+    });
   });
 
   it('puts the settings entry on screen, which is the only way to sign out', () => {

--- a/ui/web-client/src/shell.ts
+++ b/ui/web-client/src/shell.ts
@@ -266,6 +266,7 @@ export class Shell {
     const element = screen === 'deck' ? this.deckElement() : this.messageFor(screen);
     this.root.appendChild(element);
     this.current = { screen, element };
+    if (screen !== 'deck') this.root.style.background = '';
 
     // The lock is held only while a deck is actually on screen; the preference outlives the screen.
     this.services.wakeLock.setGate(screen === 'deck');
@@ -344,7 +345,8 @@ export class Shell {
     // Re-applied on every paint, not only at creation: a folder carries its own grid size, corner
     // radius and background, so walking into one keeps the previous folder's otherwise.
     this.grid.configure(geometry, grid.borderRadius);
-    this.grid.setBackground(folder && folder.background ? folder.background : null);
+    // Never on the grid as well: a translucent colour would stack there.
+    this.root.style.background = folder && folder.background ? folder.background : '';
     this.grid.setFocusedWidget(this.deckInput.focusedWidgetId());
 
     this.grid.update(
@@ -358,6 +360,7 @@ export class Shell {
   }
 
   private showFolderView(folderId: string): void {
+    this.root.style.background = '';
     if (this.grid) {
       this.grid.destroy();
       this.grid = null;


### PR DESCRIPTION
Closes #760

## Summary

The web client painted the folder background only on the letterboxed grid, so the rest of the screen showed the theme colour. It is now painted on the full-screen root, and cleared again off the deck and in provider-drawn folders.

## Testing

Full solution build and test suites pass, web client suites pass with five new scenarios. Verified in a browser against a running host at wide and tall viewports in light and dark: the folder colour now reaches every edge. Not tested on the reporter's Echo Show.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
