### PR TITLE
Report a dropped invocation as cancelled

### DIFF
--- a/docs/src/content/docs/reference/protocol.md
+++ b/docs/src/content/docs/reference/protocol.md
@@ -316,9 +316,9 @@ honour cancellation.
 | No inbound traffic for 60 s (host pings every 20 s) | Host aborts the socket |
 
 A resume keeps the session id, negotiated version, capability map, declared catalogue and the plugin-side
-idempotency cache. It drops in-flight invocations, event subscriptions and queued outbound messages. A
-fresh session after expiry is not a resume and may need capability state and lifecycle
-re-initialisation. Reconnect with full-jitter exponential backoff: 1 s initial, 30 s maximum, factor 2.
+idempotency cache. It drops in-flight invocations (a retry of one with its idempotency key runs
+again), event subscriptions and queued outbound messages. A fresh session after expiry is not a resume
+and may need capability state and lifecycle re-initialisation. Reconnect with full-jitter exponential backoff: 1 s initial, 30 s maximum, factor 2.
 `MacroDeck.Plugin.Hosting` does all of this for .NET plugins.
 
 ## Security

--- a/sdk/src/MacroDeck.Plugin.Hosting/Capabilities/CapabilityDispatcher.cs
+++ b/sdk/src/MacroDeck.Plugin.Hosting/Capabilities/CapabilityDispatcher.cs
@@ -218,7 +218,7 @@ internal sealed class CapabilityDispatcher(
 		}
 		catch (OperationCanceledException) when (invocation.Token.IsCancellationRequested)
 		{
-			var timedOut = !invocation.CancelledByPeer;
+			var timedOut = !invocation.CancelledByPeer && !invocation.ConnectionLost;
 
 			return CapabilityInvocationResult.Failed(
 				timedOut ? ProtocolErrorCodes.Timeout : ProtocolErrorCodes.Cancelled,
@@ -357,12 +357,14 @@ internal sealed class CapabilityDispatcher(
 	private sealed class Invocation : IDisposable
 	{
 		private readonly CancellationTokenSource _cancellation;
+		private readonly CancellationToken _connectionToken;
 		private int _cancelledByPeer;
 		private int _replied;
 
 		public Invocation(string correlationId, int? deadlineMs, DateTimeOffset now, CancellationToken connectionToken)
 		{
 			CorrelationId = correlationId;
+			_connectionToken = connectionToken;
 			_cancellation = CancellationTokenSource.CreateLinkedTokenSource(connectionToken);
 
 			// The protocol's invoke timeout is the ceiling even when the caller asked for longer: a
@@ -386,6 +388,8 @@ internal sealed class CapabilityDispatcher(
 
 		/// <summary>True when a <c>capability.cancel</c> caused the cancellation, rather than the deadline.</summary>
 		public bool CancelledByPeer => Volatile.Read(ref _cancelledByPeer) == 1;
+
+		public bool ConnectionLost => _connectionToken.IsCancellationRequested;
 
 		/// <summary>Wins the right to send the one reply. Only the first caller gets true.</summary>
 		public bool TryComplete() => Interlocked.Exchange(ref _replied, 1) == 0;

--- a/sdk/tests/MacroDeck.Plugin.Hosting.Tests.UnitTests/CapabilityDispatcherTests.cs
+++ b/sdk/tests/MacroDeck.Plugin.Hosting.Tests.UnitTests/CapabilityDispatcherTests.cs
@@ -337,6 +337,43 @@ public class CapabilityDispatcherTests
 	}
 
 	[Test]
+	public async Task A_retry_after_the_connection_dropped_mid_invocation_runs_again()
+	{
+		var calls = 0;
+		var running = new TaskCompletionSource();
+		using var connection = new CancellationTokenSource();
+
+		using var dispatcher = TestSession.Dispatcher(new TestCapabilityHandler("actions",
+			async (_, token) =>
+			{
+				if (Interlocked.Increment(ref calls) > 1)
+				{
+					return CapabilityInvocationResult.Ok();
+				}
+
+				running.TrySetResult();
+				await Task.Delay(Timeout.Infinite, token);
+				return CapabilityInvocationResult.Ok();
+			}));
+
+		var first = dispatcher.DispatchAsync(Invoke(idempotencyKey: "key"), Reply, connection.Token);
+		await running.Task;
+
+		await connection.CancelAsync();
+		await first;
+		dispatcher.AbortInFlight();
+		_replies.Clear();
+
+		await dispatcher.DispatchAsync(Invoke(idempotencyKey: "key"), Reply, CancellationToken.None);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(calls, Is.EqualTo(2));
+			Assert.That(Single().Error, Is.Null);
+		});
+	}
+
+	[Test]
 	public async Task A_repeated_idempotency_key_while_the_first_is_in_flight_is_refused()
 	{
 		var running = new TaskCompletionSource();


### PR DESCRIPTION
## Summary

On a connection drop, an in-flight invocation was reported as TIMEOUT and that result was cached, so a retry after the resume replayed TIMEOUT. A dropped connection now counts as a cancellation, so the key is released and the retry runs again. Stacked on fix/cancelled-result-not-cached; merge that PR first.

## Testing

Full solution build and tests pass in Release, except the same environment-only PluginSubjectResolverTests case. A new dispatcher test drops the connection mid-invocation and retries; it fails against the previous dispatcher.

## Plugin SDK / API compatibility

No public API changed. The reply rules are unchanged; protocol.md now states that a retry of a dropped invocation runs again.

- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed

## Checklist

- [x] Tests were added or updated where needed
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
