### PR TITLE
Keep widget editor tab state when saving

### DIFF
--- a/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/widget-configuration-editor/widget-configuration-editor.component.spec.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/widget-configuration-editor/widget-configuration-editor.component.spec.ts
@@ -226,6 +226,40 @@ describe('WidgetConfigurationEditorComponent', () => {
 
       expect(next.data).toEqual({ label: 'After' } as WidgetData);
     });
+
+    async function editLabel(fixture: ComponentFixture<WidgetConfigurationEditorComponent>, value: string): Promise<void> {
+      const label = stringField('label', 'Before');
+      configHandle().root.set(configRoot([propertiesRegion([label])]));
+      await settle(fixture);
+      fixture.debugElement.injector.get(UiNodeEventBus).emit(label, UiConfigEvents.Change, value);
+      await settle(fixture);
+    }
+
+    it('keeps the session, and with it the open tab, when saving reseeds the draft the tree itself produced', async () => {
+      const fixture = await createFixture(widget({ data: { label: 'Before' } as WidgetData }));
+      const first = configHandle();
+      await editLabel(fixture, 'Edited');
+
+      fixture.componentRef.setInput('widget', widget({ data: { label: 'Edited' } as WidgetData }));
+      fixture.componentInstance.reload();
+      await settle(fixture);
+
+      expect(opens.filter(r => r.kind === 'config').length).toBe(1);
+      expect(first.closed).toBeFalse();
+    });
+
+    it('still reopens after an edit when the reseeded draft differs from what the tree produced', async () => {
+      const fixture = await createFixture(widget({ data: { label: 'Before' } as WidgetData }));
+      await editLabel(fixture, 'Edited');
+
+      fixture.componentRef.setInput('widget', widget({ data: { label: 'From JSON' } as WidgetData }));
+      fixture.componentInstance.reload();
+      await settle(fixture);
+
+      const configOpens = opens.filter(r => r.kind === 'config');
+      expect(configOpens.length).toBe(2);
+      expect(configOpens[1]).toEqual(jasmine.objectContaining({ widgetData: JSON.stringify({ label: 'From JSON' }) }));
+    });
   });
 
   it('is not ready until the host answers, so the page never reveals the preview-only fallback', async () => {

--- a/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/widget-configuration-editor/widget-configuration-editor.component.ts
+++ b/ui/angular/projects/desktop-ui/src/app/components/widgets/widget-editors/widget-configuration-editor/widget-configuration-editor.component.ts
@@ -41,6 +41,7 @@ import {
 } from '@shared';
 import { UiNodeComponent } from '../../../ui-render/ui-node.component';
 import { UiRenderContext } from '../../../ui-render/ui-render-context';
+import { deepEqual } from '../../../../util/deep-equal';
 import { WidgetEditorShellComponent } from '../common/widget-editor-shell/widget-editor-shell.component';
 
 const DRAFT_EVENT_NAMES: ReadonlySet<string> = new Set([
@@ -116,9 +117,7 @@ export class WidgetConfigurationEditorComponent implements IWidgetEditorComponen
 
   private seenTree = false;
 
-  /** The draft the current session was opened with, so `reload` can tell a real change from a reseed
-   * that left the configuration exactly as the tree already has it. */
-  private openedWith: string | null = null;
+  private treeDraft: WidgetData | null = null;
 
   constructor() {
     effect(() => this.context.setRoot(this.root()));
@@ -166,10 +165,9 @@ export class WidgetConfigurationEditorComponent implements IWidgetEditorComponen
    * Called by the editor page whenever it reseeds this editor.
    */
   reload(): void {
-    // The page reseeds this editor on every live update it adopts too, most of which change nothing the
-    // tree is built from. Reopening then would throw away tree-local state the draft does not carry -
-    // which tab is open, which state is selected - for no gain, so an unchanged draft is left alone.
-    if (JSON.stringify(this.widget.data) === this.openedWith) return;
+    // Reopening throws away tree-local state such as the open tab, so only a draft the tree did not
+    // produce itself is worth it.
+    if (deepEqual(this.widget.data, this.treeDraft)) return;
 
     this.handle()?.close();
     this.handle.set(null);
@@ -181,10 +179,9 @@ export class WidgetConfigurationEditorComponent implements IWidgetEditorComponen
   }
 
   private async openSession(): Promise<void> {
-    // Read before the await, not after it: `reload` compares against this to decide whether to reopen,
-    // and a draft captured after an awaited catalogue lookup could already be a later one.
+    // Captured before the await: a draft read after the catalogue lookup could already be a later one.
     const widgetData = JSON.stringify(this.widget.data);
-    this.openedWith = widgetData;
+    this.treeDraft = structuredClone(this.widget.data);
 
     const info = await this.widgetTypes.infoFor(this.widget.type);
     if (info && !info.supportsConfigUi) {
@@ -225,6 +222,7 @@ export class WidgetConfigurationEditorComponent implements IWidgetEditorComponen
     }
 
     Object.assign(data, next);
+    this.treeDraft = structuredClone(this.widget.data);
     this.previewData.set({ ...data });
   }
 }


### PR DESCRIPTION
Reported directly by the maintainer (no issue)

## Summary

Saving in the widget editor reopened the config UI session, so the tree was rebuilt and the button editor lost its selected tab. The editor now only reopens when the draft differs from what its own tree produced.

## Testing

desktop-ui suite passes (3920), with two new specs for the reload decision. Verified in a browser against a running host: after Save the Long Press tab stays selected and no session is reopened, while a JSON mode edit still rebuilds the tree.

## Notes

If the host ever echoes back saved data it normalized differently, that echo still rebuilds the tree, as before.

## Checklist

- [x] Tests were added or updated where needed
- [x] The change was verified manually where appropriate
- [ ] Documentation was updated if the change affects documented behaviour
- [x] I reviewed and understand every submitted change
