### PR TITLE
Honour disabled regions on hardware presses

### DIFF
--- a/docs/src/content/docs/features/devices.md
+++ b/docs/src/content/docs/features/devices.md
@@ -193,7 +193,7 @@ stays open, the next press works:
 
 | Result | Meaning |
 | --- | --- |
-| `Accepted` | The host took it. |
+| `Accepted` | The host took it. For a `ShortPress` or `LongPress` on a tile a plugin or integration serves, it can mean *queued*: see below. |
 | `Rejected` + `WidgetNotOnSurface` | The press raced a surface push. Re-render the newest surface. |
 | `Rejected` + `HostLocked` | The host is locked and runs nothing until unlocked. |
 | `Rejected` + `TriggerFailed` | The widget was edited or deleted between push and press. |
@@ -209,6 +209,15 @@ answered `NotSupported`.
 | (timer elapses while held) | `onLongPress`. |
 | `Release` | `onTouchEnd`, plus `onShortPress` if the long press had not fired. |
 | `ShortPress` / `LongPress` | That trigger directly - no synthesis. |
+
+A tile that a plugin or integration serves, rather than a built-in one, answers a press from its own UI tree
+first, exactly as it does on screen: a [disabled region](/ui/components/modifier/) absorbs the press, and a
+control that declares the press receives it instead of the tile's flows. The host asks that tree once per
+press and waits at most a second for it; a tree that does not answer in time absorbs the press. Because the
+tree may arrive over the same connection your report came in on, the host never holds your report for it:
+`Press` and `Release` return at once as always, and a `ShortPress` or `LongPress` whose tree has not answered
+yet is answered `Accepted` and runs afterwards, so a failure of that flow no longer comes back as
+`Rejected` + `TriggerFailed`. Built-in tiles keep the full verdict.
 
 Press state is tracked **per widget**: releasing one widget never ends another's press, and a second
 `Press` for a widget already held is ignored (no timer restart, no second `onTouchStart`). If your hardware

--- a/docs/src/content/docs/ui/components/modifier.md
+++ b/docs/src/content/docs/ui/components/modifier.md
@@ -131,7 +131,9 @@ contract](/ui/concepts/events/#interaction-only-where-declared).
   a slider, dial, toggle, segmented control or text field inside one cannot be operated.
 - **A disabled region absorbs every press on the tile.** If any node in a deck tile's tree is disabled,
   pressing anywhere on the tile runs none of the tile's own flows. `Disabled` therefore means "a control
-  that is unavailable"; to fade something that is only decorative, use `Opacity` instead.
+  that is unavailable"; to fade something that is only decorative, use `Opacity` instead. On a hardware
+  deck the host asks a plugin tile's tree once per press. A tree that does not answer within a second, or
+  a plugin already at its limit of open views, absorbs that press as well.
 
 ![A mute button tile, dimmed: the red face, the crossed-out microphone and the Mute label all shown at reduced opacity](../../../../assets/ui/modifier-disabled.png)
 
@@ -143,9 +145,6 @@ Known gaps:
 
 - The web client's keyboard and hardware activation honours the absorption but not the tree's own
   activation.
-- The host's hardware path
-  ([`DeviceInteractionRouter`](https://github.com/Macro-Deck-App/Macro-Deck/blob/main/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceInteractionRouter.cs))
-  runs a tile's triggers without consulting the tree.
 
 ## Properties
 

--- a/engineering/decisions/0065-the-component-profile-authoring-contracts.md
+++ b/engineering/decisions/0065-the-component-profile-authoring-contracts.md
@@ -79,11 +79,12 @@ event, so the events stay the contract, and what reaches the wire is presentatio
 disabled for assistive technology. The reader gate still refuses events inside a disabled region even
 when a hand-written tree declares them; a producer built on the DSL never produces that combination. A
 disabled region absorbs every press on its tile, so the tile's own flow cannot run underneath a control
-shown as unavailable. The host's hardware path runs a tile's triggers without consulting the tree, and
-stays a known gap. An unbound slider declares nothing and is drawn as a level that cannot be moved. A
-component definition's own event list is metadata and never a gate — gating there would either let a
-component emit interactions the producer never opted into, or silence a node whose definition forgot to
-list an event.
+shown as unavailable. The host's hardware path asks the tree of a tile a plugin or integration serves
+the same way, once per press, before it runs the tile's triggers; a built-in tile is not asked, because
+its tree never carries a disabled region and the action button's own claim is those triggers. An unbound
+slider declares nothing and is drawn as a level that cannot be moved. A component definition's own event
+list is metadata and never a gate — gating there would either let a component emit interactions the
+producer never opted into, or silence a node whose definition forgot to list an event.
 
 **An interactive level travels as a fraction of its track, never in the producer's units.** A reader
 snaps and paints locally so the control never waits for a round trip, and a producer's units — a track

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceInteractionRouter.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceInteractionRouter.cs
@@ -1,8 +1,12 @@
+using System.Text.Json;
 using MacroDeck.Sdk.Devices;
 using MacroDeckHost.Application.HostLocking;
+using MacroDeckHost.Application.Ui.Sessions;
 using MacroDeckHost.Application.Ui.Transport;
 using MacroDeckHost.Application.Ui.Transport.Messages.Actions;
+using MacroDeckHost.Application.Ui.Transport.Messages.UiSessions;
 using MacroDeckHost.Domain.Common;
+using MacroDeckHost.Domain.Widgets;
 using Microsoft.Extensions.DependencyInjection;
 using ILogger = Serilog.ILogger;
 
@@ -15,14 +19,30 @@ namespace MacroDeckHost.Application.Devices.Surfaces;
 /// </summary>
 public sealed class DeviceInteractionRouter
 {
+	// A hardware press waits this long for a plugin tile's tree. Past it the press is absorbed rather than
+	// running flows under a control that may be shown as disabled.
+	private static readonly TimeSpan _treeDeadline = TimeSpan.FromSeconds(1);
+
+	private static readonly string[] _shortPressPhases =
+		[WidgetTriggerTypes.TouchStart, WidgetTriggerTypes.TouchEnd, WidgetTriggerTypes.ShortPress];
+
+	private static readonly string[] _longPressPhases =
+		[WidgetTriggerTypes.TouchStart, WidgetTriggerTypes.LongPress, WidgetTriggerTypes.TouchEnd];
+
 	private readonly IServiceScopeFactory _scopeFactory;
 	private readonly IHostLockState _lockState;
+	private readonly TimeProvider _timeProvider;
 	private readonly ILogger _logger;
 
-	public DeviceInteractionRouter(IServiceScopeFactory scopeFactory, IHostLockState lockState, ILogger logger)
+	public DeviceInteractionRouter(
+		IServiceScopeFactory scopeFactory,
+		IHostLockState lockState,
+		TimeProvider timeProvider,
+		ILogger logger)
 	{
 		_scopeFactory = scopeFactory;
 		_lockState = lockState;
+		_timeProvider = timeProvider;
 		_logger = logger.ForContext<DeviceInteractionRouter>();
 	}
 
@@ -54,12 +74,60 @@ public sealed class DeviceInteractionRouter
 				await Presses(session).ReleaseAsync(widgetId);
 				return DeviceInteractionOutcome.Accepted;
 			case DeviceInteractionKind.ShortPress:
-				return await ExecuteTriggerAsync(session, widgetId, WidgetTriggerTypes.ShortPress);
+				return await ExecuteWholePressAsync(session, widgetId, WidgetTriggerTypes.ShortPress, _shortPressPhases);
 			case DeviceInteractionKind.LongPress:
-				return await ExecuteTriggerAsync(session, widgetId, WidgetTriggerTypes.LongPress);
+				return await ExecuteWholePressAsync(session, widgetId, WidgetTriggerTypes.LongPress, _longPressPhases);
 			default:
 				return DeviceInteractionOutcome.NotSupported;
 		}
+	}
+
+	public async Task<DevicePressClaim> ClaimAsync(DeviceSurfaceSession session, string widgetId)
+	{
+		var type = session.LastPushed?.Widgets
+			.FirstOrDefault(widget => string.Equals(widget.Id, widgetId, StringComparison.Ordinal))?.Type;
+		if (type is null || WidgetTypeIds.BuiltIn.Contains(type, StringComparer.Ordinal))
+		{
+			return DevicePressClaim.None;
+		}
+
+		IUiSessionBroker? broker = null;
+		string? sessionId = null;
+		try
+		{
+			await using var scope = _scopeFactory.CreateAsyncScope();
+			broker = scope.ServiceProvider.GetRequiredService<IUiSessionBroker>();
+
+			// A principal of its own, so the opener never hands back a session a client or another press holds.
+			var ticket = scope.ServiceProvider.GetRequiredService<IWidgetUiSessionOpener>()
+				.Open(new OpenWidgetUiSessionRequest { WidgetId = widgetId },
+					$"device:{session.DeviceId:N}:{Guid.NewGuid():N}",
+					isAdmin: false);
+
+			if (!ticket.Accepted)
+			{
+				// No provider at all means no tree to answer with, which is what a client falls back from too.
+				return ticket.Code == UiSessionErrorCodes.ProviderUnavailable
+					? DevicePressClaim.None
+					: DevicePressClaim.Absorbing(null, null);
+			}
+
+			sessionId = ticket.SessionId;
+			using var deadline = new CancellationTokenSource(_treeDeadline, _timeProvider);
+			if (await broker.FirstTreeAsync(sessionId, deadline.Token) is { } tree)
+			{
+				return DevicePressClaim.From(broker, sessionId, JsonDocument.Parse(tree.Utf8));
+			}
+		}
+		catch (Exception exception) when (exception is not OutOfMemoryException)
+		{
+			_logger.Warning(exception,
+				"The tree of widget {WidgetId} did not answer device {DeviceId}'s press; it is absorbed",
+				widgetId,
+				session.DeviceId);
+		}
+
+		return DevicePressClaim.Absorbing(broker, sessionId);
 	}
 
 	/// <summary>
@@ -70,13 +138,25 @@ public sealed class DeviceInteractionRouter
 	public async Task<DeviceInteractionOutcome> ExecuteTriggerAsync(
 		DeviceSurfaceSession session,
 		string widgetId,
-		string triggerType)
+		string triggerType,
+		DevicePressClaim claim)
 	{
 		// The folder the widget lives in, not the one on screen: a widget pinned into the current folder
 		// is rendered here but is only addressable under its own folder.
 		if (session.OwningFolderIdOf(widgetId) is not { } folderId)
 		{
 			return DeviceInteractionOutcome.Reject(DeviceSurfaceErrorCodes.WidgetNotOnSurface);
+		}
+
+		if (claim.TakesPress)
+		{
+			if (_lockState.IsLocked)
+			{
+				return DeviceInteractionOutcome.Reject(DeviceSurfaceErrorCodes.HostLocked);
+			}
+
+			claim.Dispatch(triggerType);
+			return DeviceInteractionOutcome.Accepted;
 		}
 
 		try
@@ -118,6 +198,49 @@ public sealed class DeviceInteractionRouter
 
 			return DeviceInteractionOutcome.Reject(DeviceSurfaceErrorCodes.TriggerFailed);
 		}
+	}
+
+	private async Task<DeviceInteractionOutcome> ExecuteWholePressAsync(
+		DeviceSurfaceSession session,
+		string widgetId,
+		string triggerType,
+		string[] phases)
+	{
+		var pending = ClaimAsync(session, widgetId);
+		if (pending.IsCompleted)
+		{
+			return await FinishWholePressAsync(session, widgetId, triggerType, phases, pending);
+		}
+
+		// Never awaited on the report: the tile's tree may arrive on the same serial plugin connection.
+		_ = FinishWholePressAsync(session, widgetId, triggerType, phases, pending);
+		return DeviceInteractionOutcome.Accepted;
+	}
+
+	private async Task<DeviceInteractionOutcome> FinishWholePressAsync(
+		DeviceSurfaceSession session,
+		string widgetId,
+		string triggerType,
+		string[] phases,
+		Task<DevicePressClaim> pending)
+	{
+		await using var claim = await pending;
+		if (_lockState.IsLocked)
+		{
+			return DeviceInteractionOutcome.Reject(DeviceSurfaceErrorCodes.HostLocked);
+		}
+
+		if (!claim.TakesPress || session.OwningFolderIdOf(widgetId) is null)
+		{
+			return await ExecuteTriggerAsync(session, widgetId, triggerType, claim);
+		}
+
+		foreach (var phase in phases)
+		{
+			claim.Dispatch(phase);
+		}
+
+		return DeviceInteractionOutcome.Accepted;
 	}
 
 	private static DeviceSurfacePressTracker Presses(DeviceSurfaceSession session)

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceInteractionRouter.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceInteractionRouter.cs
@@ -74,7 +74,10 @@ public sealed class DeviceInteractionRouter
 				await Presses(session).ReleaseAsync(widgetId);
 				return DeviceInteractionOutcome.Accepted;
 			case DeviceInteractionKind.ShortPress:
-				return await ExecuteWholePressAsync(session, widgetId, WidgetTriggerTypes.ShortPress, _shortPressPhases);
+				return await ExecuteWholePressAsync(session,
+					widgetId,
+					WidgetTriggerTypes.ShortPress,
+					_shortPressPhases);
 			case DeviceInteractionKind.LongPress:
 				return await ExecuteWholePressAsync(session, widgetId, WidgetTriggerTypes.LongPress, _longPressPhases);
 			default:

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DevicePressClaim.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DevicePressClaim.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using MacroDeckHost.Application.Ui.Sessions;
+
+namespace MacroDeckHost.Application.Devices.Surfaces;
+
+public sealed class DevicePressClaim : IAsyncDisposable
+{
+	private readonly Lock _gate = new();
+	private readonly IUiSessionBroker? _broker;
+	private readonly string? _sessionId;
+	private readonly JsonDocument? _tree;
+	private readonly JsonElement? _claimant;
+	private bool _disposed;
+
+	private DevicePressClaim(
+		IUiSessionBroker? broker,
+		string? sessionId,
+		JsonDocument? tree,
+		JsonElement? claimant,
+		bool absorbed)
+	{
+		_broker = broker;
+		_sessionId = sessionId;
+		_tree = tree;
+		_claimant = claimant;
+		Absorbed = absorbed;
+	}
+
+	public static DevicePressClaim None => new(null, null, null, null, absorbed: false);
+
+	public bool Absorbed { get; }
+
+	public bool TakesPress => Absorbed || _claimant is not null;
+
+	public static DevicePressClaim Absorbing(IUiSessionBroker? broker, string? sessionId)
+		=> new(broker, sessionId, null, null, absorbed: true);
+
+	public static DevicePressClaim From(IUiSessionBroker broker, string sessionId, JsonDocument tree)
+	{
+		var claim = UiActivationClaim.Of(tree.RootElement);
+		if (claim.Claimant is { } node &&
+			(!node.TryGetProperty("id", out var id) || id.ValueKind != JsonValueKind.String))
+		{
+			tree.Dispose();
+			return Absorbing(broker, sessionId);
+		}
+
+		return new DevicePressClaim(broker, sessionId, tree, claim.Claimant, claim.Absorbed);
+	}
+
+	public void Dispatch(string triggerType)
+	{
+		lock (_gate)
+		{
+			DispatchLocked(triggerType);
+		}
+	}
+
+	private void DispatchLocked(string triggerType)
+	{
+		if (_disposed || _claimant is not { } node || _tree is null || _broker is null || _sessionId is null ||
+			UiActivationClaim.EventFor(node, triggerType) is not { } uiEvent)
+		{
+			return;
+		}
+
+		_broker.DispatchHostEvent(_sessionId,
+			new UiSessionEventCommand
+			{
+				NodeId = node.GetProperty("id").GetString()!,
+				Name = uiEvent.Name,
+				Data = uiEvent.Payload is null
+					? default
+					: new UiRawJson(JsonSerializer.SerializeToUtf8Bytes(uiEvent.Payload)),
+				Revision = _tree.RootElement.TryGetProperty("revision", out var revision) &&
+					revision.TryGetInt32(out var value)
+						? value
+						: null
+			});
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		lock (_gate)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+			_tree?.Dispose();
+		}
+
+		if (_broker is not null && _sessionId is not null)
+		{
+			// Queued behind any dispatch on the provider pump, so the last event still reaches the session.
+			await _broker.CloseAsync(_sessionId, "The device press ended.", CancellationToken.None);
+		}
+	}
+}

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DevicePressClaim.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DevicePressClaim.cs
@@ -58,7 +58,11 @@ public sealed class DevicePressClaim : IAsyncDisposable
 
 	private void DispatchLocked(string triggerType)
 	{
-		if (_disposed || _claimant is not { } node || _tree is null || _broker is null || _sessionId is null ||
+		if (_disposed ||
+			_claimant is not { } node ||
+			_tree is null ||
+			_broker is null ||
+			_sessionId is null ||
 			UiActivationClaim.EventFor(node, triggerType) is not { } uiEvent)
 		{
 			return;

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceSurfacePressTracker.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceSurfacePressTracker.cs
@@ -18,13 +18,18 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 	public static readonly TimeSpan LongPressThreshold = TimeSpan.FromMilliseconds(600);
 
 	private readonly TimeProvider _timeProvider;
-	private readonly Func<string, string, Task> _execute;
+	private readonly Func<string, Task<DevicePressClaim>> _claim;
+	private readonly Func<string, string, DevicePressClaim, Task> _execute;
 	private readonly Lock _sync = new();
 	private readonly Dictionary<string, PressState> _presses = new(StringComparer.Ordinal);
 
-	public DeviceSurfacePressTracker(TimeProvider timeProvider, Func<string, string, Task> execute)
+	public DeviceSurfacePressTracker(
+		TimeProvider timeProvider,
+		Func<string, Task<DevicePressClaim>> claim,
+		Func<string, string, DevicePressClaim, Task> execute)
 	{
 		_timeProvider = timeProvider;
+		_claim = claim;
 		_execute = execute;
 	}
 
@@ -34,6 +39,7 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 	/// </summary>
 	public Task PressAsync(string widgetId)
 	{
+		PressState state;
 		lock (_sync)
 		{
 			if (_presses.ContainsKey(widgetId))
@@ -41,7 +47,7 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 				return Task.CompletedTask;
 			}
 
-			var state = new PressState();
+			state = new PressState();
 			state.Timer = _timeProvider.CreateTimer(_ => OnLongPressElapsed(widgetId, state),
 				null,
 				LongPressThreshold,
@@ -49,29 +55,19 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 			_presses[widgetId] = state;
 		}
 
-		return _execute(widgetId, WidgetTriggerTypes.TouchStart);
+		state.Resolve(_claim(widgetId));
+		return Settle(state, Enqueue(widgetId, state, WidgetTriggerTypes.TouchStart));
 	}
 
-	public async Task ReleaseAsync(string widgetId)
-	{
-		if (Take(widgetId) is not { } state)
-		{
-			return;
-		}
-
-		await _execute(widgetId, WidgetTriggerTypes.TouchEnd);
-		if (!state.LongPressFired)
-		{
-			await _execute(widgetId, WidgetTriggerTypes.ShortPress);
-		}
-	}
+	public Task ReleaseAsync(string widgetId)
+		=> Take(widgetId) is { } state ? Settle(state, FinishAsync(widgetId, state, released: true)) : Task.CompletedTask;
 
 	/// <summary>
 	/// Ends a press the device never released - navigation away, the device going offline, the session
 	/// closing. Emits <c>onTouchEnd</c> only, and disarms the timer so no phantom long press fires later.
 	/// </summary>
 	public Task CancelAsync(string widgetId)
-		=> Take(widgetId) is null ? Task.CompletedTask : _execute(widgetId, WidgetTriggerTypes.TouchEnd);
+		=> Take(widgetId) is { } state ? Settle(state, FinishAsync(widgetId, state, released: false)) : Task.CompletedTask;
 
 	public async Task CancelAllAsync()
 	{
@@ -94,9 +90,72 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 			foreach (var state in _presses.Values)
 			{
 				state.Timer?.Dispose();
+				_ = CloseAfterAsync(state.Tail, state);
 			}
 
 			_presses.Clear();
+		}
+	}
+
+	// A plugin's device reports and its tile's tree share one serial connection, so a press that waited
+	// here for the tree would starve the very tree it waits for. The phases still run in order behind it.
+	private static Task Settle(PressState state, Task work) => state.Claim.IsCompleted ? work : Task.CompletedTask;
+
+	private static async Task CloseAfterAsync(Task tail, PressState state)
+	{
+		await tail;
+		await (await state.Claim).DisposeAsync();
+	}
+
+	private async Task FinishAsync(string widgetId, PressState state, bool released)
+	{
+		try
+		{
+			await Enqueue(widgetId, state, WidgetTriggerTypes.TouchEnd);
+			if (released && !state.LongPressFired)
+			{
+				await Enqueue(widgetId, state, WidgetTriggerTypes.ShortPress);
+			}
+		}
+		finally
+		{
+			await (await state.Claim).DisposeAsync();
+		}
+	}
+
+	private Task Enqueue(string widgetId, PressState state, string triggerType)
+	{
+		(Task Previous, TaskCompletionSource Done) slot;
+		lock (_sync)
+		{
+			slot = Reserve(state);
+		}
+
+		return RunAsync(widgetId, state, triggerType, slot);
+	}
+
+	private static (Task Previous, TaskCompletionSource Done) Reserve(PressState state)
+	{
+		var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var previous = state.Tail;
+		state.Tail = done.Task;
+		return (previous, done);
+	}
+
+	private async Task RunAsync(
+		string widgetId,
+		PressState state,
+		string triggerType,
+		(Task Previous, TaskCompletionSource Done) slot)
+	{
+		try
+		{
+			await slot.Previous;
+			await _execute(widgetId, triggerType, await state.Claim);
+		}
+		finally
+		{
+			slot.Done.TrySetResult();
 		}
 	}
 
@@ -116,6 +175,7 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 
 	private void OnLongPressElapsed(string widgetId, PressState state)
 	{
+		(Task Previous, TaskCompletionSource Done) slot;
 		lock (_sync)
 		{
 			if (!_presses.TryGetValue(widgetId, out var current) || !ReferenceEquals(current, state))
@@ -126,15 +186,40 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 			state.LongPressFired = true;
 			state.Timer?.Dispose();
 			state.Timer = null;
+
+			// Reserved under the same lock a release takes the press with, so the long press can never land
+			// behind that release's touch end or after its claim was closed.
+			slot = Reserve(state);
 		}
 
-		_ = _execute(widgetId, WidgetTriggerTypes.LongPress);
+		_ = RunAsync(widgetId, state, WidgetTriggerTypes.LongPress, slot);
 	}
 
 	private sealed class PressState
 	{
+		private readonly TaskCompletionSource<DevicePressClaim> _claim =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public Task<DevicePressClaim> Claim => _claim.Task;
+
+		public Task Tail = Task.CompletedTask;
+
 		public ITimer? Timer;
 
 		public bool LongPressFired;
+
+		public void Resolve(Task<DevicePressClaim> claim) => _ = ResolveAsync(claim);
+
+		private async Task ResolveAsync(Task<DevicePressClaim> claim)
+		{
+			try
+			{
+				_claim.TrySetResult(await claim);
+			}
+			catch (Exception exception) when (exception is not OutOfMemoryException)
+			{
+				_claim.TrySetResult(DevicePressClaim.Absorbing(null, null));
+			}
+		}
 	}
 }

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceSurfacePressTracker.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceSurfacePressTracker.cs
@@ -60,14 +60,18 @@ public sealed class DeviceSurfacePressTracker : IDisposable
 	}
 
 	public Task ReleaseAsync(string widgetId)
-		=> Take(widgetId) is { } state ? Settle(state, FinishAsync(widgetId, state, released: true)) : Task.CompletedTask;
+		=> Take(widgetId) is { } state
+			? Settle(state, FinishAsync(widgetId, state, released: true))
+			: Task.CompletedTask;
 
 	/// <summary>
 	/// Ends a press the device never released - navigation away, the device going offline, the session
 	/// closing. Emits <c>onTouchEnd</c> only, and disarms the timer so no phantom long press fires later.
 	/// </summary>
 	public Task CancelAsync(string widgetId)
-		=> Take(widgetId) is { } state ? Settle(state, FinishAsync(widgetId, state, released: false)) : Task.CompletedTask;
+		=> Take(widgetId) is { } state
+			? Settle(state, FinishAsync(widgetId, state, released: false))
+			: Task.CompletedTask;
 
 	public async Task CancelAllAsync()
 	{

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceSurfaceService.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/DeviceSurfaceService.cs
@@ -86,7 +86,8 @@ public sealed class DeviceSurfaceService : IDeviceSurfaceService, IDeviceSurface
 			Online = _providerPresence.IsOnline(deviceId)
 		};
 		session.Presses = new DeviceSurfacePressTracker(_timeProvider,
-			(widgetId, triggerType) => _interactions.ExecuteTriggerAsync(session, widgetId, triggerType));
+			widgetId => _interactions.ClaimAsync(session, widgetId),
+			(widgetId, triggerType, claim) => _interactions.ExecuteTriggerAsync(session, widgetId, triggerType, claim));
 
 		if (!_sessions.TryAdd(deviceId, session))
 		{

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/UiActivationClaim.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/UiActivationClaim.cs
@@ -51,9 +51,12 @@ public readonly record struct UiActivationClaim(JsonElement? Claimant, bool Abso
 			return null;
 		}
 
-		if (Declares(node, UiComponentEvents.Press) || Declares(node, UiComponentEvents.LongPress) ||
-			Declares(node, UiComponentEvents.PressStart) || Declares(node, UiComponentEvents.PressEnd) ||
-			Declares(node, UiComponentEvents.Adjust) || Declares(node, UiComponentEvents.Change))
+		if (Declares(node, UiComponentEvents.Press) ||
+			Declares(node, UiComponentEvents.LongPress) ||
+			Declares(node, UiComponentEvents.PressStart) ||
+			Declares(node, UiComponentEvents.PressEnd) ||
+			Declares(node, UiComponentEvents.Adjust) ||
+			Declares(node, UiComponentEvents.Change))
 		{
 			return node;
 		}
@@ -104,7 +107,8 @@ public readonly record struct UiActivationClaim(JsonElement? Claimant, bool Abso
 		}
 
 		var current = Property(node, UiComponentProperties.Selected) is { ValueKind: JsonValueKind.Number } selected &&
-			selected.GetDouble() is var value and >= 0 && value < count
+			selected.GetDouble() is var value and >= 0 &&
+			value < count
 				? (int)Math.Floor(value)
 				: -1;
 

--- a/host/src/MacroDeckHost.Application/Devices/Surfaces/UiActivationClaim.cs
+++ b/host/src/MacroDeckHost.Application/Devices/Surfaces/UiActivationClaim.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using MacroDeck.Ui.Components;
+using MacroDeckHost.Domain.Common;
+
+namespace MacroDeckHost.Application.Devices.Surfaces;
+
+// The host's reading of activationClaim and activationFor in ui/runtime/src/ui-framework/node-gestures.ts.
+// A tile must answer a hardware press exactly as it answers a pointer or a key, so the two must agree.
+public readonly record struct UiActivationClaim(JsonElement? Claimant, bool Absorbed)
+{
+	public static UiActivationClaim Of(JsonElement tree)
+	{
+		var absorbed = false;
+		var claimant = tree.ValueKind == JsonValueKind.Object && tree.TryGetProperty("root", out var root)
+			? Visit(root, ref absorbed)
+			: null;
+
+		return new UiActivationClaim(claimant, claimant is null && absorbed);
+	}
+
+	public static (string Name, object? Payload)? EventFor(JsonElement node, string triggerType)
+	{
+		if (string.Equals(triggerType, WidgetTriggerTypes.ShortPress, StringComparison.Ordinal) &&
+			ChangeFor(node) is { } change)
+		{
+			return (UiComponentEvents.Change, change);
+		}
+
+		string? name = triggerType switch
+		{
+			WidgetTriggerTypes.ShortPress => UiComponentEvents.Press,
+			WidgetTriggerTypes.LongPress => UiComponentEvents.LongPress,
+			WidgetTriggerTypes.TouchStart => UiComponentEvents.PressStart,
+			WidgetTriggerTypes.TouchEnd => UiComponentEvents.PressEnd,
+			_ => null
+		};
+
+		return name is not null && Declares(node, name) ? (name, null) : null;
+	}
+
+	private static JsonElement? Visit(JsonElement node, ref bool absorbed)
+	{
+		if (node.ValueKind != JsonValueKind.Object)
+		{
+			return null;
+		}
+
+		if (IsDisabledRegion(node))
+		{
+			absorbed = true;
+			return null;
+		}
+
+		if (Declares(node, UiComponentEvents.Press) || Declares(node, UiComponentEvents.LongPress) ||
+			Declares(node, UiComponentEvents.PressStart) || Declares(node, UiComponentEvents.PressEnd) ||
+			Declares(node, UiComponentEvents.Adjust) || Declares(node, UiComponentEvents.Change))
+		{
+			return node;
+		}
+
+		if (node.TryGetProperty("type", out var type) && type.ValueEquals(UiComponents.Segmented))
+		{
+			return null;
+		}
+
+		if (node.TryGetProperty("children", out var children) && children.ValueKind == JsonValueKind.Array)
+		{
+			foreach (var child in children.EnumerateArray())
+			{
+				if (Visit(child, ref absorbed) is { } found)
+				{
+					return found;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static object? ChangeFor(JsonElement node)
+	{
+		if (!Declares(node, UiComponentEvents.Change))
+		{
+			return null;
+		}
+
+		var type = node.TryGetProperty("type", out var typeValue) ? typeValue.GetString() : null;
+		if (string.Equals(type, UiComponents.Toggle, StringComparison.Ordinal))
+		{
+			return Property(node, UiComponentProperties.On) is not { ValueKind: JsonValueKind.True };
+		}
+
+		if (!string.Equals(type, UiComponents.Segmented, StringComparison.Ordinal))
+		{
+			return null;
+		}
+
+		var count = node.TryGetProperty("children", out var children) && children.ValueKind == JsonValueKind.Array
+			? children.GetArrayLength()
+			: 0;
+		if (count == 0)
+		{
+			return null;
+		}
+
+		var current = Property(node, UiComponentProperties.Selected) is { ValueKind: JsonValueKind.Number } selected &&
+			selected.GetDouble() is var value and >= 0 && value < count
+				? (int)Math.Floor(value)
+				: -1;
+
+		return (current + 1) % count;
+	}
+
+	private static bool IsDisabledRegion(JsonElement node)
+		=> Property(node, UiComponentProperties.Modifiers) is { ValueKind: JsonValueKind.Object } modifiers &&
+			modifiers.TryGetProperty(UiComponentModifiers.Disabled, out var disabled) &&
+			disabled.ValueKind == JsonValueKind.True;
+
+	private static bool Declares(JsonElement node, string eventName)
+	{
+		if (Property(node, UiComponentProperties.Events) is not { ValueKind: JsonValueKind.Array } events)
+		{
+			return false;
+		}
+
+		foreach (var declared in events.EnumerateArray())
+		{
+			if (declared.ValueKind == JsonValueKind.String && declared.ValueEquals(eventName))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static JsonElement? Property(JsonElement node, string key)
+		=> node.TryGetProperty("properties", out var properties) &&
+			properties.ValueKind == JsonValueKind.Object &&
+			properties.TryGetProperty(key, out var value)
+				? value
+				: null;
+}

--- a/host/src/MacroDeckHost.Application/MacroDeckHost.Application.csproj
+++ b/host/src/MacroDeckHost.Application/MacroDeckHost.Application.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MacroDeckHost.Domain\MacroDeckHost.Domain.csproj" />
     <ProjectReference Include="..\..\..\sdk\src\MacroDeck.Sdk\MacroDeck.Sdk.csproj" />
+    <ProjectReference Include="..\..\..\ui-model\src\MacroDeck.Ui\MacroDeck.Ui.csproj" />
     <ProjectReference Include="..\..\..\protocol\src\MacroDeck.Plugin.Protocol\MacroDeck.Plugin.Protocol.csproj" />
     <ProjectReference Include="..\..\..\sdk\src\MacroDeck.Plugin.Packaging\MacroDeck.Plugin.Packaging.csproj" />
     <ProjectReference Include="..\..\..\sdk\src\MacroDeck.Localization\MacroDeck.Localization.csproj" />

--- a/host/src/MacroDeckHost.Application/Ui/Sessions/IUiSessionBroker.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Sessions/IUiSessionBroker.cs
@@ -44,11 +44,17 @@ public sealed record UiSessionOpenTicket
 }
 
 // No member here awaits a provider, which is what lets every realtime operation satisfy ADR 0062. The only
-// exception is UiSessionOpenTicket.Ready, which a caller opts into explicitly and which
+// exceptions are UiSessionOpenTicket.Ready and FirstTreeAsync, which a caller opts into explicitly and which
 // no realtime operation awaits.
 public interface IUiSessionBroker : IUiSessionSink
 {
 	UiSessionOpenTicket Open(string providerId, UiSurface surface, string ownerPrincipal);
+
+	// For a host-side reader no client attaches to. Null when the session ended before its first tree.
+	Task<UiRawJson?> FirstTreeAsync(string sessionId, CancellationToken cancellationToken);
+
+	// Raised by the host itself, so unlike SendEvent it needs no attached connection.
+	bool DispatchHostEvent(string sessionId, UiSessionEventCommand command);
 
 	Task<UiSessionOpenTicket> OpenAsync(string providerId,
 		UiSurface surface,

--- a/host/src/MacroDeckHost.Application/Ui/Sessions/UiSessionBroker.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Sessions/UiSessionBroker.cs
@@ -222,6 +222,27 @@ public sealed class UiSessionBroker : IUiSessionBroker, IDisposable
 		return new UiSendEventResponse { Accepted = true };
 	}
 
+	public async Task<UiRawJson?> FirstTreeAsync(string sessionId, CancellationToken cancellationToken)
+	{
+		if (!_contexts.TryGetValue(sessionId, out var context) || !_registry.HoldForHost(sessionId))
+		{
+			return null;
+		}
+
+		return await context.FirstTree.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	public bool DispatchHostEvent(string sessionId, UiSessionEventCommand command)
+	{
+		if (!_contexts.TryGetValue(sessionId, out var context))
+		{
+			return false;
+		}
+
+		context.ProviderPump.Enqueue(ct => DispatchEventAsync(context, command, ct));
+		return true;
+	}
+
 	public UiSessionIngestResult PublishSnapshot(string providerId, string sessionId, UiRawJson tree)
 		=> Ingest(providerId, sessionId, tree, UiPayloadShape.Tree);
 
@@ -318,6 +339,8 @@ public sealed class UiSessionBroker : IUiSessionBroker, IDisposable
 	{
 		string[] pending;
 		bool toGroup;
+
+		context.FirstTree.TrySetResult(tree);
 
 		lock (context.Gate)
 		{
@@ -649,6 +672,7 @@ public sealed class UiSessionBroker : IUiSessionBroker, IDisposable
 
 		context.Ready.TrySetResult(UiSessionOpenTicket.Rejected(e.Code ?? UiSessionErrorCodes.SessionClosed,
 			e.Message ?? "The session ended."));
+		context.FirstTree.TrySetResult(null);
 
 		_ = TearDownAsync(context, e.Reason, e.Message ?? string.Empty);
 	}
@@ -712,6 +736,9 @@ public sealed class UiSessionBroker : IUiSessionBroker, IDisposable
 		public bool ResyncRequested { get; set; }
 
 		public TaskCompletionSource<UiSessionOpenTicket> Ready { get; } =
+			new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		public TaskCompletionSource<UiRawJson?> FirstTree { get; } =
 			new(TaskCreationOptions.RunContinuationsAsynchronously);
 	}
 }

--- a/host/src/MacroDeckHost.Application/Ui/Sessions/UiSessionRegistry.cs
+++ b/host/src/MacroDeckHost.Application/Ui/Sessions/UiSessionRegistry.cs
@@ -597,6 +597,7 @@ public sealed class UiSessionRegistry : IDisposable
 
 			unattached = _bySessionId.Values
 				.Where(record => !record.EverAttached &&
+					!record.HeldByHost &&
 					!IsTerminal(record) &&
 					now - record.CreatedAt >= _attachGrace)
 				.Select(record => record.SessionId)
@@ -778,6 +779,7 @@ public sealed class UiSessionRegistry : IDisposable
 		{
 			if (!_bySessionId.TryGetValue(sessionId, out var record) ||
 				record.EverAttached ||
+				record.HeldByHost ||
 				IsTerminal(record))
 			{
 				return;
@@ -795,6 +797,26 @@ public sealed class UiSessionRegistry : IDisposable
 				Reason = UiSessionEndReason.Drained,
 				Message = "No client attached within the grace window."
 			});
+	}
+
+	// A session the host reads itself has no client to wait for, and lives until the host closes it.
+	public bool HoldForHost(string sessionId)
+	{
+		lock (_gate)
+		{
+			if (!_bySessionId.TryGetValue(sessionId, out var record) || IsTerminal(record))
+			{
+				return false;
+			}
+
+			record.HeldByHost = true;
+			if (!record.EverAttached)
+			{
+				DisarmDrain(record);
+			}
+
+			return true;
+		}
 	}
 
 	private sealed class AttachDeadlineCallback
@@ -858,6 +880,8 @@ public sealed class UiSessionRegistry : IDisposable
 		public DateTimeOffset? DetachedAt { get; set; }
 
 		public bool EverAttached { get; set; }
+
+		public bool HeldByHost { get; set; }
 
 		public ITimer? DrainTimer { get; set; }
 	}

--- a/host/tests/MacroDeckHost.Tests.PluginContractTests/DeviceSessionParityContractTests.cs
+++ b/host/tests/MacroDeckHost.Tests.PluginContractTests/DeviceSessionParityContractTests.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using MacroDeck.Plugin.Hosting.Capabilities.DeviceProvider;
+using MacroDeckHost.Application.Ui.Sessions;
 using MacroDeck.Plugin.Protocol.Capabilities;
 using MacroDeck.Plugin.Protocol.Handshake;
 using MacroDeck.Plugin.Protocol.Versioning;
@@ -144,9 +146,69 @@ internal sealed class DeviceSessionParityContractTests : CapabilityContractFixtu
 		using var providers = new RemoteDeviceProviderRegistry(SessionRegistry, Invoker, sessionOwners);
 		using var world = new DeviceSurfaceWorld(providers.Resolve(PluginId)!, PluginId);
 		_world = world;
+		router = CreateRouter(world, sessionOwners);
 
+		var deviceId = await world.RegisterAndOpenAsync(ProviderDeviceId);
+
+		Assert.That(await RunAsync(world, provider, deviceId), Is.EqualTo(_expectedObservations));
+	}
+
+	[Test]
+	public async Task A_whole_press_on_a_plugin_served_tile_is_accepted_across_the_wire_while_its_tree_is_pending()
+	{
+		var provider = new WalkthroughProvider();
+		var sessionOwners = new RemoteDeviceSessionRegistry();
+
+		PluginCallbackRouter? router = null;
+		HostInvokeHandler = (_, payload, cancellationToken)
+			=> router!.RouteAsync(PluginId, Guid.NewGuid().ToString(), payload, cancellationToken);
+
+		await ConnectAsync([
+				new DeviceProviderCapabilityHandler([provider],
+					TestMetadata.Default,
+					CreatePluginHostInvoker(),
+					PluginHostAssets)
+			],
+			[Provider()],
+			[CapabilityKinds.DeviceProvider],
+			negotiatedCapabilityVersion: 2);
+
+		var tree = new PendingTreeUiSessionBroker();
+		using var providers = new RemoteDeviceProviderRegistry(SessionRegistry, Invoker, sessionOwners);
+		using var world = new DeviceSurfaceWorld(providers.Resolve(PluginId)!,
+			PluginId,
+			services =>
+			{
+				services.AddSingleton<IUiSessionBroker>(tree);
+				services.AddSingleton<IWidgetUiSessionOpener>(new AcceptingWidgetUiSessionOpener());
+			});
+		_world = world;
+		world.Profiles.GetFoldersForProfile(ContractDeck.ProfileId)
+			.Single(folder => folder.Id == ContractDeck.FolderId)
+			.Widgets.Single().Type = "com.example.contract.meter";
+		router = CreateRouter(world, sessionOwners);
+
+		await world.RegisterAndOpenAsync(ProviderDeviceId);
+		await WaitForAsync(() => provider.Surfaces.Count == 1, "the provider never received its first surface");
+
+		var result = await provider.SendAsync(DeviceInteractionKind.ShortPress, ContractDeck.WidgetId.ToString());
+		var ranBeforeTheTree = world.Triggers.Requests.Count;
+		tree.Tree.SetResult(new UiRawJson(Encoding.UTF8.GetBytes(
+			"""{"revision":1,"surface":{"kind":"widget"},"root":{"id":"label","type":"ui.text"}}""")));
+		await WaitForAsync(() => world.Triggers.Requests.Count == 1, "the queued press never ran the tile's flow");
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(result.Status, Is.EqualTo(DeviceInteractionStatus.Accepted));
+			Assert.That(ranBeforeTheTree, Is.Zero);
+			Assert.That(world.Triggers.Requests.Single().TriggerType, Is.EqualTo("onShortPress"));
+		});
+	}
+
+	private PluginCallbackRouter CreateRouter(DeviceSurfaceWorld world, RemoteDeviceSessionRegistry sessionOwners)
+	{
 		var services = new ServiceCollection().BuildServiceProvider();
-		router = new PluginCallbackRouter(SessionRegistry,
+		return new PluginCallbackRouter(SessionRegistry,
 			Invoker,
 			services.GetRequiredService<IServiceScopeFactory>(),
 			Notifications,
@@ -169,10 +231,6 @@ internal sealed class DeviceSessionParityContractTests : CapabilityContractFixtu
 			world.Service,
 			sessionOwners,
 			HostAssetSender);
-
-		var deviceId = await world.RegisterAndOpenAsync(ProviderDeviceId);
-
-		Assert.That(await RunAsync(world, provider, deviceId), Is.EqualTo(_expectedObservations));
 	}
 
 	private DeviceSurfaceWorld? _world;

--- a/host/tests/MacroDeckHost.Tests.PluginContractTests/Harness/DeviceSurfaceWorld.cs
+++ b/host/tests/MacroDeckHost.Tests.PluginContractTests/Harness/DeviceSurfaceWorld.cs
@@ -24,7 +24,10 @@ internal sealed class DeviceSurfaceWorld : IDisposable
 {
 	private readonly ServiceProvider _services;
 
-	public DeviceSurfaceWorld(IDeviceSurfaceProvider provider, string providerId)
+	public DeviceSurfaceWorld(
+		IDeviceSurfaceProvider provider,
+		string providerId,
+		Action<IServiceCollection>? configure = null)
 	{
 		Provider = provider;
 		ProviderId = providerId;
@@ -43,6 +46,7 @@ internal sealed class DeviceSurfaceWorld : IDisposable
 		services
 			.AddSingleton<IUiTransportMessageHandler<ExecuteActionButtonTriggerRequest,
 				ExecuteActionButtonTriggerResponse>>(Triggers);
+		configure?.Invoke(services);
 		_services = services.BuildServiceProvider();
 
 		var scopeFactory = _services.GetRequiredService<IServiceScopeFactory>();
@@ -50,7 +54,7 @@ internal sealed class DeviceSurfaceWorld : IDisposable
 			new SingleProviderResolver(provider, providerId),
 			Profiles,
 			Presence,
-			new DeviceInteractionRouter(scopeFactory, new CallbackFakeHostLockState(), Serilog.Core.Logger.None),
+			new DeviceInteractionRouter(scopeFactory, new CallbackFakeHostLockState(), Time, Serilog.Core.Logger.None),
 			new NoFocusRules(),
 			new NoEventBus(),
 			new WidgetStateSubscriptionTracker(),

--- a/host/tests/MacroDeckHost.Tests.PluginContractTests/Harness/DeviceTileTreeDoubles.cs
+++ b/host/tests/MacroDeckHost.Tests.PluginContractTests/Harness/DeviceTileTreeDoubles.cs
@@ -1,0 +1,70 @@
+using MacroDeck.Ui.Model.Surfaces;
+using MacroDeckHost.Application.Ui.Sessions;
+using MacroDeckHost.Application.Ui.Transport.Messages.UiSessions;
+
+namespace MacroDeckHost.Tests.PluginContractTests.Harness;
+
+internal sealed class AcceptingWidgetUiSessionOpener : IWidgetUiSessionOpener
+{
+	public UiSessionOpenTicket Open(OpenWidgetUiSessionRequest request, string ownerPrincipal, bool isAdmin)
+		=> UiSessionOpenTicket.Opened($"tile-tree-{request.WidgetId}");
+}
+
+internal sealed class PendingTreeUiSessionBroker : IUiSessionBroker
+{
+	public TaskCompletionSource<UiRawJson?> Tree { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+	public async Task<UiRawJson?> FirstTreeAsync(string sessionId, CancellationToken cancellationToken)
+		=> await Tree.Task.WaitAsync(cancellationToken);
+
+	public bool DispatchHostEvent(string sessionId, UiSessionEventCommand command) => true;
+
+	public UiSessionOpenTicket Open(string providerId, UiSurface surface, string ownerPrincipal)
+		=> UiSessionOpenTicket.Rejected("not_supported", "not supported in this double");
+
+	public Task<UiSessionOpenTicket> OpenAsync(string providerId,
+		UiSurface surface,
+		string ownerPrincipal,
+		CancellationToken cancellationToken)
+		=> Task.FromResult(Open(providerId, surface, ownerPrincipal));
+
+	public Task CloseAsync(string sessionId, string reason, CancellationToken cancellationToken) => Task.CompletedTask;
+
+	public void InvalidateWidgetSessions(Guid widgetId)
+	{
+	}
+
+	public void CloseWidgetSessions(Guid widgetId, string reason)
+	{
+	}
+
+	public bool CloseOwned(string? sessionId, string principal, string reason) => false;
+
+	public UiAttachSessionResponse Attach(string? sessionId, string connectionId, string principal)
+		=> new() { Accepted = false, SessionId = string.Empty, Code = "not_supported", Message = null };
+
+	public void Detach(string? sessionId, string connectionId)
+	{
+	}
+
+	public void DetachConnection(string connectionId)
+	{
+	}
+
+	public UiSendEventResponse SendEvent(UiSendEventRequest request, string connectionId, string? actingClientId = null)
+		=> new() { Accepted = false, Code = "not_supported", Message = null };
+
+	public void SweepDraining()
+	{
+	}
+
+	public UiSessionIngestResult PublishSnapshot(string providerId, string sessionId, UiRawJson tree)
+		=> new() { Accepted = false, Code = "not_supported", Message = null };
+
+	public UiSessionIngestResult PublishPatch(string providerId, string sessionId, UiRawJson patch)
+		=> new() { Accepted = false, Code = "not_supported", Message = null };
+
+	public void PublishFault(string providerId, string sessionId, string code, string? message)
+	{
+	}
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Devices/Surfaces/DeviceSurfaceFixture.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Devices/Surfaces/DeviceSurfaceFixture.cs
@@ -9,6 +9,8 @@ using MacroDeckHost.Application.Persistence.Repositories;
 using MacroDeckHost.Application.Profiles;
 using MacroDeckHost.Application.Rendering;
 using MacroDeckHost.Application.Ui.Resources;
+using MacroDeckHost.Application.Ui.Sessions;
+using MacroDeckHost.Application.Ui.Transport.Messages.UiSessions;
 using MacroDeckHost.Application.Ui.Transport;
 using MacroDeckHost.Application.Ui.Transport.Messages.Actions;
 using MacroDeckHost.Application.Ui.Transport.Messages.Folders;
@@ -86,6 +88,8 @@ internal sealed class DeviceSurfaceFixture : IDisposable
 		services
 			.AddSingleton<IUiTransportMessageHandler<ExecuteActionButtonTriggerRequest,
 				ExecuteActionButtonTriggerResponse>>(Triggers);
+		services.AddSingleton<IUiSessionBroker>(UiBroker);
+		services.AddSingleton<IWidgetUiSessionOpener>(UiOpener);
 		_services = services.BuildServiceProvider();
 
 		var scopeFactory = _services.GetRequiredService<IServiceScopeFactory>();
@@ -93,7 +97,7 @@ internal sealed class DeviceSurfaceFixture : IDisposable
 			new SingleProviderResolver(Provider),
 			Profiles,
 			Presence,
-			new DeviceInteractionRouter(scopeFactory, LockState, Serilog.Core.Logger.None),
+			new DeviceInteractionRouter(scopeFactory, LockState, Time, Serilog.Core.Logger.None),
 			Focus,
 			Bus,
 			new WidgetStateSubscriptionTracker(),
@@ -129,6 +133,10 @@ internal sealed class DeviceSurfaceFixture : IDisposable
 	public RecordingEventBus Bus { get; }
 
 	public FakeHostLockState LockState { get; }
+
+	public RecordingUiSessionBroker UiBroker { get; } = new();
+
+	public RecordingWidgetUiSessionOpener UiOpener { get; } = new();
 
 	public DeviceSurfaceService Service { get; }
 
@@ -424,6 +432,21 @@ internal sealed class RecordingSurfaceProvider : IDeviceSurfaceProvider
 	{
 		Closes.Add((deviceId, reason));
 		return Task.CompletedTask;
+	}
+}
+
+internal sealed class RecordingWidgetUiSessionOpener : IWidgetUiSessionOpener
+{
+	public List<string?> OpenedWidgetIds { get; } = [];
+
+	public string? RefusalCode { get; set; }
+
+	public UiSessionOpenTicket Open(OpenWidgetUiSessionRequest request, string ownerPrincipal, bool isAdmin)
+	{
+		OpenedWidgetIds.Add(request.WidgetId);
+		return RefusalCode is { } code
+			? UiSessionOpenTicket.Rejected(code, "refused by the test")
+			: UiSessionOpenTicket.Opened($"session-{OpenedWidgetIds.Count}");
 	}
 }
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Devices/Surfaces/DeviceTileTreeClaimTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Devices/Surfaces/DeviceTileTreeClaimTests.cs
@@ -13,11 +13,11 @@ internal sealed class DeviceTileTreeClaimTests
 	private const string ActionButtonId = "action-button";
 
 	private const string ClaimingTree = """
-		{"id":"root","type":"ui.stack","children":[
-			{"id":"label","type":"ui.text"},
-			{"id":"mute","type":"ui.button","properties":{"events":["press","long-press","press-start","press-end"]}},
-			{"id":"solo","type":"ui.stack","properties":{"modifiers":{"disabled":true}}}]}
-		""";
+										{"id":"root","type":"ui.stack","children":[
+											{"id":"label","type":"ui.text"},
+											{"id":"mute","type":"ui.button","properties":{"events":["press","long-press","press-start","press-end"]}},
+											{"id":"solo","type":"ui.stack","properties":{"modifiers":{"disabled":true}}}]}
+										""";
 
 	private static readonly string[] _shortPressTriggers = ["onTouchStart", "onTouchEnd", "onShortPress"];
 
@@ -74,10 +74,10 @@ internal sealed class DeviceTileTreeClaimTests
 	public async Task A_disabled_region_absorbs_the_whole_press_so_neither_the_control_nor_the_tiles_flow_runs()
 	{
 		TreeIs("""
-			{"id":"root","type":"ui.stack","children":[
-				{"id":"controls","type":"ui.stack","properties":{"modifiers":{"disabled":true}},"children":[
-					{"id":"mute","type":"ui.button","properties":{"events":["press"]}}]}]}
-			""");
+			   {"id":"root","type":"ui.stack","children":[
+			   	{"id":"controls","type":"ui.stack","properties":{"modifiers":{"disabled":true}},"children":[
+			   		{"id":"mute","type":"ui.button","properties":{"events":["press"]}}]}]}
+			   """);
 
 		await HoldAsync(200);
 
@@ -100,7 +100,8 @@ internal sealed class DeviceTileTreeClaimTests
 		{
 			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
 			Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "press-end", "press" }));
-			Assert.That(_fixture.UiBroker.HostEvents.Select(sent => (sent.SessionId, sent.Command.NodeId, sent.Command.Revision)).Distinct(),
+			Assert.That(_fixture.UiBroker.HostEvents
+					.Select(sent => (sent.SessionId, sent.Command.NodeId, sent.Command.Revision)).Distinct(),
 				Is.EqualTo(new[] { ("session-1", "mute", (int?)7) }));
 			Assert.That(_fixture.UiOpener.OpenedWidgetIds, Has.Count.EqualTo(1));
 			Assert.That(_fixture.UiBroker.ClosedSessions, Is.EqualTo(new[] { "session-1" }));
@@ -187,9 +188,9 @@ internal sealed class DeviceTileTreeClaimTests
 	public async Task A_segment_of_a_segmented_control_that_claims_nothing_does_not_claim_the_press()
 	{
 		TreeIs("""
-			{"id":"picker","type":"ui.segmented","children":[
-				{"id":"day","type":"ui.stack","properties":{"events":["press"]}}]}
-			""");
+			   {"id":"picker","type":"ui.segmented","children":[
+			   	{"id":"day","type":"ui.stack","properties":{"events":["press"]}}]}
+			   """);
 
 		await HoldAsync(200);
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Devices/Surfaces/DeviceTileTreeClaimTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Devices/Surfaces/DeviceTileTreeClaimTests.cs
@@ -1,0 +1,341 @@
+using System.Text;
+using System.Text.Json;
+using MacroDeck.Sdk.Devices;
+using MacroDeckHost.Application.Devices.Surfaces;
+using MacroDeckHost.Application.Ui.Sessions;
+
+namespace MacroDeckHost.Tests.UnitTests.Devices.Surfaces;
+
+[TestFixture]
+internal sealed class DeviceTileTreeClaimTests
+{
+	private const string PluginTileId = "plugin-tile";
+	private const string ActionButtonId = "action-button";
+
+	private const string ClaimingTree = """
+		{"id":"root","type":"ui.stack","children":[
+			{"id":"label","type":"ui.text"},
+			{"id":"mute","type":"ui.button","properties":{"events":["press","long-press","press-start","press-end"]}},
+			{"id":"solo","type":"ui.stack","properties":{"modifiers":{"disabled":true}}}]}
+		""";
+
+	private static readonly string[] _shortPressTriggers = ["onTouchStart", "onTouchEnd", "onShortPress"];
+
+	private DeviceSurfaceFixture _fixture = null!;
+	private Guid _deviceId;
+
+	[SetUp]
+	public async Task SetUp()
+	{
+		_fixture = new DeviceSurfaceFixture();
+		var pluginTile = DeviceSurfaceFixture.Button(PluginTileId, 0, 0);
+		pluginTile.Type = "com.example.mixer.channel";
+		_fixture.Home.Widgets.AddRange([pluginTile, DeviceSurfaceFixture.Button(ActionButtonId, 1, 0)]);
+		_deviceId = await _fixture.OpenDeviceAsync();
+	}
+
+	[TearDown]
+	public void TearDown() => _fixture.Dispose();
+
+	private void TreeIs(string root)
+		=> _fixture.UiBroker.Tree = new UiRawJson(Encoding.UTF8.GetBytes(
+			$$"""{"revision":7,"surface":{"kind":"widget"},"root":{{root}}}"""));
+
+	private Task<DeviceInteractionOutcome> SubmitAsync(DeviceInteractionKind kind, string widgetId = PluginTileId)
+		=> _fixture.Service.SubmitInteractionAsync(_deviceId,
+			new DeviceInteraction { Kind = kind, Target = new DeviceInteractionTarget { WidgetId = widgetId } });
+
+	private async Task HoldAsync(int milliseconds, string widgetId = PluginTileId)
+	{
+		var press = SubmitAsync(DeviceInteractionKind.Press, widgetId);
+		_fixture.Time.Advance(TimeSpan.FromMilliseconds(milliseconds));
+		await DeviceSurfaceFixture.DrainAsync();
+		await press;
+		await SubmitAsync(DeviceInteractionKind.Release, widgetId);
+		await DeviceSurfaceFixture.DrainAsync();
+	}
+
+	private string[] SentEvents => [.. _fixture.UiBroker.HostEvents.Select(sent => sent.Command.Name)];
+
+	private static UiRawJson Snapshot(string root)
+		=> new(Encoding.UTF8.GetBytes($$"""{"revision":7,"surface":{"kind":"widget"},"root":{{root}}}"""));
+
+	private async Task PressSettledAsync()
+	{
+		for (var attempt = 0; attempt < 500 && _fixture.UiBroker.ClosedSessions.Count == 0; attempt++)
+		{
+			await Task.Delay(10);
+		}
+
+		await DeviceSurfaceFixture.DrainAsync();
+	}
+
+	[Test]
+	public async Task A_disabled_region_absorbs_the_whole_press_so_neither_the_control_nor_the_tiles_flow_runs()
+	{
+		TreeIs("""
+			{"id":"root","type":"ui.stack","children":[
+				{"id":"controls","type":"ui.stack","properties":{"modifiers":{"disabled":true}},"children":[
+					{"id":"mute","type":"ui.button","properties":{"events":["press"]}}]}]}
+			""");
+
+		await HoldAsync(200);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+			Assert.That(_fixture.UiBroker.HostEvents, Is.Empty);
+			Assert.That(_fixture.UiBroker.ClosedSessions, Has.Count.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public async Task A_claiming_control_receives_every_phase_of_one_press_in_one_session()
+	{
+		TreeIs(ClaimingTree);
+
+		await HoldAsync(200);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+			Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "press-end", "press" }));
+			Assert.That(_fixture.UiBroker.HostEvents.Select(sent => (sent.SessionId, sent.Command.NodeId, sent.Command.Revision)).Distinct(),
+				Is.EqualTo(new[] { ("session-1", "mute", (int?)7) }));
+			Assert.That(_fixture.UiOpener.OpenedWidgetIds, Has.Count.EqualTo(1));
+			Assert.That(_fixture.UiBroker.ClosedSessions, Is.EqualTo(new[] { "session-1" }));
+		});
+	}
+
+	[Test]
+	public async Task A_held_press_sends_the_claiming_control_a_long_press_instead_of_a_press()
+	{
+		TreeIs(ClaimingTree);
+
+		await HoldAsync(700);
+
+		Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "long-press", "press-end" }));
+	}
+
+	[Test]
+	public async Task A_tree_that_does_not_answer_within_a_second_absorbs_the_press()
+	{
+		await HoldAsync(1000);
+		await PressSettledAsync();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+			Assert.That(_fixture.UiBroker.ClosedSessions, Has.Count.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public async Task A_plugin_that_is_not_running_leaves_the_press_to_the_tiles_flow()
+	{
+		_fixture.UiOpener.RefusalCode = UiSessionErrorCodes.ProviderUnavailable;
+
+		await HoldAsync(200);
+
+		Assert.That(_fixture.Triggers.TriggerTypes, Is.EqualTo(_shortPressTriggers));
+	}
+
+	[Test]
+	public async Task A_tree_session_the_host_cannot_open_absorbs_the_press()
+	{
+		_fixture.UiOpener.RefusalCode = UiSessionErrorCodes.TooManySessions;
+
+		await HoldAsync(200);
+
+		Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+	}
+
+	[Test]
+	public async Task A_whole_press_queued_behind_its_tree_runs_nothing_once_the_host_locks()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		await SubmitAsync(DeviceInteractionKind.ShortPress).WaitAsync(TimeSpan.FromSeconds(5));
+		_fixture.LockState.IsLocked = true;
+		_fixture.UiBroker.PendingTree.SetResult(Snapshot("""{"id":"label","type":"ui.text"}"""));
+		await PressSettledAsync();
+
+		Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+	}
+
+	[Test]
+	public async Task A_claiming_control_receives_nothing_while_the_host_is_locked()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		await SubmitAsync(DeviceInteractionKind.Press).WaitAsync(TimeSpan.FromSeconds(5));
+		_fixture.LockState.IsLocked = true;
+		_fixture.UiBroker.PendingTree.SetResult(Snapshot(ClaimingTree));
+		_fixture.Time.Advance(TimeSpan.FromMilliseconds(700));
+		await DeviceSurfaceFixture.DrainAsync();
+		await _fixture.ChangeToAsync(_deviceId, DeviceSurfaceFixture.LightsFolderId);
+		await PressSettledAsync();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.UiBroker.HostEvents, Is.Empty);
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+		});
+	}
+
+	[Test]
+	public async Task A_segment_of_a_segmented_control_that_claims_nothing_does_not_claim_the_press()
+	{
+		TreeIs("""
+			{"id":"picker","type":"ui.segmented","children":[
+				{"id":"day","type":"ui.stack","properties":{"events":["press"]}}]}
+			""");
+
+		await HoldAsync(200);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.EqualTo(_shortPressTriggers));
+			Assert.That(_fixture.UiBroker.HostEvents, Is.Empty);
+		});
+	}
+
+	[Test]
+	public async Task A_tree_that_claims_nothing_leaves_the_press_to_the_tiles_flow()
+	{
+		TreeIs("""{"id":"root","type":"ui.stack","children":[{"id":"label","type":"ui.text"}]}""");
+
+		await HoldAsync(200);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.EqualTo(_shortPressTriggers));
+			Assert.That(_fixture.UiBroker.HostEvents, Is.Empty);
+			Assert.That(_fixture.UiBroker.ClosedSessions, Has.Count.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public async Task A_press_report_does_not_wait_for_the_tiles_tree_so_the_tree_can_arrive_behind_it()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		await SubmitAsync(DeviceInteractionKind.Press).WaitAsync(TimeSpan.FromSeconds(5));
+		_fixture.UiBroker.PendingTree.SetResult(Snapshot(ClaimingTree));
+		await DeviceSurfaceFixture.DrainAsync();
+		await SubmitAsync(DeviceInteractionKind.Release);
+		await PressSettledAsync();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "press-end", "press" }));
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+		});
+	}
+
+	[Test]
+	public async Task A_release_reported_before_the_tree_arrives_keeps_the_phases_in_order()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		await SubmitAsync(DeviceInteractionKind.Press).WaitAsync(TimeSpan.FromSeconds(5));
+		await SubmitAsync(DeviceInteractionKind.Release).WaitAsync(TimeSpan.FromSeconds(5));
+		_fixture.UiBroker.PendingTree.SetResult(Snapshot(ClaimingTree));
+		await PressSettledAsync();
+
+		Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "press-end", "press" }));
+	}
+
+	[Test]
+	public async Task A_long_press_reached_while_the_tree_is_pending_still_follows_the_touch_start()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		await SubmitAsync(DeviceInteractionKind.Press).WaitAsync(TimeSpan.FromSeconds(5));
+		_fixture.Time.Advance(TimeSpan.FromMilliseconds(700));
+		await DeviceSurfaceFixture.DrainAsync();
+		_fixture.UiBroker.PendingTree.SetResult(Snapshot(ClaimingTree));
+		await SubmitAsync(DeviceInteractionKind.Release);
+		await PressSettledAsync();
+
+		Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "long-press", "press-end" }));
+	}
+
+	[Test]
+	public async Task Navigating_away_while_the_tree_is_pending_neither_waits_for_it_nor_runs_the_flow()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		await SubmitAsync(DeviceInteractionKind.Press).WaitAsync(TimeSpan.FromSeconds(5));
+		await _fixture.ChangeToAsync(_deviceId, DeviceSurfaceFixture.LightsFolderId).WaitAsync(TimeSpan.FromSeconds(5));
+		_fixture.Time.Advance(TimeSpan.FromSeconds(1));
+		await PressSettledAsync();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+			Assert.That(_fixture.UiBroker.ClosedSessions, Has.Count.EqualTo(1));
+		});
+	}
+
+	[Test]
+	public async Task A_repeated_press_report_opens_one_tree_session()
+	{
+		TreeIs(ClaimingTree);
+
+		await SubmitAsync(DeviceInteractionKind.Press);
+		await HoldAsync(200);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.UiOpener.OpenedWidgetIds, Has.Count.EqualTo(1));
+			Assert.That(SentEvents, Is.EqualTo(new[] { "press-start", "press-end", "press" }));
+		});
+	}
+
+	[Test]
+	public async Task A_whole_press_report_on_a_tree_still_pending_is_accepted_as_queued_and_its_flow_runs_later()
+	{
+		_fixture.UiBroker.PendingTree = new TaskCompletionSource<UiRawJson?>();
+
+		var outcome = await SubmitAsync(DeviceInteractionKind.ShortPress).WaitAsync(TimeSpan.FromSeconds(5));
+		var ranBeforeTheTree = _fixture.Triggers.TriggerTypes;
+		_fixture.UiBroker.PendingTree.SetResult(Snapshot("""{"id":"label","type":"ui.text"}"""));
+		await PressSettledAsync();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(outcome, Is.EqualTo(DeviceInteractionOutcome.Accepted));
+			Assert.That(ranBeforeTheTree, Is.Empty);
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.EqualTo(new[] { "onShortPress" }));
+		});
+	}
+
+	[Test]
+	public async Task A_whole_press_reported_at_once_flips_a_claiming_toggle()
+	{
+		TreeIs("""{"id":"power","type":"ui.toggle","properties":{"on":true,"events":["change"]}}""");
+
+		await SubmitAsync(DeviceInteractionKind.ShortPress);
+
+		var sent = _fixture.UiBroker.HostEvents.Single().Command;
+		Assert.Multiple(() =>
+		{
+			Assert.That(sent.Name, Is.EqualTo("change"));
+			Assert.That(JsonDocument.Parse(sent.Data.Utf8).RootElement.GetBoolean(), Is.False);
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.Empty);
+		});
+	}
+
+	[Test]
+	public async Task A_built_in_tile_runs_its_flow_without_opening_a_tree()
+	{
+		await HoldAsync(200, ActionButtonId);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(_fixture.Triggers.TriggerTypes, Is.EqualTo(_shortPressTriggers));
+			Assert.That(_fixture.UiOpener.OpenedWidgetIds, Is.Empty);
+		});
+	}
+}

--- a/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/RecordingUiSessionBroker.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/TestSupport/RecordingUiSessionBroker.cs
@@ -25,8 +25,41 @@ internal sealed class RecordingUiSessionBroker : IUiSessionBroker
 
 	public void CloseWidgetSessions(Guid widgetId, string reason) => ClosedWidgets.Add(widgetId);
 
+	public UiRawJson? Tree { get; set; }
+
+	public TaskCompletionSource<UiRawJson?>? PendingTree { get; set; }
+
+	public List<(string SessionId, UiSessionEventCommand Command)> HostEvents { get; } = [];
+
+	public List<string> ClosedSessions { get; } = [];
+
+	public async Task<UiRawJson?> FirstTreeAsync(string sessionId, CancellationToken cancellationToken)
+	{
+		if (Tree is { } tree)
+		{
+			return tree;
+		}
+
+		if (PendingTree is { } pending)
+		{
+			return await pending.Task.WaitAsync(cancellationToken);
+		}
+
+		await Task.Delay(Timeout.Infinite, cancellationToken);
+		return null;
+	}
+
+	public bool DispatchHostEvent(string sessionId, UiSessionEventCommand command)
+	{
+		HostEvents.Add((sessionId, command));
+		return true;
+	}
+
 	public Task CloseAsync(string sessionId, string reason, CancellationToken cancellationToken)
-		=> Task.CompletedTask;
+	{
+		ClosedSessions.Add(sessionId);
+		return Task.CompletedTask;
+	}
 
 	public bool CloseOwned(string? sessionId, string principal, string reason) => false;
 

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Ui/Sessions/InProcessUiSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Ui/Sessions/InProcessUiSessionTests.cs
@@ -66,7 +66,8 @@ internal sealed class InProcessUiSessionTests : UiSessionFixture
 		var sessionId = await OpenAsync(ProviderId);
 
 		var tree = await Broker.FirstTreeAsync(sessionId, CancellationToken.None);
-		var dispatched = Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press" });
+		var dispatched
+			= Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press" });
 		await Broker.CloseAsync(sessionId, "done", CancellationToken.None);
 		await WaitForAsync(() => session.DisposeCalls == 1, "Closing never reached the provider.");
 		await SettleAsync();
@@ -77,8 +78,11 @@ internal sealed class InProcessUiSessionTests : UiSessionFixture
 			Assert.That(JsonDocument.Parse(tree!.Value.Utf8).RootElement.GetProperty("revision").GetInt32(),
 				Is.EqualTo(3));
 			Assert.That(dispatched, Is.True);
-			Assert.That(session.Dispatched.Single().Name, Is.EqualTo("press"), "An event raised just before closing was lost.");
-			Assert.That(Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press" }),
+			Assert.That(session.Dispatched.Single().Name,
+				Is.EqualTo("press"),
+				"An event raised just before closing was lost.");
+			Assert.That(Broker.DispatchHostEvent(sessionId,
+					new UiSessionEventCommand { NodeId = "root", Name = "press" }),
 				Is.False,
 				"An ended session still accepted a host event.");
 		});
@@ -95,7 +99,8 @@ internal sealed class InProcessUiSessionTests : UiSessionFixture
 		Registry.SweepDraining();
 		await SettleAsync();
 
-		var dispatched = Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press-end" });
+		var dispatched
+			= Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press-end" });
 		await WaitForAsync(() => session.Dispatched.Count == 1, "A held press lost its closing event.");
 		await Broker.CloseAsync(sessionId, "done", CancellationToken.None);
 		await WaitForAsync(() => session.DisposeCalls == 1, "Closing never reached the provider.");

--- a/host/tests/MacroDeckHost.Tests.UnitTests/Ui/Sessions/InProcessUiSessionTests.cs
+++ b/host/tests/MacroDeckHost.Tests.UnitTests/Ui/Sessions/InProcessUiSessionTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using MacroDeck.Ui.Model.Nodes;
 using MacroDeck.Ui.Model.Patches;
 using MacroDeck.Ui.Model.Serialization;
@@ -56,6 +57,50 @@ internal sealed class InProcessUiSessionTests : UiSessionFixture
 			Assert.That(Invoker.Invocations, Is.Empty, "An in-process session produced capability.invoke traffic.");
 			Assert.That(MessagesFor<UiSessionInvalidatedEvent>("c1"), Is.Empty);
 		});
+	}
+
+	[Test]
+	public async Task A_host_reader_gets_the_opening_tree_and_raises_an_event_without_attaching()
+	{
+		var session = AddInProcessProvider(() => TreeAt(3));
+		var sessionId = await OpenAsync(ProviderId);
+
+		var tree = await Broker.FirstTreeAsync(sessionId, CancellationToken.None);
+		var dispatched = Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press" });
+		await Broker.CloseAsync(sessionId, "done", CancellationToken.None);
+		await WaitForAsync(() => session.DisposeCalls == 1, "Closing never reached the provider.");
+		await SettleAsync();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(tree, Is.Not.Null);
+			Assert.That(JsonDocument.Parse(tree!.Value.Utf8).RootElement.GetProperty("revision").GetInt32(),
+				Is.EqualTo(3));
+			Assert.That(dispatched, Is.True);
+			Assert.That(session.Dispatched.Single().Name, Is.EqualTo("press"), "An event raised just before closing was lost.");
+			Assert.That(Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press" }),
+				Is.False,
+				"An ended session still accepted a host event.");
+		});
+	}
+
+	[Test]
+	public async Task A_session_the_host_reads_outlives_the_attach_grace_until_the_host_closes_it()
+	{
+		var session = AddInProcessProvider(() => TreeAt(1));
+		var sessionId = await OpenAsync(ProviderId);
+		await Broker.FirstTreeAsync(sessionId, CancellationToken.None);
+
+		Time.Advance(TimeSpan.FromMinutes(2));
+		Registry.SweepDraining();
+		await SettleAsync();
+
+		var dispatched = Broker.DispatchHostEvent(sessionId, new UiSessionEventCommand { NodeId = "root", Name = "press-end" });
+		await WaitForAsync(() => session.Dispatched.Count == 1, "A held press lost its closing event.");
+		await Broker.CloseAsync(sessionId, "done", CancellationToken.None);
+		await WaitForAsync(() => session.DisposeCalls == 1, "Closing never reached the provider.");
+
+		Assert.That(dispatched, Is.True);
 	}
 
 	[Test]

--- a/sdk/src/MacroDeck.Sdk/Devices/DeviceInteractionStatus.cs
+++ b/sdk/src/MacroDeck.Sdk/Devices/DeviceInteractionStatus.cs
@@ -3,7 +3,9 @@ namespace MacroDeck.Sdk.Devices;
 /// <summary>What the host did with an interaction a provider reported.</summary>
 public enum DeviceInteractionStatus
 {
-	/// <summary>The host resolved the interaction and ran whatever it maps to.</summary>
+	/// <summary>The host resolved the interaction and ran whatever it maps to, or queued it behind the
+	/// UI tree of a tile a plugin or integration serves - see
+	/// <see cref="IDeviceSession.SendInteractionAsync" />.</summary>
 	Accepted,
 
 	/// <summary>

--- a/sdk/src/MacroDeck.Sdk/Devices/IDeviceSession.cs
+++ b/sdk/src/MacroDeck.Sdk/Devices/IDeviceSession.cs
@@ -38,7 +38,10 @@ public interface IDeviceSession : IAsyncDisposable
 	/// The host's verdict. A <see cref="DeviceInteractionStatus.Rejected" /> result - a stale widget id -
 	/// and a <see cref="DeviceInteractionStatus.NotSupported" /> one - a kind with no widget model yet -
 	/// are both normal outcomes rather than failures: nothing ran, the session stays open, and the next
-	/// valid interaction still works.
+	/// valid interaction still works. A whole press (<see cref="DeviceInteractionKind.ShortPress" /> or
+	/// <see cref="DeviceInteractionKind.LongPress" />) on a tile a plugin or integration serves may be
+	/// answered <see cref="DeviceInteractionStatus.Accepted" /> while it is still queued behind that
+	/// tile's UI tree, so a failure of the flow it runs afterwards is not reported here.
 	/// </returns>
 	Task<DeviceInteractionResult> SendInteractionAsync(
 		DeviceInteraction interaction,


### PR DESCRIPTION
Follow-up to #776 (no separate issue).

## Summary
A hardware press on a tile a plugin or integration serves now answers to the tile's UI tree, as on screen:
a disabled region absorbs it, and a control declaring the press receives it instead of the tile's flows.

## Testing
All suites pass after a -warnaserror build (bar the Plugin.Cli build test, red locally on main too); no real hardware.

## Plugin SDK / API compatibility
Agreed behaviour change, no shape change: a ShortPress or LongPress on such a tile whose tree has not
answered yet returns Accepted as queued. Documented in devices.md and IDeviceSession.
- [x] No public, non-obsolete SDK or plugin protocol contract was removed or changed
- [x] Any intentional break was explicitly agreed beforehand and is described below

## Checklist
- [x] Tests were added or updated where needed
- [ ] The change was verified manually where appropriate
- [x] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
