### PR TITLE
Clear localization state between desktop-ui specs

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/components/pages/integration-detail-page/integration-detail-page.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/pages/integration-detail-page/integration-detail-page.component.spec.ts
@@ -144,6 +144,8 @@ describe('IntegrationDetailPageComponent', () => {
     input.dispatchEvent(new Event('input'));
   }
 
+  afterEach(() => localStorage.clear());
+
   beforeEach(() => {
     // The localization catalog is cached in localStorage; a language another spec switched to must
     // not leak into these expectations.

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/about-settings.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/sections/about-settings.component.spec.ts
@@ -20,7 +20,10 @@ describe('AboutSettingsComponent', () => {
     operatingSystem: 'macOS 15 (Arm64)',
   };
 
+  beforeEach(() => localStorage.clear());
+
   afterEach(() => {
+    localStorage.clear();
     delete (window as { macroDeckShell?: unknown }).macroDeckShell;
   });
 

--- a/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/settings-modal.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/shell/settings-modal/settings-modal.component.spec.ts
@@ -72,6 +72,8 @@ describe('SettingsModalComponent', () => {
   let api: jasmine.SpyObj<ApiService>;
   let narrowQuery: FakeMediaQueryList;
 
+  afterEach(() => localStorage.clear());
+
   beforeEach(async () => {
     localStorage.clear();
     localStorage.setItem('md.localization.translations', JSON.stringify(ENGLISH_SETTINGS_LABELS));

--- a/ui/angular/projects/desktop-ui/src/app/shared/components/ui-render/ui-widget-node.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/shared/components/ui-render/ui-widget-node.component.spec.ts
@@ -77,7 +77,10 @@ function forecastTree(dayCount: number): UiNode {
 }
 
 describe('shared-ui-widget-node', () => {
-  afterEach(() => TestBed.resetTestingModule());
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    localStorage.clear();
+  });
 
   describe('range bar', () => {
     it('gives the filled span the track\'s own rounded ends', async () => {

--- a/ui/angular/projects/desktop-ui/src/app/shared/components/widget-types/ui-tree-widget/ui-tree-widget.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/shared/components/widget-types/ui-tree-widget/ui-tree-widget.component.spec.ts
@@ -111,6 +111,8 @@ describe('UiTreeWidgetComponent', () => {
     });
   });
 
+  afterEach(() => localStorage.clear());
+
   describe('layout', () => {
     it("gives the tree the widget's real box so a non-square tile is filled edge to edge", async () => {
       const fixture = createFixture({ widgetId: 'w-1', width: 240, height: 80 });


### PR DESCRIPTION
Flaky CI failure seen on #765 (no issue).

## Summary

The About settings spec rendered its build time in German when it ran after a spec that switched the app language, because the cached localization culture survives in the shared Karma localStorage. The About spec now starts from a clean localStorage, and the four specs that load a German catalog clear it afterwards.

## Testing

Reproduced the CI failure locally by leaving a German culture in localStorage before the About spec; it passes with the fix. Full desktop-ui suite passes (3886 specs).

## Checklist

- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
