### PR TITLE
Exclude build output from plugin packages

### DIFF
--- a/docs/src/content/docs/cli/build.md
+++ b/docs/src/content/docs/cli/build.md
@@ -40,11 +40,13 @@ assets/icon.png
 ```
 
 Everything else beside `manifest.json` is copied once into the package root, so a manifest referring to
-`assets/icon.png` resolves. `macrodeck-build.json`, each target's configured `output` directory, and
-`bin/`, `obj/`, `.git/`, `.vs/`, `.idea/`, `node_modules/` and `.DS_Store` are excluded - **everything else
-is packaged, including your sources**, so keep anything you do not want to distribute out of the directory
-holding the manifest. Staging happens in a temporary directory outside your project and is removed when the
-command finishes.
+`assets/icon.png` resolves. `macrodeck-build.json`, each target's configured `output` directory, the
+`--output` directory (unless it is the project directory itself), and `bin/`, `obj/`, `.git/`, `.vs/`,
+`.idea/`, `node_modules/`, `.DS_Store` and any `.macroDeckPlugin` file are excluded - **everything else is
+packaged, including your sources**, so keep anything you do not want to distribute out of the directory
+holding the manifest. An `--output` directory inside the project, such as the default `.` or `./artifacts`,
+is therefore safe to build into repeatedly. Staging happens in a temporary directory outside your project
+and is removed when the command finishes.
 
 ## Every requested runtime identifier must produce its entrypoint
 

--- a/docs/src/content/docs/cli/pack.md
+++ b/docs/src/content/docs/cli/pack.md
@@ -16,10 +16,10 @@ reader `validate` uses, then recomputes `files[]` from what is actually on disk.
 
 A bad manifest never becomes an artifact: the same `ManifestValidator` `validate` runs is the first step,
 and any problem it finds stops `pack` before a single byte is written, reported the same way `validate`
-would report it. Every file under `--source` except `manifest.json` itself is then hashed from disk and
-becomes a fresh `files[]` entry - **whatever `files[]` the source manifest already declared is discarded,
-never merged or compared against**. A symlink, an unsafe path, or any of the artifact size/entry limits
-the plugin hosting guide's [`.macroDeckPlugin` artifact section](/sdk/hosting/#the-macrodeckplugin-artifact) documents also stops the pack before
+would report it. Every file under `--source` except `manifest.json` itself, the `--output` file and any
+`.macroDeckPlugin` file is then hashed from disk and becomes a fresh `files[]` entry - **whatever `files[]`
+the source manifest already declared is discarded, never merged or compared against**. A symlink, an unsafe
+path, or any of the artifact size/entry limits the plugin hosting guide's [`.macroDeckPlugin` artifact section](/sdk/hosting/#the-macrodeckplugin-artifact) documents also stops the pack before
 writing.
 
 [`build`](/cli/build/) calls this exact implementation once it has staged a payload, so a built package and a

--- a/sdk/src/MacroDeck.Plugin.Cli/Building/BuildStaging.cs
+++ b/sdk/src/MacroDeck.Plugin.Cli/Building/BuildStaging.cs
@@ -37,7 +37,9 @@ internal static class BuildStaging
 		IReadOnlyCollection<string> excludedDirectories,
 		CancellationToken cancellationToken)
 	{
-		var excluded = new HashSet<string>(excludedDirectories.Select(Path.GetFullPath), PathComparer);
+		var excluded = new HashSet<string>(
+			excludedDirectories.Select(path => Path.TrimEndingDirectorySeparator(Path.GetFullPath(path))),
+			PathComparer);
 
 		CopyDirectory(Path.GetFullPath(sourceRoot),
 			Path.GetFullPath(sourceRoot),
@@ -103,6 +105,7 @@ internal static class BuildStaging
 			var name = Path.GetFileName(file);
 
 			if (_excludedFiles.Contains(name, StringComparer.OrdinalIgnoreCase) ||
+				PluginArtifactFiles.HasArtifactExtension(name) ||
 				name.Equals(PluginBuildConfigReader.FileName, StringComparison.OrdinalIgnoreCase) ||
 				(current.Equals(root, StringComparison.Ordinal) &&
 					name.Equals(PluginArtifactFiles.ManifestFileName, StringComparison.OrdinalIgnoreCase)))

--- a/sdk/src/MacroDeck.Plugin.Cli/Building/PluginBuilder.cs
+++ b/sdk/src/MacroDeck.Plugin.Cli/Building/PluginBuilder.cs
@@ -145,6 +145,7 @@ internal static class PluginBuilder
 			{
 				var excluded = targets.Values
 					.Select(target => Path.GetFullPath(Path.Combine(sourceRoot, target.Output)))
+					.Append(Path.GetFullPath(request.OutputDirectory))
 					.ToList();
 
 				BuildStaging.CopySharedAssets(sourceRoot, stagingDirectory, excluded, cancellationToken);

--- a/sdk/src/MacroDeck.Plugin.Cli/Packing/PluginPacker.cs
+++ b/sdk/src/MacroDeck.Plugin.Cli/Packing/PluginPacker.cs
@@ -79,7 +79,7 @@ internal static class PluginPacker
 		var sourceRoot = Path.GetFullPath(sourceDirectory);
 		var fullManifestPath = Path.GetFullPath(manifestPath);
 
-		var payloadResult = CollectPayloadEntries(sourceRoot, fullManifestPath);
+		var payloadResult = CollectPayloadEntries(sourceRoot, Path.GetFullPath(outputPath));
 		if (payloadResult.Rejection is { } rejection)
 		{
 			return rejection;
@@ -282,12 +282,20 @@ internal static class PluginPacker
 
 	private static (IReadOnlyList<PayloadEntry> Entries, PluginPackResult? Rejection) CollectPayloadEntries(
 		string sourceRoot,
-		string fullManifestPath)
+		string fullOutputPath)
 	{
 		var entries = new List<PayloadEntry>();
 
 		foreach (var absolutePath in Directory.EnumerateFiles(sourceRoot, "*", SearchOption.AllDirectories))
 		{
+			if (PluginArtifactFiles.HasArtifactExtension(absolutePath) ||
+				string.Equals(absolutePath,
+					fullOutputPath,
+					OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+			{
+				continue;
+			}
+
 			var relativePath = Path.GetRelativePath(sourceRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
 
 			// The archive's manifest.json is always the recomputed one built from --manifest's content,

--- a/sdk/tests/MacroDeck.Plugin.Cli.Tests.UnitTests/PluginBuilderTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Cli.Tests.UnitTests/PluginBuilderTests.cs
@@ -658,7 +658,8 @@ public class PluginBuilderTests
 
 			Assert.Multiple(() =>
 			{
-				Assert.That(entries.Where(entry => entry.EndsWith(".macroDeckPlugin", StringComparison.OrdinalIgnoreCase)),
+				Assert.That(entries.Where(entry =>
+						entry.EndsWith(".macroDeckPlugin", StringComparison.OrdinalIgnoreCase)),
 					Is.Empty);
 				Assert.That(entries, Does.Not.Contain("artifacts/SHA256SUMS"));
 				Assert.That(entries, Does.Contain("assets/icon.png"));

--- a/sdk/tests/MacroDeck.Plugin.Cli.Tests.UnitTests/PluginBuilderTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Cli.Tests.UnitTests/PluginBuilderTests.cs
@@ -637,10 +637,44 @@ public class PluginBuilderTests
 		}
 	}
 
+	[Test]
+	public async Task Building_twice_into_an_output_directory_inside_the_project_never_packs_the_first_artifact()
+	{
+		var rids = ManifestFixtures.PickForeignRids(2);
+		var project = BuildFixtures.WriteProject(rids);
+		var artifacts = Path.Combine(project, "artifacts") + Path.DirectorySeparatorChar;
+
+		try
+		{
+			var runner = new FakePluginBuildRunner { OnRun = BuildFixtures.ProducingOutput(project, rids) };
+
+			var first = await BuildAsync(project, runner, output: artifacts);
+			await File.WriteAllTextAsync(Path.Combine(artifacts, "SHA256SUMS"), "checksums");
+			var second = await BuildAsync(project, runner, rid: rids[0], output: artifacts);
+
+			Assert.That(first.Success && second.Success, Is.True, first.FailureMessage ?? second.FailureMessage);
+
+			var entries = ArtifactEntries(second.Pack!.OutputPath!);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(entries.Where(entry => entry.EndsWith(".macroDeckPlugin", StringComparison.OrdinalIgnoreCase)),
+					Is.Empty);
+				Assert.That(entries, Does.Not.Contain("artifacts/SHA256SUMS"));
+				Assert.That(entries, Does.Contain("assets/icon.png"));
+			});
+		}
+		finally
+		{
+			Delete(project);
+		}
+	}
+
 	private Task<PluginBuildResult> BuildAsync(string project,
 		IPluginBuildRunner runner,
 		string? rid = null,
-		bool force = false)
+		bool force = false,
+		string? output = null)
 	{
 		return PluginBuilder.BuildAsync(new PluginBuildRequest
 			{
@@ -648,7 +682,7 @@ public class PluginBuilderTests
 				ManifestPath = Path.Combine(project, "manifest.json"),
 				BuildConfigPath = Path.Combine(project, "macrodeck-build.json"),
 				Rid = rid,
-				OutputDirectory = _output,
+				OutputDirectory = output ?? _output,
 				Force = force,
 				StagingRoot = _stagingRoot
 			},

--- a/sdk/tests/MacroDeck.Plugin.Cli.Tests.UnitTests/PluginPackerTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Cli.Tests.UnitTests/PluginPackerTests.cs
@@ -54,6 +54,46 @@ public class PluginPackerTests
 	}
 
 	[Test]
+	public async Task PackAsync_into_the_source_tree_never_packs_its_own_output_or_an_earlier_artifact()
+	{
+		var directory = ManifestFixtures.WriteValidManifestDirectory();
+		var outputPath = Path.Combine(directory, "plugin.macroDeckPlugin");
+		var renamedOutputPath = Path.Combine(directory, "out", "plugin.zip");
+
+		try
+		{
+			var first = await PluginPacker.PackAsync(directory,
+				Path.Combine(directory, "manifest.json"),
+				_ => outputPath,
+				force: false);
+			var second = await PluginPacker.PackAsync(directory,
+				Path.Combine(directory, "manifest.json"),
+				_ => renamedOutputPath,
+				force: false);
+			var third = await PluginPacker.PackAsync(directory,
+				Path.Combine(directory, "manifest.json"),
+				_ => renamedOutputPath,
+				force: true);
+
+			Assert.That(first.Success && second.Success && third.Success, Is.True);
+
+			using var archive = ZipFile.OpenRead(renamedOutputPath);
+			var entries = archive.Entries.Select(entry => entry.FullName).ToList();
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(entries, Does.Not.Contain("plugin.macroDeckPlugin"));
+				Assert.That(entries, Does.Not.Contain("out/plugin.zip"));
+				Assert.That(entries, Does.Contain(ManifestFixtures.EntrypointFileName));
+			});
+		}
+		finally
+		{
+			Directory.Delete(directory, recursive: true);
+		}
+	}
+
+	[Test]
 	public async Task PackAsync_output_inspects_clean_through_the_independent_reader_and_its_file_digests_verify()
 	{
 		var directory = ManifestFixtures.WriteValidManifestDirectory();


### PR DESCRIPTION
Reported directly by the maintainer (no issue).

## Summary

Building or packing into an output directory inside the plugin project packed the previous artifact into the next one. Build now excludes its own output directory and any .macroDeckPlugin file; pack excludes its own output file and any .macroDeckPlugin file.

## Testing

Full solution build and all test suites pass, with regression tests for build and pack that fail without the fix. Verified with the real CLI on a scaffolded plugin: build --output ./artifacts then build --rid osx-arm64 no longer nests the first artifact. Windows and Linux not run.

## Plugin SDK / API compatibility

- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
