### PR TITLE
Match keyboard combo triggers by content

### DIFF
--- a/host/src/MacroDeckHost.Application/Triggers/EventSubscriptionMatcher.cs
+++ b/host/src/MacroDeckHost.Application/Triggers/EventSubscriptionMatcher.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using MacroDeckHost.Application.Variables;
+using MacroDeck.Sdk.Actions;
 
 namespace MacroDeckHost.Application.Triggers;
 
@@ -74,7 +75,7 @@ public sealed class EventSubscriptionMatcher : IEventSubscriptionMatcher
 			}
 
 			if (!context.TryResolveEventParameter(payload.Name, out var actual) ||
-				!Holds(actual, configured.Operator, expected.Value))
+				!Holds(payload.Type, actual, configured.Operator, expected.Value))
 			{
 				return false;
 			}
@@ -97,6 +98,79 @@ public sealed class EventSubscriptionMatcher : IEventSubscriptionMatcher
 
 	private static bool Holds(object? actual, string @operator, object? expected)
 		=> ActionConditionEvaluator.EvaluateOperator(actual, @operator, expected);
+
+	private static bool Holds(ActionParameterType type, object? actual, string @operator, object? expected)
+		=> type == ActionParameterType.KeyboardCombo &&
+			@operator is "==" or "!=" &&
+			TryReadCombo(actual, out var actualCombo) &&
+			TryReadCombo(expected, out var expectedCombo)
+				? actualCombo == expectedCombo == (@operator == "==")
+				: Holds(actual, @operator, expected);
+
+	private static bool TryReadCombo(object? value, out (string Key, string Modifiers) combo)
+	{
+		combo = default;
+		JsonElement element;
+		try
+		{
+			element = value switch
+			{
+				null => default,
+				JsonElement json => json,
+				string text => JsonSerializer.Deserialize<JsonElement>(text),
+				_ => JsonSerializer.SerializeToElement(value)
+			};
+		}
+		catch (Exception e) when (e is JsonException or NotSupportedException or InvalidOperationException)
+		{
+			return false;
+		}
+
+		if (element.ValueKind != JsonValueKind.Object)
+		{
+			return false;
+		}
+
+		string? key = null;
+		var modifiers = new SortedSet<string>(StringComparer.Ordinal);
+		foreach (var property in element.EnumerateObject())
+		{
+			if (string.Equals(property.Name, "key", StringComparison.OrdinalIgnoreCase))
+			{
+				if (property.Value.ValueKind != JsonValueKind.String)
+				{
+					return false;
+				}
+
+				key = property.Value.GetString()!.ToUpperInvariant();
+			}
+			else if (string.Equals(property.Name, "modifiers", StringComparison.OrdinalIgnoreCase))
+			{
+				if (property.Value.ValueKind != JsonValueKind.Array)
+				{
+					return false;
+				}
+
+				foreach (var modifier in property.Value.EnumerateArray())
+				{
+					if (modifier.ValueKind != JsonValueKind.String)
+					{
+						return false;
+					}
+
+					modifiers.Add(modifier.GetString()!.ToUpperInvariant());
+				}
+			}
+		}
+
+		if (key is null)
+		{
+			return false;
+		}
+
+		combo = (key, string.Join('+', modifiers));
+		return true;
+	}
 
 	private static bool TryReadLiteral(JsonElement element, out object? value)
 	{
@@ -147,6 +221,12 @@ public sealed class EventSubscriptionMatcher : IEventSubscriptionMatcher
 				}
 
 				if (VariableTemplateRenderer.ContainsLiquid(text))
+				{
+					continue;
+				}
+
+				// A JSON object literal may be a structured value that Matches compares by content, not text.
+				if (text.StartsWith('{'))
 				{
 					continue;
 				}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Triggers/EventSubscriptionMatcherTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Triggers/EventSubscriptionMatcherTests.cs
@@ -145,6 +145,114 @@ public class EventSubscriptionMatcherTests
 
 	private static Dictionary<string, object?> Omitted() => new(StringComparer.Ordinal);
 
+	private const string EditorCombo = """{"modifiers":["Ctrl","Shift"],"key":"F3"}""";
+
+	private const string ReorderedCombo = """{"key":"F3","modifiers":["Shift","Ctrl"]}""";
+
+	private static readonly EventDefinitionDescriptor _hotkeyPressed = new(QualifiedId.Parse("hotkey::pressed"),
+		"hotkey",
+		"Hotkey",
+		true,
+		new EventDefinition
+		{
+			Id = "pressed",
+			Name = "Hotkey Pressed",
+			ConfigurationParameters = [ActionParameter.KeyboardCombo("combo", "Combo")],
+			PayloadParameters = [ActionParameter.KeyboardCombo("combo", "Combo")]
+		});
+
+	private static EventSubscription ComboSubscription(string configuredJson, string? op = null)
+		=> new(EventTriggerOwner.ForWidget(Guid.NewGuid()),
+			"t1",
+			"hotkey::pressed",
+			new Dictionary<string, EventConfigurationValue>(StringComparer.Ordinal)
+			{
+				["combo"] = Config(configuredJson, op)
+			},
+			null);
+
+	private static bool ComboMatches(string configuredJson, object? published, string? op = null)
+		=> Matcher().Matches(ComboSubscription(configuredJson, op),
+			_hotkeyPressed,
+			Context(new Dictionary<string, object?>(StringComparer.Ordinal) { ["combo"] = published }));
+
+	[TestCase(EditorCombo)]
+	[TestCase(ReorderedCombo)]
+	[TestCase("""{"key":"F3","modifiers":["Ctrl","Shift"]}""")]
+	[TestCase("""{"modifiers":["Shift","Ctrl"],"key":"F3"}""")]
+	[TestCase("""{"key":"f3","modifiers":["ctrl","shift"]}""")]
+	public void A_combo_trigger_matches_the_same_combo_published_in_any_order(string published)
+		=> Assert.That(ComboMatches(EditorCombo, published), Is.True);
+
+	[Test]
+	public void A_combo_configured_as_a_json_string_is_not_quick_rejected_for_a_reordered_combo()
+	{
+		var subscription = ComboSubscription(JsonSerializer.Serialize(EditorCombo));
+		var occurrence = new EventOccurrence("hotkey::pressed",
+			new Dictionary<string, object?>(StringComparer.Ordinal) { ["combo"] = ReorderedCombo });
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(EventSubscriptionMatcher.QuickReject(subscription, occurrence), Is.False);
+			Assert.That(Matcher().Matches(subscription, _hotkeyPressed, Context(occurrence.Parameters)), Is.True);
+		});
+	}
+
+	[Test]
+	public void A_combo_configured_with_modifiers_in_click_order_matches_the_recorded_order()
+		=> Assert.That(ComboMatches("""{"modifiers":["Shift","Ctrl"],"key":"F3"}""", EditorCombo), Is.True);
+
+	[Test]
+	public void A_combo_trigger_matches_a_combo_published_as_a_structured_value()
+	{
+		var element = JsonDocument.Parse(ReorderedCombo).RootElement.Clone();
+		var dictionary = new Dictionary<string, object?>
+		{
+			["key"] = "F3",
+			["modifiers"] = new List<object?> { "Shift", "Ctrl" }
+		};
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(ComboMatches(EditorCombo, element), Is.True);
+			Assert.That(ComboMatches(EditorCombo, dictionary), Is.True);
+		});
+	}
+
+	[TestCase("""{"modifiers":["Ctrl","Shift"],"key":"F4"}""")]
+	[TestCase("""{"modifiers":["Ctrl"],"key":"F3"}""")]
+	[TestCase("""{"modifiers":["Ctrl","Shift","Alt"],"key":"F3"}""")]
+	[TestCase("{}")]
+	[TestCase("""{"foo":1}""")]
+	[TestCase("Ctrl+Shift+F3")]
+	public void A_combo_trigger_does_not_match_a_different_combo(string published)
+		=> Assert.That(ComboMatches(EditorCombo, published), Is.False);
+
+	[Test]
+	public void A_not_equal_combo_trigger_compares_combos_regardless_of_order()
+	{
+		Assert.Multiple(() =>
+		{
+			Assert.That(ComboMatches(EditorCombo, ReorderedCombo, "!="), Is.False);
+			Assert.That(ComboMatches(EditorCombo, """{"modifiers":["Ctrl"],"key":"F3"}""", "!="), Is.True);
+		});
+	}
+
+	[Test]
+	public void A_text_parameter_holding_combo_json_is_still_compared_verbatim()
+	{
+		var subscription = new EventSubscription(EventTriggerOwner.ForWidget(Guid.NewGuid()),
+			"t1",
+			"obs::scene-changed",
+			new Dictionary<string, EventConfigurationValue>(StringComparer.Ordinal)
+			{
+				["sceneName"] = Config(EditorCombo)
+			},
+			null);
+
+		Assert.That(Matcher().Matches(subscription, _sceneChanged, Context(Payload(ReorderedCombo))), Is.False);
+	}
+
 	[Test]
 	public void IsNotEmpty_filter_matches_only_a_non_empty_delivered_parameter()
 	{


### PR DESCRIPTION
Closes #751

## Summary

An event trigger bound to a KeyboardCombo parameter compared the configured and the published combo as raw JSON text, so the same combo with a different property or modifier order never fired. It now compares the key and the set of modifiers.

## Testing

Release build with warnings as errors passes, and the host suites pass, including new matcher tests that fail on the old code. Locally the macOS lock-state test (screen was locked) and the conformance aggregate (heavily loaded run) failed; neither references the host, and both pass on main CI. Verified against a running host with a test plugin publishing reordered combos: they now fire, a different key still does not.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
