### PR TITLE
Refresh templated labels on state change

### DIFF
--- a/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetSession.cs
+++ b/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetSession.cs
@@ -56,6 +56,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 	private readonly LabelSubscriptionTracker _labelSubscriptions;
 	private readonly IWidgetRenderSignals _renderSignals;
 	private readonly IUiTransport _uiTransport;
+	private readonly LabelRenderChannel _labelRenders;
 	private readonly bool _interactive;
 	private readonly string? _variableScopeWidgetId;
 
@@ -145,6 +146,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		LabelSubscriptionTracker labelSubscriptions,
 		IWidgetRenderSignals renderSignals,
 		IUiTransport uiTransport,
+		LabelRenderChannel labelRenders,
 		bool interactive,
 		string? variableScopeWidgetId = null)
 	{
@@ -163,6 +165,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		ArgumentNullException.ThrowIfNull(labelSubscriptions);
 		ArgumentNullException.ThrowIfNull(renderSignals);
 		ArgumentNullException.ThrowIfNull(uiTransport);
+		ArgumentNullException.ThrowIfNull(labelRenders);
 
 		_configState = configState;
 		_activeState = activeState;
@@ -179,6 +182,7 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		_labelSubscriptions = labelSubscriptions;
 		_renderSignals = renderSignals;
 		_uiTransport = uiTransport;
+		_labelRenders = labelRenders;
 		_interactive = interactive;
 		_variableScopeWidgetId = variableScopeWidgetId;
 		_activeStateIsExplicit = configState.Peek().StoredActiveStateId is not null;
@@ -498,7 +502,8 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 	/// <summary>Writes <paramref name="stateId" /> as the active state and, for a label that is not a
 	/// Liquid template, its raw text too - a template's resolved text arrives only through
 	/// <see cref="OnLabelSignal" />, never computed here, so the tree never carries anything but a fully
-	/// resolved string. Also re-keys the label-subscription tracker registration to the new state. Callers
+	/// resolved string. Also re-keys the label-subscription tracker registration to the new state and, for a
+	/// template, queues a render of it. Callers
 	/// are already holding <see cref="_viewSync" /> - synchronously from <see cref="Dispatch" /> for a
 	/// press, or explicitly in <see cref="OnStateSignal" /> for an external one.</summary>
 	private void ApplyActiveState(string? stateId)
@@ -547,6 +552,8 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 		if (newState is not null)
 		{
 			_labelSubscriptions.Add(_connectionId, widgetKey, newState);
+			// Enqueue after Add: the render only resolves states that are subscribed when it runs.
+			_labelRenders.Enqueue(_widget.Id);
 		}
 
 		_subscribedLabelState = newState;
@@ -571,13 +578,13 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 	{
 		var pushedState = LabelGroups.Normalize(evt.State);
 
-		if (!string.Equals(pushedState, _subscribedLabelState, StringComparison.Ordinal))
-		{
-			return;
-		}
-
 		lock (_viewSync)
 		{
+			if (_disposed || !string.Equals(pushedState, _subscribedLabelState, StringComparison.Ordinal))
+			{
+				return;
+			}
+
 			using (_view!.Batch())
 			{
 				_labelText.Value = evt.Text;
@@ -626,9 +633,10 @@ internal sealed class ActionButtonWidgetSession : IUiSession, IOriginAwareUiSess
 					_labelText.Value = rawLabel;
 				}
 			}
+
+			RekeyLabelSubscription(stateId, isLiquid);
 		}
 
-		RekeyLabelSubscription(stateId, isLiquid);
 		ScheduleIconResolution();
 	}
 

--- a/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetUiProvider.cs
+++ b/host/src/MacroDeckHost.Widgets/ActionButton/ActionButtonWidgetUiProvider.cs
@@ -32,6 +32,7 @@ public sealed class ActionButtonWidgetUiProvider : IBuiltInWidgetUiProvider
 	private readonly IHostLockState _lockState;
 	private readonly WidgetStateSubscriptionTracker _stateSubscriptions;
 	private readonly LabelSubscriptionTracker _labelSubscriptions;
+	private readonly LabelRenderChannel _labelRenders;
 	private readonly IWidgetRenderSignals _renderSignals;
 	private readonly IUiTransport _uiTransport;
 	private readonly IWidgetSampleTextResolver _sampleText;
@@ -47,6 +48,7 @@ public sealed class ActionButtonWidgetUiProvider : IBuiltInWidgetUiProvider
 		IHostLockState lockState,
 		WidgetStateSubscriptionTracker stateSubscriptions,
 		LabelSubscriptionTracker labelSubscriptions,
+		LabelRenderChannel labelRenders,
 		IWidgetRenderSignals renderSignals,
 		IUiTransport uiTransport,
 		IWidgetSampleTextResolver sampleText,
@@ -61,6 +63,7 @@ public sealed class ActionButtonWidgetUiProvider : IBuiltInWidgetUiProvider
 		_lockState = lockState;
 		_stateSubscriptions = stateSubscriptions;
 		_labelSubscriptions = labelSubscriptions;
+		_labelRenders = labelRenders;
 		_renderSignals = renderSignals;
 		_uiTransport = uiTransport;
 		_sampleText = sampleText;
@@ -193,6 +196,7 @@ public sealed class ActionButtonWidgetUiProvider : IBuiltInWidgetUiProvider
 			_labelSubscriptions,
 			_renderSignals,
 			_uiTransport,
+			_labelRenders,
 			interactive,
 			variableScopeWidgetId);
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetConfigTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetConfigTests.cs
@@ -1033,6 +1033,7 @@ public class ActionButtonWidgetConfigTests
 			null!,
 			new WidgetStateSubscriptionTracker(),
 			new LabelSubscriptionTracker(),
+			new LabelRenderChannel(),
 			null!,
 			null!,
 			null!,

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetSessionTests.cs
@@ -562,7 +562,8 @@ public class ActionButtonWidgetSessionTests
 			Serilog.Log.Logger);
 		await labelService.StartAsync(CancellationToken.None);
 
-		fixture.Signals.RaiseStateChanged(new WidgetStateUpdatedEvent { WidgetId = _widgetId.ToString(), StateId = "b" });
+		fixture.Signals.RaiseStateChanged(
+			new WidgetStateUpdatedEvent { WidgetId = _widgetId.ToString(), StateId = "b" });
 
 		var deadline = DateTime.UtcNow.AddSeconds(15);
 		string? shown;

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetSessionTests.cs
@@ -16,6 +16,7 @@ using MacroDeckHost.Application.Ui.Transport.Messages.Widgets;
 using MacroDeckHost.Application.Widgets;
 using MacroDeckHost.Domain.Entities;
 using MacroDeckHost.Domain.Widgets;
+using MacroDeckHost.Infrastructure.BackgroundServices;
 using MacroDeckHost.Tests.UnitTests.TestSupport;
 using MacroDeckHost.Tests.UnitTests.Triggers;
 using MacroDeckHost.Widgets.ActionButton;
@@ -35,6 +36,12 @@ public class ActionButtonWidgetSessionTests
 		"\"flows\":\"[]\"}";
 
 	private const string LiquidLabelData = "{\"stateMode\":false,\"label\":\"Vol: {{ vol }}%\"}";
+
+	private const string TemplatedTwoStateData =
+		"{\"stateMode\":true,\"activeStateId\":\"a\",\"states\":[" +
+		"{\"id\":\"a\",\"label\":\"A\",\"appearance\":{\"label\":\"{{ vars.name }} Off\"}}," +
+		"{\"id\":\"b\",\"label\":\"B\",\"appearance\":{\"label\":\"{{ vars.name }} On\"}}]," +
+		"\"flows\":\"[]\"}";
 
 	// No "activeStateId" at all - a freshly placed two-state button, never explicitly advanced or set.
 	private const string TwoStateDataNoStoredActiveId =
@@ -531,6 +538,45 @@ public class ActionButtonWidgetSessionTests
 		Assert.That(fixture.LabelSubscriptions.HasAnySubscribers(widgetKey),
 			Is.False,
 			"a signal handler must never be able to register a new subscription once disposal has begun");
+		Assert.That(fixture.LabelRenders.Reader.TryRead(out _),
+			Is.False,
+			"a disposed session must not queue label renders");
+	}
+
+	[Test]
+	public async Task A_state_change_shows_the_new_states_templated_label_without_any_variable_changing()
+	{
+		var fixture = Build(TemplatedTwoStateData, interactive: true, initialLabel: "Strip3 Off");
+		var labelText = new Devices.Surfaces.FakeLabelTextService();
+		labelText.Set(_widgetId, "a", "Strip3 Off");
+		labelText.Set(_widgetId, "b", "Strip3 On");
+		await using var services = new ServiceCollection()
+			.AddScoped<ILabelTextService>(_ => labelText)
+			.BuildServiceProvider();
+		using var labelService = new LabelRenderBackgroundService(new Variables.StartedHostLifetime(),
+			fixture.LabelRenders,
+			services.GetRequiredService<IServiceScopeFactory>(),
+			fixture.Transport,
+			fixture.LabelSubscriptions,
+			fixture.Signals,
+			Serilog.Log.Logger);
+		await labelService.StartAsync(CancellationToken.None);
+
+		fixture.Signals.RaiseStateChanged(new WidgetStateUpdatedEvent { WidgetId = _widgetId.ToString(), StateId = "b" });
+
+		var deadline = DateTime.UtcNow.AddSeconds(15);
+		string? shown;
+		do
+		{
+			await Task.Delay(20);
+			await fixture.Host.SettleAsync();
+			shown = fixture.Host.ById("actionButton.label").Text("text");
+		} while (shown != "Strip3 On" && DateTime.UtcNow < deadline);
+
+		Assert.That(shown, Is.EqualTo("Strip3 On"));
+
+		await labelService.StopAsync(CancellationToken.None);
+		await fixture.Session.DisposeAsync();
 	}
 
 	/// <summary>An <see cref="IWidgetRenderSignals" /> whose subscription <c>Dispose()</c> does not stop
@@ -696,6 +742,7 @@ public class ActionButtonWidgetSessionTests
 		var labelSubscriptions = new LabelSubscriptionTracker();
 		var signals = renderSignals ?? new WidgetRenderSignals();
 		var transport = new RecordingTransport();
+		var labelRenders = new LabelRenderChannel();
 		var iconServiceFake = iconService ?? new FakeWidgetIconService();
 		var iconProviderState = new UiState<WidgetIconResolution>(iconServiceFake.Resolution);
 		var scopeFactory = new ServiceCollection()
@@ -718,6 +765,7 @@ public class ActionButtonWidgetSessionTests
 			labelSubscriptions,
 			signals,
 			transport,
+			labelRenders,
 			interactive);
 		var element = ActionButtonWidgetView.Build(configState,
 			activeState,
@@ -741,7 +789,8 @@ public class ActionButtonWidgetSessionTests
 			stateSubscriptions,
 			labelSubscriptions,
 			iconServiceFake,
-			folder);
+			folder,
+			labelRenders);
 	}
 
 	private sealed record SessionFixture(
@@ -753,7 +802,8 @@ public class ActionButtonWidgetSessionTests
 		WidgetStateSubscriptionTracker StateSubscriptions,
 		LabelSubscriptionTracker LabelSubscriptions,
 		FakeWidgetIconService IconService,
-		FolderEntity Folder);
+		FolderEntity Folder,
+		LabelRenderChannel LabelRenders);
 
 	/// <summary>A configurable <see cref="IWidgetIconService" /> stand-in - defaults to
 	/// <see cref="WidgetIconResolution.Inactive" />, matching a button with no icon-provider assignment.</summary>

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetUiProviderTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Widgets/Ui/ActionButtonWidgetUiProviderTests.cs
@@ -456,6 +456,7 @@ public class ActionButtonWidgetUiProviderTests
 			lockState ?? new FakeHostLockState(),
 			new WidgetStateSubscriptionTracker(),
 			new LabelSubscriptionTracker(),
+			new LabelRenderChannel(),
 			renderSignals ?? new WidgetRenderSignals(),
 			new RecordingTransport(),
 			TestLocalization.SampleText,


### PR DESCRIPTION
Closes #761

## Summary

An open deck tile never re-rendered a templated label when its button changed state, so it kept the previous state's text until a variable the template referenced changed. A change into a templated state now queues the same label render that variable changes use.

## Testing

Full solution build with warnings as errors and all test suites pass. A new test drives the session through the real label render service and fails without the fix. Reproduced against a running host over the UI WebSocket before and after; not checked in a browser.

## Notes

The new state's label appears about 200 ms after its colours, the label render debounce.

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
