### PR TITLE
Cache a cancelled invocation's real outcome

### DIFF
--- a/docs/src/content/docs/reference/protocol.md
+++ b/docs/src/content/docs/reference/protocol.md
@@ -258,7 +258,9 @@ socket:
 Delivery is **at-most-once**. There are no sequence numbers and no replay log for messages lost during
 a disconnect; do not expect the host to replay an unacknowledged event after reconnecting. For a
 retryable operation that must not run twice, send an `idempotencyKey`: a repeat while the original is in
-flight gets `DUPLICATE_IDEMPOTENCY_KEY`, a repeat after completion gets the cached result.
+flight gets `DUPLICATE_IDEMPOTENCY_KEY`, a repeat after completion gets the cached result. A cancelled
+invocation caches nothing, so a retry with its key runs again; an invocation that finished despite the
+cancel keeps its result, so a retry replays it instead of running twice.
 
 ## Limits
 
@@ -313,7 +315,7 @@ honour cancellation.
 | `session.goodbye` or `DELETE /api/plugins/sessions/{sessionId}` | Session non-resumable at once |
 | No inbound traffic for 60 s (host pings every 20 s) | Host aborts the socket |
 
-A resume keeps the session id, negotiated version, capability map, declared catalogue and the host-side
+A resume keeps the session id, negotiated version, capability map, declared catalogue and the plugin-side
 idempotency cache. It drops in-flight invocations, event subscriptions and queued outbound messages. A
 fresh session after expiry is not a resume and may need capability state and lifecycle
 re-initialisation. Reconnect with full-jitter exponential backoff: 1 s initial, 30 s maximum, factor 2.

--- a/docs/src/content/docs/reference/websocket.md
+++ b/docs/src/content/docs/reference/websocket.md
@@ -423,7 +423,7 @@ A reply sets `correlationId` to the `id` it answers. Five types **require** one:
 - Cancellation is best-effort both ways. `capability.cancel` / `host.cancel` against an unknown correlation is a no-op, never an error (no reply at all).
 - The receiver of a cancel still emits exactly one `capability.result` with a cancelled outcome, unless it had already replied.
 - Delivery is at-most-once: no sequence numbers, no replay buffer. Retry safety comes from `idempotencyKey` only.
-- A repeat key while the original is in flight fails with `DUPLICATE_IDEMPOTENCY_KEY`; after completion it returns the cached result. The cache is host-side and survives a resume; a restarted plugin process re-executes.
+- A repeat key while the original is in flight fails with `DUPLICATE_IDEMPOTENCY_KEY`; after completion it returns the cached result. A cancelled invocation caches nothing, so a retry runs again; one that finished despite the cancel keeps its result. The cache is plugin-side and survives a resume; a restarted plugin process re-executes.
 
 ## Backpressure
 

--- a/sdk/src/MacroDeck.Plugin.Hosting/Capabilities/CapabilityDispatcher.cs
+++ b/sdk/src/MacroDeck.Plugin.Hosting/Capabilities/CapabilityDispatcher.cs
@@ -93,16 +93,19 @@ internal sealed class CapabilityDispatcher(
 		{
 			var result = await RunAsync(payload!, envelope, invocation);
 
-			if (invocation.TryComplete())
+			// A run that finished after its cancel was answered stays cached, or a retry would run it twice.
+			if (result.Error?.Code == ProtocolErrorCodes.Cancelled)
 			{
-				Remember(envelope.IdempotencyKey, result);
-				await reply(ToEnvelope(correlationId, result), connectionToken);
+				Forget(envelope.IdempotencyKey);
 			}
 			else
 			{
-				// Something else already answered - a cancel, or the connection dropping. There is no
-				// result to remember, so the claim has to go or the key stays poisoned.
-				Forget(envelope.IdempotencyKey);
+				Remember(envelope.IdempotencyKey, result);
+			}
+
+			if (invocation.TryComplete())
+			{
+				await reply(ToEnvelope(correlationId, result), connectionToken);
 			}
 		}
 		finally
@@ -275,7 +278,7 @@ internal sealed class CapabilityDispatcher(
 		}
 	}
 
-	/// <summary>Releases a claimed key that produced no result, so a retry is not refused forever.</summary>
+	/// <summary>Releases a claimed key that produced no result or was cancelled, so a retry runs again.</summary>
 	private void Forget(string? key)
 	{
 		if (!string.IsNullOrEmpty(key))

--- a/sdk/tests/MacroDeck.Plugin.Hosting.Tests.UnitTests/CapabilityDispatcherTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Hosting.Tests.UnitTests/CapabilityDispatcherTests.cs
@@ -242,6 +242,101 @@ public class CapabilityDispatcherTests
 	}
 
 	[Test]
+	public async Task A_retry_after_a_cancel_the_handler_honoured_runs_again(
+		[Values] bool handlerStopsInsideCancel)
+	{
+		var calls = 0;
+		var running = new TaskCompletionSource();
+		var release = new TaskCompletionSource();
+
+		using var dispatcher = TestSession.Dispatcher(new TestCapabilityHandler("actions",
+			async (_, token) =>
+			{
+				if (Interlocked.Increment(ref calls) > 1)
+				{
+					return CapabilityInvocationResult.Ok();
+				}
+
+				running.TrySetResult();
+
+				if (handlerStopsInsideCancel)
+				{
+					var stopped = new TaskCompletionSource();
+					await using var registration = token.Register(() => stopped.TrySetCanceled(token));
+					await stopped.Task;
+				}
+				else
+				{
+					await release.Task;
+					token.ThrowIfCancellationRequested();
+				}
+
+				return CapabilityInvocationResult.Ok();
+			}));
+
+		var envelope = Invoke(idempotencyKey: "key");
+		var first = dispatcher.DispatchAsync(envelope, Reply, CancellationToken.None);
+		await running.Task;
+
+		dispatcher.Cancel(new ProtocolEnvelope
+		{
+			Type = MessageTypes.CapabilityCancel,
+			Id = Guid.CreateVersion7().ToString(),
+			CorrelationId = envelope.Id
+		});
+		release.TrySetResult();
+		await first;
+		_replies.Clear();
+
+		await dispatcher.DispatchAsync(Invoke(idempotencyKey: "key"), Reply, CancellationToken.None);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(calls, Is.EqualTo(2));
+			Assert.That(Single().Error, Is.Null);
+		});
+	}
+
+	[Test]
+	public async Task A_retry_after_a_cancel_the_handler_ignored_replays_its_result()
+	{
+		var calls = 0;
+		var running = new TaskCompletionSource();
+		var release = new TaskCompletionSource();
+
+		using var dispatcher = TestSession.Dispatcher(new TestCapabilityHandler("actions",
+			async (_, _) =>
+			{
+				Interlocked.Increment(ref calls);
+				running.TrySetResult();
+				await release.Task;
+				return CapabilityInvocationResult.Ok();
+			}));
+
+		var envelope = Invoke(idempotencyKey: "key");
+		var first = dispatcher.DispatchAsync(envelope, Reply, CancellationToken.None);
+		await running.Task;
+
+		var cancelled = dispatcher.Cancel(new ProtocolEnvelope
+		{
+			Type = MessageTypes.CapabilityCancel,
+			Id = Guid.CreateVersion7().ToString(),
+			CorrelationId = envelope.Id
+		});
+		release.TrySetResult();
+		await first;
+
+		await dispatcher.DispatchAsync(Invoke(idempotencyKey: "key"), Reply, CancellationToken.None);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(cancelled!.Error!.Code, Is.EqualTo(ProtocolErrorCodes.Cancelled));
+			Assert.That(calls, Is.EqualTo(1));
+			Assert.That(Single().Error, Is.Null);
+		});
+	}
+
+	[Test]
 	public async Task A_repeated_idempotency_key_while_the_first_is_in_flight_is_refused()
 	{
 		var running = new TaskCompletionSource();


### PR DESCRIPTION
## Summary

After a cancel, the idempotency cache depended on whether the cancel or the handler answered first, so a retry either replayed CANCELLED or ran again. It now follows the handler's real outcome: a cancelled run caches nothing, a run that finished despite the cancel stays cached.

## Testing

Full solution build and tests pass in Release, except PluginSubjectResolverTests.A_project_is_actually_built_before_its_output_is_resolved, which fails locally only because global.json pins an SDK this machine lacks. New dispatcher tests cover both reply owners and fail against the previous dispatcher.

## Plugin SDK / API compatibility

No public API changed. Retry after a cancel is now deterministic and documented in protocol.md and websocket.md, which also no longer call the plugin-side cache host-side.

- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed

## Checklist

- [x] Tests were added or updated where needed
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
